### PR TITLE
Make displayed length in `StringEqualityStrategy` configurable

### DIFF
--- a/Src/FluentAssertions/Configuration/GlobalFormattingOptions.cs
+++ b/Src/FluentAssertions/Configuration/GlobalFormattingOptions.cs
@@ -26,7 +26,7 @@ public class GlobalFormattingOptions : FormattingOptions
             UseLineBreaks = UseLineBreaks,
             MaxDepth = MaxDepth,
             MaxLines = MaxLines,
-            StringComparisonLength = StringComparisonLength,
+            StringPrintLength = StringPrintLength,
             ScopedFormatters = [.. ScopedFormatters],
             ValueFormatterAssembly = ValueFormatterAssembly,
             ValueFormatterDetectionMode = ValueFormatterDetectionMode

--- a/Src/FluentAssertions/Configuration/GlobalFormattingOptions.cs
+++ b/Src/FluentAssertions/Configuration/GlobalFormattingOptions.cs
@@ -26,6 +26,7 @@ public class GlobalFormattingOptions : FormattingOptions
             UseLineBreaks = UseLineBreaks,
             MaxDepth = MaxDepth,
             MaxLines = MaxLines,
+            StringComparisonLength = StringComparisonLength,
             ScopedFormatters = [.. ScopedFormatters],
             ValueFormatterAssembly = ValueFormatterAssembly,
             ValueFormatterDetectionMode = ValueFormatterDetectionMode

--- a/Src/FluentAssertions/Formatting/FormattingOptions.cs
+++ b/Src/FluentAssertions/Formatting/FormattingOptions.cs
@@ -43,18 +43,20 @@ public class FormattingOptions
     public int MaxLines { get; set; } = 100;
 
     /// <summary>
-    /// Sets the default number of characters shown when highlighting the difference of two strings.
+    /// Sets the default number of characters shown when printing the difference of two strings.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The actual number of shown characters depends on the word-boundary-algorithm.
+    /// The actual number of shown characters depends on the word-boundary-algorithm.<br />
+    /// This algorithm searches for a word boundary (a blank) in the range from 5 characters previous and 10 characters after the
+    /// <see cref="StringPrintLength"/>. If found it displays a full word, otherwise it falls back to the <see cref="StringPrintLength"/>.
     /// </para>
     /// <para>
     /// This property is not thread-safe and should not be modified through <see cref="AssertionConfiguration"/> from within a unit test.
     /// See the <see href="https://awesomeassertions.org/extensibility/#thread-safety">docs</see> on how to safely use it.
     /// </para>
     /// </remarks>
-    public int StringComparisonLength { get; set; } = 50;
+    public int StringPrintLength { get; set; } = 50;
 
     /// <summary>
     /// Removes a scoped formatter that was previously added through <see cref="FormattingOptions.AddFormatter"/>.
@@ -85,7 +87,7 @@ public class FormattingOptions
             UseLineBreaks = UseLineBreaks,
             MaxDepth = MaxDepth,
             MaxLines = MaxLines,
-            StringComparisonLength = StringComparisonLength,
+            StringPrintLength = StringPrintLength,
             ScopedFormatters = [.. ScopedFormatters],
         };
     }

--- a/Src/FluentAssertions/Formatting/FormattingOptions.cs
+++ b/Src/FluentAssertions/Formatting/FormattingOptions.cs
@@ -43,6 +43,20 @@ public class FormattingOptions
     public int MaxLines { get; set; } = 100;
 
     /// <summary>
+    /// Sets the default number of characters shown when highlighting the difference of two strings.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The actual number of shown characters depends on the word-boundary-algorithm.
+    /// </para>
+    /// <para>
+    /// This property is not thread-safe and should not be modified through <see cref="AssertionConfiguration"/> from within a unit test.
+    /// See the <see href="https://awesomeassertions.org/extensibility/#thread-safety">docs</see> on how to safely use it.
+    /// </para>
+    /// </remarks>
+    public int StringComparisonLength { get; set; } = 50;
+
+    /// <summary>
     /// Removes a scoped formatter that was previously added through <see cref="FormattingOptions.AddFormatter"/>.
     /// </summary>
     /// <param name="formatter">A custom implementation of <see cref="IValueFormatter"/></param>
