### PR TITLE
Adapt displayed length in `StringEqualityStrategy` to between 45 and 60 characters

### DIFF
--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -204,13 +204,13 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
     /// Calculates how many characters to keep in <paramref name="value"/>.
     /// </summary>
     /// <remarks>
-    /// If a word end is found between 15 and 25 characters, use this word end, otherwise keep 20 characters.
+    /// If a word end is found between 45 and 60 characters, use this word end, otherwise keep 50 characters.
     /// </remarks>
     private static int GetLengthOfPhraseToShowOrDefaultLength(string value)
     {
-        const int defaultLength = 20;
-        const int minLength = 15;
-        const int maxLength = 25;
+        const int minLength = 45;
+        const int defaultLength = minLength + 5;
+        const int maxLength = minLength + 15;
         const int lengthOfWhitespace = 1;
 
         var indexOfWordBoundary = value

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -346,7 +346,7 @@ public partial class StringAssertionSpecs
             act.Should().Throw<XunitException>().WithMessage($"""
                 Expected subject to be the same string, but they differ on line 5 and column 16 (index {expectedIndex}):
                              ↓ (actual)
-                  "…-> Bob : Another authentication Request\r\nAlice <-- Bob :…"
+                  "…-> Bob : Another authentication Request*\nAlice <-- Bob :…"
                   "…-> Bob : Invalid authentication Request\r\nAlice <-- Bob :…"
                              ↑ (expected).
                 """);

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -211,8 +211,8 @@ public partial class StringAssertionSpecs
             act.Should().Throw<XunitException>().WithMessage("""
                 Expected subject to be the same string because we use arrows now, but they differ at index 20:
                                    ↓ (actual)
-                  "…is a long text that…"
-                  "…is a long text which…"
+                  "…is a long text that differs in between two words"
+                  "…is a long text which differs in between two words"
                                    ↑ (expected).
                 """);
         }
@@ -220,7 +220,7 @@ public partial class StringAssertionSpecs
         [Fact]
         public void Only_add_ellipsis_for_long_text()
         {
-            const string subject = "this is a long text that differs";
+            const string subject = "this is a long text that has more than 60 characters so it requires ellipsis";
             const string expected = "this was too short";
 
             // Act
@@ -230,7 +230,7 @@ public partial class StringAssertionSpecs
             act.Should().Throw<XunitException>().WithMessage("""
                 Expected subject to be the same string because we use arrows now, but they differ at index 5:
                         ↓ (actual)
-                  "this is a long text that…"
+                  "this is a long text that has more than 60 characters so it…"
                   "this was too short"
                         ↑ (expected).
                 """);
@@ -266,11 +266,11 @@ public partial class StringAssertionSpecs
         }
 
         [Theory]
-        [InlineData("ThisLongTextIsUsedToCheckADifferenceAtTheEnd after 10 + 5 characters")]
-        [InlineData("ThisLongTextIsUsedToCheckADifferen after 10 + 15 characters")]
-        public void Will_look_for_a_word_boundary_between_15_and_25_characters_after_the_mismatching_index_to_highlight_the_mismatch(string expected)
+        [InlineData("This Is A LongTextWithMoreThan60CharactersWhichIs after 10 + 35 characters")]
+        [InlineData("This Is A LongTextWithMoreThan60Ch after 10 + 50 characters")]
+        public void Will_look_for_a_word_boundary_between_45_and_60_characters_after_the_mismatching_index_to_highlight_the_mismatch(string expected)
         {
-            const string subject = "ThisLongTextIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
+            const string subject = "This Is A LongTextWithMoreThan60CharactersWhichIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
 
             // Act
             Action act = () => subject.Should().Be(expected);
@@ -300,12 +300,12 @@ public partial class StringAssertionSpecs
         }
 
         [Theory]
-        [InlineData("ThisLongTextIsUsedToCheckADifferenceAtTheEndO after 10 + 4 characters", "eAtTheEndOfThe WordB…\"")]
-        [InlineData("ThisLongTextIsUsedToCheckADiffere after 10 + 16 characters", "ckADifferenceAtTheEn…\"")]
-        public void Will_fallback_to_20_characters_if_no_word_boundary_can_be_found_after_the_mismatching_index(
+        [InlineData("This Is A LongTextWithMoreThan60C that differs with 60 characters remaining", "oreThan60CharactersWhichIsUsedToCheckADifferenceAt…\"")]
+        [InlineData("This Is A LongTextWithMoreThan60Ch IsALongTextIsUsedToCheckADiffere after 10 + 16 characters", "reThan60CharactersWhichIsUsedToCheckADifferenceAtTheEndOfThe…\"")]
+        public void Will_fallback_to_50_characters_if_no_word_boundary_can_be_found_after_the_mismatching_index(
                 string expected, string expectedMessagePart)
         {
-            const string subject = "ThisLongTextIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
+            const string subject = "This Is A LongTextWithMoreThan60CharactersWhichIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
 
             // Act
             Action act = () => subject.Should().Be(expected);
@@ -346,8 +346,8 @@ public partial class StringAssertionSpecs
             act.Should().Throw<XunitException>().WithMessage($"""
                 Expected subject to be the same string, but they differ on line 5 and column 16 (index {expectedIndex}):
                              ↓ (actual)
-                  "…-> Bob : Another…"
-                  "…-> Bob : Invalid…"
+                  "…-> Bob : Another authentication Request\r\nAlice <-- Bob :…"
+                  "…-> Bob : Invalid authentication Request\r\nAlice <-- Bob :…"
                              ↑ (expected).
                 """);
         }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -347,7 +347,7 @@ public partial class StringAssertionSpecs
                 Expected subject to be the same string, but they differ on line 5 and column 16 (index {expectedIndex}):
                              ↓ (actual)
                   "…-> Bob : Another authentication Request*\nAlice <-- Bob :…"
-                  "…-> Bob : Invalid authentication Request\r\nAlice <-- Bob :…"
+                  "…-> Bob : Invalid authentication Request*\nAlice <-- Bob :…"
                              ↑ (expected).
                 """);
         }


### PR DESCRIPTION
Fixes #46 


## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
