### PR TITLE
chore: update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "ignorePaths": [
         "Build/**"
     ],
+	"ignoreDeps": ["system.threading.tasks.extensions"],
     "packageRules": [
         {
             "matchSourceUrls": [
@@ -26,6 +27,24 @@
                 "https://github.com/dotnet/wpf"
             ],
             "enabled": false
+        },
+        {
+            "matchPackageNames": [
+                "xunit.runner.visualstudio"
+            ],
+            "allowedVersions": "< 3.0.0"
+        },
+        {
+            "matchPackageNames": [
+                "xunit.v3"
+            ],
+            "allowedVersions": "< 2.0.0"
+        },
+        {
+            "matchPackageNames": [
+                "xunit.v3.core"
+            ],
+            "allowedVersions": "< 2.0.0"
         }
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -35,15 +35,7 @@
             "allowedVersions": "< 3.0.0"
         },
         {
-            "matchPackageNames": [
-                "xunit.v3"
-            ],
-            "allowedVersions": "< 2.0.0"
-        },
-        {
-            "matchPackageNames": [
-                "xunit.v3.core"
-            ],
+            "matchPackageNames": [ "/xunit.v3/" ],
             "allowedVersions": "< 2.0.0"
         }
     ]


### PR DESCRIPTION
We need to ignore `System.Threading.Tasks.Extensions` https://github.com/AwesomeAssertions/AwesomeAssertions/pull/64
We cannot update the xunit major as well, as it's no longer supports net47 https://github.com/AwesomeAssertions/AwesomeAssertions/pull/71


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