@@ -71,6 +85,7 @@ public class FormattingOptions
             UseLineBreaks = UseLineBreaks,
             MaxDepth = MaxDepth,
             MaxLines = MaxLines,
+            StringComparisonLength = StringComparisonLength,
             ScopedFormatters = [.. ScopedFormatters],
         };
     }

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -212,7 +212,7 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
     /// </remarks>
     private static int GetLengthOfPhraseToShowOrDefaultLength(string value)
     {
-        var defaultLength = AssertionConfiguration.Current.Formatting.StringComparisonLength;
+        var defaultLength = AssertionConfiguration.Current.Formatting.StringPrintLength;
         int minLength = defaultLength - 5;
         int maxLength = defaultLength + 10;
         const int lengthOfWhitespace = 1;

--- a/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityStrategy.cs
@@ -212,9 +212,9 @@ internal class StringEqualityStrategy : IStringComparisonStrategy
     /// </remarks>
     private static int GetLengthOfPhraseToShowOrDefaultLength(string value)
     {
-        const int minLength = 45;
-        const int defaultLength = minLength + 5;
-        const int maxLength = minLength + 15;
+        var defaultLength = AssertionConfiguration.Current.Formatting.StringComparisonLength;
+        int minLength = defaultLength - 5;
+        int maxLength = defaultLength + 10;
         const int lengthOfWhitespace = 1;
 
         var indexOfWordBoundary = value

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1407,6 +1407,7 @@ namespace FluentAssertions.Formatting
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
         public int MaxLines { get; set; }
+        public int StringComparisonLength { get; set; }
         public bool UseLineBreaks { get; set; }
         public void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1407,7 +1407,7 @@ namespace FluentAssertions.Formatting
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
         public int MaxLines { get; set; }
-        public int StringComparisonLength { get; set; }
+        public int StringPrintLength { get; set; }
         public bool UseLineBreaks { get; set; }
         public void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1426,7 +1426,7 @@ namespace FluentAssertions.Formatting
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
         public int MaxLines { get; set; }
-        public int StringComparisonLength { get; set; }
+        public int StringPrintLength { get; set; }
         public bool UseLineBreaks { get; set; }
         public void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1426,6 +1426,7 @@ namespace FluentAssertions.Formatting
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
         public int MaxLines { get; set; }
+        public int StringComparisonLength { get; set; }
         public bool UseLineBreaks { get; set; }
         public void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1351,7 +1351,7 @@ namespace FluentAssertions.Formatting
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
         public int MaxLines { get; set; }
-        public int StringComparisonLength { get; set; }
+        public int StringPrintLength { get; set; }
         public bool UseLineBreaks { get; set; }
         public void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1351,6 +1351,7 @@ namespace FluentAssertions.Formatting
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
         public int MaxLines { get; set; }
+        public int StringComparisonLength { get; set; }
         public bool UseLineBreaks { get; set; }
         public void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1407,6 +1407,7 @@ namespace FluentAssertions.Formatting
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
         public int MaxLines { get; set; }
+        public int StringComparisonLength { get; set; }
         public bool UseLineBreaks { get; set; }
         public void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1407,7 +1407,7 @@ namespace FluentAssertions.Formatting
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
         public int MaxLines { get; set; }
-        public int StringComparisonLength { get; set; }
+        public int StringPrintLength { get; set; }
         public bool UseLineBreaks { get; set; }
         public void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }

--- a/Tests/FluentAssertions.Specs/Configuration/FormattingOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Configuration/FormattingOptionsSpecs.cs
@@ -18,12 +18,12 @@ public sealed class FormattingOptionsSpecs : IDisposable
         AssertionConfiguration.Current.Formatting.UseLineBreaks = true;
         AssertionConfiguration.Current.Formatting.MaxDepth = 123;
         AssertionConfiguration.Current.Formatting.MaxLines = 33;
-        AssertionConfiguration.Current.Formatting.StringComparisonLength = 321;
+        AssertionConfiguration.Current.Formatting.StringPrintLength = 321;
 
         AssertionScope.Current.FormattingOptions.UseLineBreaks.Should().BeTrue();
         AssertionScope.Current.FormattingOptions.MaxDepth.Should().Be(123);
         AssertionScope.Current.FormattingOptions.MaxLines.Should().Be(33);
-        AssertionScope.Current.FormattingOptions.StringComparisonLength.Should().Be(321);
+        AssertionScope.Current.FormattingOptions.StringPrintLength.Should().Be(321);
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Configuration/FormattingOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Configuration/FormattingOptionsSpecs.cs
@@ -18,10 +18,12 @@ public sealed class FormattingOptionsSpecs : IDisposable
         AssertionConfiguration.Current.Formatting.UseLineBreaks = true;
         AssertionConfiguration.Current.Formatting.MaxDepth = 123;
         AssertionConfiguration.Current.Formatting.MaxLines = 33;
+        AssertionConfiguration.Current.Formatting.StringComparisonLength = 321;
 
         AssertionScope.Current.FormattingOptions.UseLineBreaks.Should().BeTrue();
         AssertionScope.Current.FormattingOptions.MaxDepth.Should().Be(123);
         AssertionScope.Current.FormattingOptions.MaxLines.Should().Be(33);
+        AssertionScope.Current.FormattingOptions.StringComparisonLength.Should().Be(321);
     }
 
     [Fact]

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -15,6 +15,35 @@ namespace FluentAssertions.Specs.Formatting;
 public sealed class FormatterSpecs : IDisposable
 {
     [Fact]
+    public void Use_configuration_when_highlighting_string_difference()
+    {
+        // Arrange
+        string subject = "this is a very long string with lots of words that most won't be displayed in the error message!";
+        string expected = "this is another string that differs after a couple of words.";
+        Action action = () => subject.Should().Be(expected);
+
+        int previousStringComparisonLength = AssertionConfiguration.Current.Formatting.StringComparisonLength;
+        try
+        {
+            // Act
+            AssertionConfiguration.Current.Formatting.StringComparisonLength = 10;
+
+            // Assert
+            action.Should().Throw<Exception>().WithMessage("""
+                                                           *
+                                                                       ↓ (actual)
+                                                             "this is a very long…"
+                                                             "this is another…"
+                                                                       ↑ (expected).
+                                                           """);
+        }
+        finally
+        {
+            AssertionConfiguration.Current.Formatting.StringComparisonLength = previousStringComparisonLength;
+        }
+    }
+
+    [Fact]
     public void When_value_contains_cyclic_reference_it_should_create_descriptive_error_message()
     {
         // Arrange

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -22,11 +22,11 @@ public sealed class FormatterSpecs : IDisposable
         string expected = "this is another string that differs after a couple of words.";
         Action action = () => subject.Should().Be(expected);
 
-        int previousStringComparisonLength = AssertionConfiguration.Current.Formatting.StringComparisonLength;
+        int previousStringPrintLength = AssertionConfiguration.Current.Formatting.StringPrintLength;
         try
         {
             // Act
-            AssertionConfiguration.Current.Formatting.StringComparisonLength = 10;
+            AssertionConfiguration.Current.Formatting.StringPrintLength = 10;
 
             // Assert
             action.Should().Throw<Exception>().WithMessage("""
@@ -39,7 +39,7 @@ public sealed class FormatterSpecs : IDisposable
         }
         finally
         {
-            AssertionConfiguration.Current.Formatting.StringComparisonLength = previousStringComparisonLength;
+            AssertionConfiguration.Current.Formatting.StringPrintLength = previousStringPrintLength;
         }
     }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 
 ### What's new
 * Add `ForConstraint` to `GivenSelector<T>` allowing further chaining after `.Then` - [#44](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/44)
+* Increase default displayed length in `StringEqualityStrategy` - [#94](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/94)
 * Make displayed length in `StringEqualityStrategy` configurable - [#100](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/100)
 
 ### Fixes

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 
 ### What's new
 * Add `ForConstraint` to `GivenSelector<T>` allowing further chaining after `.Then` - [#44](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/44)
+* Make displayed length in `StringEqualityStrategy` configurable - [#100](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/100)
 
 ### Fixes
 * Fixed formatting of failure messages when comparing strings with braces - [#96](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/96)


### PR DESCRIPTION
Follow-up to #94 (fixes #46):

Add a new configuration option `AssertionConfiguration.Current.Formatting.StringComparisonLength` which sets the default number of characters shown when highlighting the difference of two strings.


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
