### PR TITLE
Fixed formatting of failure messages when comparing strings with braces

### DIFF
--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -43,8 +43,12 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
                 locationDescription = $"on line {lineNumber + 1} and column {column} (index {indexOfMismatch})";
             }
 
-            assertionChain.FailWith(
-                $"{ExpectationDescription}the same string{{reason}}, but they differ {locationDescription}:{Environment.NewLine}{GetMismatchSegmentForLongStrings(subject, expected, indexOfMismatch)}.");
+            string mismatchSegment = GetMismatchSegmentForLongStrings(subject, expected, indexOfMismatch).EscapePlaceholders();
+
+            assertionChain.FailWith($$"""
+                {{ExpectationDescription}}the same string{reason}, but they differ {{locationDescription}}:
+                {{mismatchSegment}}.
+                """);
         }
         else if (ValidateAgainstLengthDifferences(assertionChain, subject, expected))
         {

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -351,6 +351,28 @@ public partial class StringAssertionSpecs
                              ↑ (expected).
                 """);
         }
+
+        [Fact]
+        public void When_differing_actual_and_expected_string_contain_braces_they_are_formatted_correctly()
+        {
+            // Act
+            Action act = () => "public class Foo { }".Should().Be("public class Bar { }");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*Foo { }*Bar { }*↑ (expected).", "because no formatting warning must be appended");
+        }
+
+        [Fact]
+        public void When_the_longer_expected_string_and_actual_string_contain_braces_they_are_formatted_correctly()
+        {
+            // Act
+            Action act = () => "public class Foo { }".Should().Be("public class Foo { };");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*Foo { };\"*Foo { }\"*differs near \"}\" (index 19).", "because no formatting warning must be appended");
+        }
     }
 
     public class NotBe

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,16 +12,19 @@ sidebar:
 ### What's new
 * Add `ForConstraint` to `GivenSelector<T>` allowing further chaining after `.Then` - [#44](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/44)
 
+### Fixes
+* Fixed formatting of failure messages when comparing strings with braces - [#88](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/96)
+
 ## 8.0.2
 
 ### Improvements
 * Add missing StringSyntaxAttribute to public method "because" parameter - [#84](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/84)
 
 ### Fixes
-* Fix a formatting problem, when using `{}` inside or as a `Dictionary` key - [#24](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/24)
-* Fix a regression, where a canceled `Task` was treated as a failure in `CompleteWithinAsync` - [b9cef9184](https://github.com/AwesomeAssertions/AwesomeAssertions/commit/b9cef9185f19d65228be59b0e3a1a3f6abfb8ef4)
-* Fix a regression, where a call to `BeEquivalentTo` only gives one diff after a preceding successful assertion - [#74](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/74)
-* Fix equivalency to always prefer normal over explicitly implemented property - [#80](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/80)
+* Fixed a formatting problem, when using `{}` inside or as a `Dictionary` key - [#24](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/24)
+* Fixed a regression, where a canceled `Task` was treated as a failure in `CompleteWithinAsync` - [b9cef9184](https://github.com/AwesomeAssertions/AwesomeAssertions/commit/b9cef9185f19d65228be59b0e3a1a3f6abfb8ef4)
+* Fixed a regression, where a call to `BeEquivalentTo` only gives one diff after a preceding successful assertion - [#74](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/74)
+* Fixed equivalency to always prefer normal over explicitly implemented property - [#80](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/80)
 
 ## 8.0.1
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,7 +13,7 @@ sidebar:
 * Add `ForConstraint` to `GivenSelector<T>` allowing further chaining after `.Then` - [#44](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/44)
 
 ### Fixes
-* Fixed formatting of failure messages when comparing strings with braces - [#88](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/96)
+* Fixed formatting of failure messages when comparing strings with braces - [#96](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/96)
 
 ## 8.0.2
 


### PR DESCRIPTION
Fix #88 

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
