### PR TITLE
Add `ForConstraint` to `AssertionChain.GivenSelector`

### DIFF
--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -45,6 +45,18 @@ public class GivenSelector<T>
         return this;
     }
 
+    public GivenSelector<T> ForConstraint(OccurrenceConstraint constraint, Func<T, int> func)
+    {
+        Guard.ThrowIfArgumentIsNull(func);
+
+        if (assertionChain.Succeeded)
+        {
+            assertionChain.ForConstraint(constraint, func(selector));
+        }
+
+        return this;
+    }
+
     public GivenSelector<TOut> Given<TOut>(Func<T, TOut> selector)
     {
         Guard.ThrowIfArgumentIsNull(selector);
@@ -71,6 +83,12 @@ public class GivenSelector<T>
     public ContinuationOfGiven<T> FailWith(string message, params object[] args)
     {
         assertionChain.FailWith(message, args);
+        return new ContinuationOfGiven<T>(this);
+    }
+
+    public ContinuationOfGiven<T> FailWith(Func<T, string> message)
+    {
+        assertionChain.FailWith(message(selector));
         return new ContinuationOfGiven<T>(this);
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1190,10 +1190,12 @@ namespace FluentAssertions.Execution
     public class GivenSelector<T>
     {
         public bool Succeeded { get; }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(System.Func<T, string> message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<T, object>[] args) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForConstraint(FluentAssertions.OccurrenceConstraint constraint, System.Func<T, int> func) { }
         public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
     public interface IAssertionStrategy

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1203,10 +1203,12 @@ namespace FluentAssertions.Execution
     public class GivenSelector<T>
     {
         public bool Succeeded { get; }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(System.Func<T, string> message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<T, object>[] args) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForConstraint(FluentAssertions.OccurrenceConstraint constraint, System.Func<T, int> func) { }
         public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
     public interface IAssertionStrategy

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1134,10 +1134,12 @@ namespace FluentAssertions.Execution
     public class GivenSelector<T>
     {
         public bool Succeeded { get; }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(System.Func<T, string> message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<T, object>[] args) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForConstraint(FluentAssertions.OccurrenceConstraint constraint, System.Func<T, int> func) { }
         public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
     public interface IAssertionStrategy

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1190,10 +1190,12 @@ namespace FluentAssertions.Execution
     public class GivenSelector<T>
     {
         public bool Succeeded { get; }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(System.Func<T, string> message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<T, object>[] args) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForConstraint(FluentAssertions.OccurrenceConstraint constraint, System.Func<T, int> func) { }
         public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
     }
     public interface IAssertionStrategy


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
This was proposed by me [here](https://github.com/fluentassertions/fluentassertions/issues/2797), because it could combine multiple `AssertionChain` statements to one chain. Before the `AssertionChain` change happend I implemented this also for the previously existing `IAssertionScope` with the same intent.

But I open this as a draft, since I am open minded to API discussions first.

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
