### PR TITLE
Fix formatting of curly braces (#23)

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps;
@@ -79,7 +80,7 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         if (onlyOneNull)
         {
             assertionChain.FailWith(
-                $"Expected {currentNode.Subject.Description} to be {{0}}{{reason}}, but found {{1}}.", expected, subject);
+                $"Expected {currentNode.Subject.Description.EscapePlaceholders()} to be {{0}}{{reason}}, but found {{1}}.", expected, subject);
 
             return false;
         }

--- a/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/FluentAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -1300,6 +1300,36 @@ public class DictionarySpecs
 
         subject.Should().BeEquivalentTo(expected);
     }
+
+    [Fact]
+    public void A_subject_string_key_with_curly_braces_is_formatted_correctly_in_failure_message()
+    {
+        // Arrange
+        var actual = new Dictionary<string, string> { ["{}"] = "" };
+        var expected = new Dictionary<string, string> { ["{}"] = null };
+
+        // Act
+        Action act = () => actual.Should().BeEquivalentTo(expected);
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("Expected actual[{}] to be *, but found *.");
+    }
+
+    [Fact]
+    public void A_subject_key_with_braces_in_string_representation_is_formatted_correctly_in_failure_message()
+    {
+        // Arrange
+        var actual = new Dictionary<RecordStruct, string> { [new()] = "" };
+        var expected = new Dictionary<RecordStruct, string> { [new()] = null };
+
+        // Act
+        Action act = () => actual.Should().BeEquivalentTo(expected);
+
+        // Assert
+        act.Should().Throw<XunitException>().WithMessage("Expected actual[RecordStruct { }] to be *, but found *.");
+    }
+
+    private record struct RecordStruct();
 }
 
 internal class NonGenericChildDictionary : Dictionary<string, int>


### PR DESCRIPTION
* Fix formatting of curly braces in string representation of dictionary key in failure message.

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/develop/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
