### PR TITLE
Provide access to AssertionChain of assertion classes

### DIFF
--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -27,11 +27,9 @@ public class BooleanAssertions
 public class BooleanAssertions<TAssertions>
     where TAssertions : BooleanAssertions<TAssertions>
 {
-    private readonly AssertionChain assertionChain;
-
     public BooleanAssertions(bool? value, AssertionChain assertionChain)
     {
-        this.assertionChain = assertionChain;
+        CurrentAssertionChain = assertionChain;
         Subject = value;
     }
 
@@ -39,6 +37,11 @@ public class BooleanAssertions<TAssertions>
     /// Gets the object whose value is being asserted.
     /// </summary>
     public bool? Subject { get; }
+
+    /// <summary>
+    /// Provides access to the <see cref="AssertionChain"/> that this assertion class was initialized with.
+    /// </summary>
+    public AssertionChain CurrentAssertionChain { get; }
 
     /// <summary>
     /// Asserts that the value is <see langword="false"/>.
@@ -52,7 +55,7 @@ public class BooleanAssertions<TAssertions>
     /// </param>
     public AndConstraint<TAssertions> BeFalse([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == false)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", false, Subject);
@@ -72,7 +75,7 @@ public class BooleanAssertions<TAssertions>
     /// </param>
     public AndConstraint<TAssertions> BeTrue([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == true)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", true, Subject);
@@ -94,7 +97,7 @@ public class BooleanAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(bool expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", expected, Subject);
@@ -116,7 +119,7 @@ public class BooleanAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(bool unexpected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:boolean} not to be {0}{reason}, but found {1}.", unexpected, Subject);
@@ -141,7 +144,7 @@ public class BooleanAssertions<TAssertions>
     {
         bool? antecedent = Subject;
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(antecedent is not null)
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:antecedent} ({0}) to imply consequent ({1}){reason}, ", antecedent, consequent,

--- a/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateOnlyAssertions.cs
@@ -30,11 +30,9 @@ public class DateOnlyAssertions : DateOnlyAssertions<DateOnlyAssertions>
 public class DateOnlyAssertions<TAssertions>
     where TAssertions : DateOnlyAssertions<TAssertions>
 {
-    private readonly AssertionChain assertionChain;
-
     public DateOnlyAssertions(DateOnly? value, AssertionChain assertionChain)
     {
-        this.assertionChain = assertionChain;
+        CurrentAssertionChain = assertionChain;
         Subject = value;
     }
 
@@ -42,6 +40,11 @@ public class DateOnlyAssertions<TAssertions>
     /// Gets the object whose value is being asserted.
     /// </summary>
     public DateOnly? Subject { get; }
+
+    /// <summary>
+    /// Provides access to the <see cref="AssertionChain"/> that this assertion class was initialized with.
+    /// </summary>
+    public AssertionChain CurrentAssertionChain { get; }
 
     /// <summary>
     /// Asserts that the current <see cref="DateOnly"/> is exactly equal to the <paramref name="expected"/> value.
@@ -57,7 +60,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(DateOnly expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be {0}{reason}, but found {1}.",
@@ -80,7 +83,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(DateOnly? expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be {0}{reason}, but found {1}.",
@@ -103,7 +106,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(DateOnly unexpected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} not to be {0}{reason}, but it is.", unexpected);
@@ -125,7 +128,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(DateOnly? unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} not to be {0}{reason}, but it is.", unexpected);
@@ -147,7 +150,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeBefore(DateOnly expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject < expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be before {0}{reason}, but found {1}.", expected,
@@ -187,7 +190,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOnOrBefore(DateOnly expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject <= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be on or before {0}{reason}, but found {1}.", expected,
@@ -227,7 +230,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeAfter(DateOnly expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject > expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be after {0}{reason}, but found {1}.", expected,
@@ -267,7 +270,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOnOrAfter(DateOnly expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject >= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be on or after {0}{reason}, but found {1}.", expected,
@@ -307,7 +310,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveYear(int expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the year part of {context:the date} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -333,7 +336,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveYear(int unexpected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.HasValue)
             .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but found a <null> DateOnly.",
@@ -360,7 +363,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveMonth(int expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the month part of {context:the date} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -386,7 +389,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveMonth(int unexpected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the month part of {context:the date} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -412,7 +415,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveDay(int expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the day part of {context:the date} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -438,7 +441,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveDay(int unexpected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the day part of {context:the date} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -507,7 +510,7 @@ public class DateOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateOnly?> validValues,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(validValues.Contains(Subject))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date} to be one of {0}{reason}, but found {1}.", validValues, Subject);

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -37,11 +37,9 @@ public class DateTimeAssertions : DateTimeAssertions<DateTimeAssertions>
 public class DateTimeAssertions<TAssertions>
     where TAssertions : DateTimeAssertions<TAssertions>
 {
-    private readonly AssertionChain assertionChain;
-
     public DateTimeAssertions(DateTime? value, AssertionChain assertionChain)
     {
-        this.assertionChain = assertionChain;
+        CurrentAssertionChain = assertionChain;
         Subject = value;
     }
 
@@ -49,6 +47,11 @@ public class DateTimeAssertions<TAssertions>
     /// Gets the object whose value is being asserted.
     /// </summary>
     public DateTime? Subject { get; }
+
+    /// <summary>
+    /// Provides access to the <see cref="AssertionChain"/> that this assertion class was initialized with.
+    /// </summary>
+    public AssertionChain CurrentAssertionChain { get; }
 
     /// <summary>
     /// Asserts that the current <see cref="DateTime"/> is exactly equal to the <paramref name="expected"/> value.
@@ -64,7 +67,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(DateTime expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
@@ -87,7 +90,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(DateTime? expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
@@ -110,7 +113,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(DateTime unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
@@ -132,7 +135,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(DateTime? unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
@@ -175,7 +178,7 @@ public class DateTimeAssertions<TAssertions>
 
         TimeSpan? difference = (Subject - nearbyTime)?.Duration();
 
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:the date and time} to be within {0} from {1}{reason}", precision, nearbyTime,
                 chain => chain
@@ -221,7 +224,7 @@ public class DateTimeAssertions<TAssertions>
         long distanceToMaxInTicks = (DateTime.MaxValue - distantTime).Ticks;
         DateTime maximumValue = distantTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject < minimumValue || Subject > maximumValue)
             .BecauseOf(because, becauseArgs)
             .FailWith(
@@ -246,7 +249,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> BeBefore(DateTime expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject < expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be before {0}{reason}, but found {1}.", expected,
@@ -286,7 +289,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOnOrBefore(DateTime expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject <= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but found {1}.", expected,
@@ -326,7 +329,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> BeAfter(DateTime expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject > expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be after {0}{reason}, but found {1}.", expected,
@@ -366,7 +369,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOnOrAfter(DateTime expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject >= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but found {1}.", expected,
@@ -406,7 +409,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveYear(int expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the year part of {context:the date} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -432,7 +435,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveYear(int unexpected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.HasValue)
             .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but found a <null> DateTime.",
@@ -459,7 +462,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveMonth(int expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the month part of {context:the date} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -485,7 +488,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveMonth(int unexpected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the month part of {context:the date} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -511,7 +514,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveDay(int expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the day part of {context:the date} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -537,7 +540,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveDay(int unexpected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the day part of {context:the date} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -563,7 +566,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveHour(int expected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the hour part of {context:the time} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -589,7 +592,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveHour(int unexpected, [StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the hour part of {context:the time} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -615,7 +618,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveMinute(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the minute part of {context:the time} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -641,7 +644,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveMinute(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the minute part of {context:the time} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -667,7 +670,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveSecond(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the seconds part of {context:the time} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -693,7 +696,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveSecond(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the seconds part of {context:the time} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -714,7 +717,7 @@ public class DateTimeAssertions<TAssertions>
     /// </param>
     public DateTimeRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
     {
-        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject, TimeSpanCondition.MoreThan,
+        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.MoreThan,
             timeSpan);
     }
 
@@ -728,7 +731,7 @@ public class DateTimeAssertions<TAssertions>
     /// </param>
     public DateTimeRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
     {
-        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject, TimeSpanCondition.AtLeast,
+        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.AtLeast,
             timeSpan);
     }
 
@@ -741,7 +744,7 @@ public class DateTimeAssertions<TAssertions>
     /// </param>
     public DateTimeRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
     {
-        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject, TimeSpanCondition.Exactly,
+        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.Exactly,
             timeSpan);
     }
 
@@ -754,7 +757,7 @@ public class DateTimeAssertions<TAssertions>
     /// </param>
     public DateTimeRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
     {
-        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject, TimeSpanCondition.Within,
+        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.Within,
             timeSpan);
     }
 
@@ -767,7 +770,7 @@ public class DateTimeAssertions<TAssertions>
     /// </param>
     public DateTimeRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
     {
-        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject, TimeSpanCondition.LessThan,
+        return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.LessThan,
             timeSpan);
     }
 
@@ -787,7 +790,7 @@ public class DateTimeAssertions<TAssertions>
     {
         DateTime expectedDate = expected.Date;
 
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}", expectedDate,
                 chain => chain
@@ -816,7 +819,7 @@ public class DateTimeAssertions<TAssertions>
     {
         DateTime unexpectedDate = unexpected.Date;
 
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the date part of {context:the date and time} to be {0}{reason}", unexpectedDate,
                 chain => chain
@@ -886,7 +889,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTime?> validValues,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(validValues.Contains(Subject))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:date and time} to be one of {0}{reason}, but found {1}.", validValues, Subject);
@@ -910,7 +913,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> BeIn(DateTimeKind expectedKind,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:the date and time} to be in " + expectedKind + "{reason}", chain => chain
                 .ForCondition(Subject.HasValue)
@@ -938,7 +941,7 @@ public class DateTimeAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBeIn(DateTimeKind unexpectedKind,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect {context:the date and time} to be in " + unexpectedKind + "{reason}", chain => chain
                 .Given(() => Subject)

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -38,11 +38,9 @@ public class DateTimeOffsetAssertions
 public class DateTimeOffsetAssertions<TAssertions>
     where TAssertions : DateTimeOffsetAssertions<TAssertions>
 {
-    private readonly AssertionChain assertionChain;
-
     public DateTimeOffsetAssertions(DateTimeOffset? value, AssertionChain assertionChain)
     {
-        this.assertionChain = assertionChain;
+        CurrentAssertionChain = assertionChain;
         Subject = value;
     }
 
@@ -50,6 +48,11 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// Gets the object whose value is being asserted.
     /// </summary>
     public DateTimeOffset? Subject { get; }
+
+    /// <summary>
+    /// Provides access to the <see cref="AssertionChain"/> that this assertion class was initialized with.
+    /// </summary>
+    public AssertionChain CurrentAssertionChain { get; }
 
     /// <summary>
     /// Asserts that the current <see cref="DateTimeOffset"/> represents the same point in time as the <paramref name="expected"/> value.
@@ -65,7 +68,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(DateTimeOffset expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:the date and time} to represent the same point in time as {0}{reason}, ",
                 expected, chain => chain
@@ -94,14 +97,14 @@ public class DateTimeOffsetAssertions<TAssertions>
     {
         if (!expected.HasValue)
         {
-            assertionChain
+            CurrentAssertionChain
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!Subject.HasValue)
                 .FailWith("Expected {context:the date and time} to be <null>{reason}, but it was {0}.", Subject);
         }
         else
         {
-            assertionChain
+            CurrentAssertionChain
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:the date and time} to represent the same point in time as {0}{reason}, ",
                     expected, chain => chain.ForCondition(Subject.HasValue)
@@ -128,7 +131,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(DateTimeOffset unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith(
@@ -152,7 +155,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(DateTimeOffset? unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith(
@@ -176,7 +179,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> BeExactly(DateTimeOffset expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:the date and time} to be exactly {0}{reason}, ", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -205,14 +208,14 @@ public class DateTimeOffsetAssertions<TAssertions>
     {
         if (!expected.HasValue)
         {
-            assertionChain
+            CurrentAssertionChain
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!Subject.HasValue)
                 .FailWith("Expected {context:the date and time} to be <null>{reason}, but it was {0}.", Subject);
         }
         else
         {
-            assertionChain
+            CurrentAssertionChain
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:the date and time} to be exactly {0}{reason}, ", expected, chain => chain
                     .ForCondition(Subject.HasValue)
@@ -240,7 +243,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBeExactly(DateTimeOffset unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject?.EqualsExact(unexpected) != true)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:the date and time} to be exactly {0}{reason}, but it was.", unexpected);
@@ -262,7 +265,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBeExactly(DateTimeOffset? unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(!((Subject == null && unexpected == null) ||
                 (Subject != null && unexpected != null && Subject.Value.EqualsExact(unexpected.Value))))
             .BecauseOf(because, becauseArgs)
@@ -306,7 +309,7 @@ public class DateTimeOffsetAssertions<TAssertions>
 
         TimeSpan? difference = (Subject - nearbyTime)?.Duration();
 
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:the date and time} to be within {0} from {1}{reason}", precision, nearbyTime,
                 chain => chain
@@ -352,7 +355,7 @@ public class DateTimeOffsetAssertions<TAssertions>
         long distanceToMaxInTicks = (DateTimeOffset.MaxValue - distantTime).Ticks;
         DateTimeOffset maximumValue = distantTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject < minimumValue || Subject > maximumValue)
             .BecauseOf(because, becauseArgs)
             .FailWith(
@@ -377,7 +380,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> BeBefore(DateTimeOffset expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject < expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be before {0}{reason}, but it was {1}.", expected,
@@ -417,7 +420,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOnOrBefore(DateTimeOffset expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject <= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but it was {1}.", expected,
@@ -457,7 +460,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> BeAfter(DateTimeOffset expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject > expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be after {0}{reason}, but it was {1}.", expected,
@@ -497,7 +500,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOnOrAfter(DateTimeOffset expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject >= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but it was {1}.", expected,
@@ -537,7 +540,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveYear(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the year part of {context:the date} to be {0}{reason}, ", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -563,7 +566,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveYear(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the year part of {context:the date} to be {0}{reason}, ", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -589,7 +592,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveMonth(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the month part of {context:the date} to be {0}{reason}, ", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -615,7 +618,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveMonth(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the month part of {context:the date} to be {0}{reason}, ", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -641,7 +644,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveDay(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the day part of {context:the date} to be {0}{reason}, ", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -667,7 +670,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveDay(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the day part of {context:the date} to be {0}{reason}, ", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -693,7 +696,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveHour(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the hour part of {context:the time} to be {0}{reason}, ", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -719,7 +722,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveHour(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the hour part of {context:the time} to be {0}{reason}, ", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -745,7 +748,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveMinute(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the minute part of {context:the time} to be {0}{reason}, ", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -771,7 +774,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveMinute(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the minute part of {context:the time} to be {0}{reason}, ", unexpected,
                 chain => chain
@@ -798,7 +801,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveSecond(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the seconds part of {context:the time} to be {0}{reason}, ", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -824,7 +827,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveSecond(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the seconds part of {context:the time} to be {0}{reason}, ", unexpected,
                 chain => chain
@@ -851,7 +854,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveOffset(TimeSpan expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the offset of {context:the date} to be {0}{reason}, ", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -877,7 +880,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveOffset(TimeSpan unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the offset of {context:the date} to be {0}{reason}, ", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -898,7 +901,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// </param>
     public DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
     {
-        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject,
+        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
             TimeSpanCondition.MoreThan, timeSpan);
     }
 
@@ -912,7 +915,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// </param>
     public DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
     {
-        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject,
+        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
             TimeSpanCondition.AtLeast, timeSpan);
     }
 
@@ -925,7 +928,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// </param>
     public DateTimeOffsetRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
     {
-        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject,
+        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
             TimeSpanCondition.Exactly, timeSpan);
     }
 
@@ -938,7 +941,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// </param>
     public DateTimeOffsetRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
     {
-        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject,
+        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
             TimeSpanCondition.Within, timeSpan);
     }
 
@@ -951,7 +954,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// </param>
     public DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
     {
-        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, assertionChain, Subject,
+        return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
             TimeSpanCondition.LessThan, timeSpan);
     }
 
@@ -971,7 +974,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     {
         DateTime expectedDate = expected.Date;
 
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}, ", expectedDate,
                 chain => chain
@@ -1000,7 +1003,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     {
         DateTime unexpectedDate = unexpected.Date;
 
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the date part of {context:the date and time} to be {0}{reason}, ", unexpectedDate,
                 chain => chain
@@ -1070,7 +1073,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTimeOffset?> validValues,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(validValues.Contains(Subject))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the date and time} to be one of {0}{reason}, but it was {1}.", validValues, Subject);

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -30,8 +30,6 @@ public class EnumAssertions<TEnum, TAssertions>
     where TEnum : struct, Enum
     where TAssertions : EnumAssertions<TEnum, TAssertions>
 {
-    private readonly AssertionChain assertionChain;
-
     public EnumAssertions(TEnum subject, AssertionChain assertionChain)
         : this((TEnum?)subject, assertionChain)
     {
@@ -39,11 +37,16 @@ public class EnumAssertions<TEnum, TAssertions>
 
     private protected EnumAssertions(TEnum? value, AssertionChain assertionChain)
     {
-        this.assertionChain = assertionChain;
+        CurrentAssertionChain = assertionChain;
         Subject = value;
     }
 
     public TEnum? Subject { get; }
+
+    /// <summary>
+    /// Provides access to the <see cref="AssertionChain"/> that this assertion class was initialized with.
+    /// </summary>
+    public AssertionChain CurrentAssertionChain { get; }
 
     /// <summary>
     /// Asserts that the current <typeparamref name="TEnum"/> is exactly equal to the <paramref name="expected"/> value.
@@ -59,7 +62,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> Be(TEnum expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject?.Equals(expected) == true)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to be {0}{reason}, but found {1}.",
@@ -82,7 +85,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> Be(TEnum? expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Nullable.Equals(Subject, expected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to be {0}{reason}, but found {1}.",
@@ -105,7 +108,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> NotBe(TEnum unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject?.Equals(unexpected) != true)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} not to be {0}{reason}, but it is.", unexpected);
@@ -127,7 +130,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> NotBe(TEnum? unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(!Nullable.Equals(Subject, unexpected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} not to be {0}{reason}, but it is.", unexpected);
@@ -148,7 +151,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> BeDefined([StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:the enum} to be defined in {0}{reason}, ", typeof(TEnum), chain => chain
                 .ForCondition(Subject is not null)
@@ -173,7 +176,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> NotBeDefined([StringSyntax("CompositeFormat")] string because = "",
         params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect {context:the enum} to be defined in {0}{reason}, ", typeof(TEnum), chain => chain
                 .ForCondition(Subject is not null)
@@ -199,7 +202,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> HaveValue(decimal expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject is { } value && GetValue(value) == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have value {0}{reason}, but found {1}.",
@@ -222,7 +225,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> NotHaveValue(decimal unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(!(Subject is { } value && GetValue(value) == unexpected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have value {0}{reason}, but found {1}.",
@@ -246,7 +249,7 @@ public class EnumAssertions<TEnum, TAssertions>
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
         where T : struct, Enum
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject is { } value && GetValue(value) == GetValue(expected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have same value as {0}{reason}, but found {1}.",
@@ -270,7 +273,7 @@ public class EnumAssertions<TEnum, TAssertions>
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
         where T : struct, Enum
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(!(Subject is { } value && GetValue(value) == GetValue(unexpected)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have same value as {0}{reason}, but found {1}.",
@@ -294,7 +297,7 @@ public class EnumAssertions<TEnum, TAssertions>
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
         where T : struct, Enum
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject is { } value && GetName(value) == GetName(expected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to have same name as {0}{reason}, but found {1}.",
@@ -318,7 +321,7 @@ public class EnumAssertions<TEnum, TAssertions>
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
         where T : struct, Enum
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(!(Subject is { } value && GetName(value) == GetName(unexpected)))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to not have same name as {0}{reason}, but found {1}.",
@@ -341,7 +344,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject?.HasFlag(expectedFlag) == true)
             .FailWith("Expected {context:the enum} to have flag {0}{reason}, but found {1}.", expectedFlag, Subject);
@@ -363,7 +366,7 @@ public class EnumAssertions<TEnum, TAssertions>
     public AndConstraint<TAssertions> NotHaveFlag(TEnum unexpectedFlag,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject?.HasFlag(unexpectedFlag) != true)
             .FailWith("Expected {context:the enum} to not have flag {0}{reason}.", unexpectedFlag);
@@ -390,7 +393,7 @@ public class EnumAssertions<TEnum, TAssertions>
     {
         Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate), "Cannot match an enum against a <null> predicate.");
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(predicate.Compile()(Subject))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:the enum} to match {1}{reason}, but found {0}.", Subject, predicate.Body);
@@ -433,7 +436,7 @@ public class EnumAssertions<TEnum, TAssertions>
         Guard.ThrowIfArgumentIsEmpty(validValues, nameof(validValues),
             "Cannot assert that an enum is one of an empty list of enums");
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:the enum} to be one of {0}{reason}, but found <null>", validValues)
             .Then

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -26,11 +26,9 @@ public class GuidAssertions : GuidAssertions<GuidAssertions>
 public class GuidAssertions<TAssertions>
     where TAssertions : GuidAssertions<TAssertions>
 {
-    private readonly AssertionChain assertionChain;
-
     public GuidAssertions(Guid? value, AssertionChain assertionChain)
     {
-        this.assertionChain = assertionChain;
+        CurrentAssertionChain = assertionChain;
         Subject = value;
     }
 
@@ -38,6 +36,11 @@ public class GuidAssertions<TAssertions>
     /// Gets the object whose value is being asserted.
     /// </summary>
     public Guid? Subject { get; }
+
+    /// <summary>
+    /// Provides access to the <see cref="AssertionChain"/> that this assertion class was initialized with.
+    /// </summary>
+    public AssertionChain CurrentAssertionChain { get; }
 
     #region BeEmpty / NotBeEmpty
 
@@ -53,7 +56,7 @@ public class GuidAssertions<TAssertions>
     /// </param>
     public AndConstraint<TAssertions> BeEmpty([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == Guid.Empty)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:Guid} to be empty{reason}, but found {0}.", Subject);
@@ -73,7 +76,7 @@ public class GuidAssertions<TAssertions>
     /// </param>
     public AndConstraint<TAssertions> NotBeEmpty([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject is { } value && value != Guid.Empty)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:Guid} to be empty{reason}.");
@@ -122,7 +125,7 @@ public class GuidAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(Guid expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
@@ -167,7 +170,7 @@ public class GuidAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(Guid unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {context:Guid} to be {0}{reason}.", Subject);

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -27,11 +27,9 @@ public class SimpleTimeSpanAssertions : SimpleTimeSpanAssertions<SimpleTimeSpanA
 public class SimpleTimeSpanAssertions<TAssertions>
     where TAssertions : SimpleTimeSpanAssertions<TAssertions>
 {
-    private readonly AssertionChain assertionChain;
-
     public SimpleTimeSpanAssertions(TimeSpan? value, AssertionChain assertionChain)
     {
-        this.assertionChain = assertionChain;
+        CurrentAssertionChain = assertionChain;
         Subject = value;
     }
 
@@ -39,6 +37,11 @@ public class SimpleTimeSpanAssertions<TAssertions>
     /// Gets the object whose value is being asserted.
     /// </summary>
     public TimeSpan? Subject { get; }
+
+    /// <summary>
+    /// Provides access to the <see cref="AssertionChain"/> that this assertion class was initialized with.
+    /// </summary>
+    public AssertionChain CurrentAssertionChain { get; }
 
     /// <summary>
     /// Asserts that the time difference of the current <see cref="TimeSpan"/> is greater than zero.
@@ -52,7 +55,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     /// </param>
     public AndConstraint<TAssertions> BePositive([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject > TimeSpan.Zero)
             .FailWith("Expected {context:time} to be positive{reason}, but found {0}.", Subject);
@@ -72,7 +75,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     /// </param>
     public AndConstraint<TAssertions> BeNegative([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject < TimeSpan.Zero)
             .FailWith("Expected {context:time} to be negative{reason}, but found {0}.", Subject);
@@ -95,7 +98,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(TimeSpan expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(expected == Subject)
             .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
@@ -118,7 +121,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(TimeSpan unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(unexpected != Subject)
             .BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {0}{reason}.", unexpected);
@@ -141,7 +144,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     public AndConstraint<TAssertions> BeLessThan(TimeSpan expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject < expected)
             .FailWith("Expected {context:time} to be less than {0}{reason}, but found {1}.", expected, Subject);
@@ -164,7 +167,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     public AndConstraint<TAssertions> BeLessThanOrEqualTo(TimeSpan expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject <= expected)
             .FailWith("Expected {context:time} to be less than or equal to {0}{reason}, but found {1}.", expected, Subject);
@@ -187,7 +190,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     public AndConstraint<TAssertions> BeGreaterThan(TimeSpan expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject > expected)
             .FailWith("Expected {context:time} to be greater than {0}{reason}, but found {1}.", expected, Subject);
@@ -210,7 +213,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
     public AndConstraint<TAssertions> BeGreaterThanOrEqualTo(TimeSpan expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject >= expected)
             .FailWith("Expected {context:time} to be greater than or equal to {0}{reason}, but found {1}.", expected, Subject);
@@ -248,7 +251,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
         TimeSpan minimumValue = nearbyTime - precision;
         TimeSpan maximumValue = nearbyTime + precision;
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject >= minimumValue && Subject.Value <= maximumValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be within {0} from {1}{reason}, but found {2}.",
@@ -288,7 +291,7 @@ public class SimpleTimeSpanAssertions<TAssertions>
         TimeSpan minimumValue = distantTime - precision;
         TimeSpan maximumValue = distantTime + precision;
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject < minimumValue || Subject > maximumValue)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to not be within {0} from {1}{reason}, but found {2}.",

--- a/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/FluentAssertions/Primitives/TimeOnlyAssertions.cs
@@ -31,11 +31,9 @@ public class TimeOnlyAssertions : TimeOnlyAssertions<TimeOnlyAssertions>
 public class TimeOnlyAssertions<TAssertions>
     where TAssertions : TimeOnlyAssertions<TAssertions>
 {
-    private readonly AssertionChain assertionChain;
-
     public TimeOnlyAssertions(TimeOnly? value, AssertionChain assertionChain)
     {
-        this.assertionChain = assertionChain;
+        CurrentAssertionChain = assertionChain;
         Subject = value;
     }
 
@@ -43,6 +41,11 @@ public class TimeOnlyAssertions<TAssertions>
     /// Gets the object whose value is being asserted.
     /// </summary>
     public TimeOnly? Subject { get; }
+
+    /// <summary>
+    /// Provides access to the <see cref="AssertionChain"/> that this assertion class was initialized with.
+    /// </summary>
+    public AssertionChain CurrentAssertionChain { get; }
 
     /// <summary>
     /// Asserts that the current <see cref="TimeOnly"/> is exactly equal to the <paramref name="expected"/> value.
@@ -58,7 +61,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(TimeOnly expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be {0}{reason}, but found {1}.",
@@ -81,7 +84,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> Be(TimeOnly? expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject == expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be {0}{reason}, but found {1}.",
@@ -104,7 +107,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(TimeOnly unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} not to be {0}{reason}, but it is.", unexpected);
@@ -126,7 +129,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotBe(TimeOnly? unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject != unexpected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} not to be {0}{reason}, but it is.", unexpected);
@@ -161,7 +164,7 @@ public class TimeOnlyAssertions<TAssertions>
             ? MinimumDifference(Subject.Value, nearbyTime)
             : null;
 
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected {context:the time} to be within {0} from {1}{reason}, ", precision, nearbyTime,
                 chain => chain
@@ -205,7 +208,7 @@ public class TimeOnlyAssertions<TAssertions>
     {
         Guard.ThrowIfArgumentIsNegative(precision);
 
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect {context:the time} to be within {0} from {1}{reason}, ", precision, distantTime,
                 chain => chain
@@ -232,7 +235,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeBefore(TimeOnly expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject < expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be before {0}{reason}, but found {1}.", expected,
@@ -272,7 +275,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOnOrBefore(TimeOnly expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject <= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be on or before {0}{reason}, but found {1}.", expected,
@@ -312,7 +315,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeAfter(TimeOnly expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject > expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be after {0}{reason}, but found {1}.", expected,
@@ -352,7 +355,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOnOrAfter(TimeOnly expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(Subject >= expected)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be on or after {0}{reason}, but found {1}.", expected,
@@ -392,7 +395,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveHours(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the hours part of {context:the time} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -418,7 +421,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveHours(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .ForCondition(Subject.HasValue)
             .FailWith("Did not expect the hours part of {context:the time} to be {0}{reason}, but found a <null> TimeOnly.",
@@ -445,7 +448,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveMinutes(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the minutes part of {context:the time} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -471,7 +474,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveMinutes(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the minutes part of {context:the time} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -497,7 +500,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveSeconds(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the seconds part of {context:the time} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -523,7 +526,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveSeconds(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the seconds part of {context:the time} to be {0}{reason}", unexpected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -549,7 +552,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> HaveMilliseconds(int expected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Expected the milliseconds part of {context:the time} to be {0}{reason}", expected, chain => chain
                 .ForCondition(Subject.HasValue)
@@ -575,7 +578,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> NotHaveMilliseconds(int unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .BecauseOf(because, becauseArgs)
             .WithExpectation("Did not expect the milliseconds part of {context:the time} to be {0}{reason}", unexpected,
                 chain => chain
@@ -645,7 +648,7 @@ public class TimeOnlyAssertions<TAssertions>
     public AndConstraint<TAssertions> BeOneOf(IEnumerable<TimeOnly?> validValues,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(validValues.Contains(Subject))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:time} to be one of {0}{reason}, but found {1}.", validValues, Subject);

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -18,15 +18,13 @@ namespace FluentAssertions.Types;
 [DebuggerNonUserCode]
 public class TypeSelectorAssertions
 {
-    private readonly AssertionChain assertionChain;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="TypeSelectorAssertions"/> class.
     /// </summary>
     /// <exception cref="ArgumentNullException"><paramref name="types"/> is or contains <see langword="null"/>.</exception>
     public TypeSelectorAssertions(AssertionChain assertionChain, params Type[] types)
     {
-        this.assertionChain = assertionChain;
+        CurrentAssertionChain = assertionChain;
         Guard.ThrowIfArgumentIsNull(types);
         Guard.ThrowIfArgumentContainsNull(types);
 
@@ -37,6 +35,11 @@ public class TypeSelectorAssertions
     /// Gets the object whose value is being asserted.
     /// </summary>
     public IEnumerable<Type> Subject { get; }
+
+    /// <summary>
+    /// Provides access to the <see cref="AssertionChain"/> that this assertion class was initialized with.
+    /// </summary>
+    public AssertionChain CurrentAssertionChain { get; }
 
     /// <summary>
     /// Asserts that the current <see cref="Type"/> is decorated with the specified <typeparamref name="TAttribute"/>.
@@ -55,7 +58,7 @@ public class TypeSelectorAssertions
             .Where(type => !type.IsDecoratedWith<TAttribute>())
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesWithoutAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with {0}{reason}," +
@@ -92,7 +95,7 @@ public class TypeSelectorAssertions
             .Where(type => !type.IsDecoratedWith(isMatchingAttributePredicate))
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesWithoutMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with {0} that matches {1}{reason}," +
@@ -122,7 +125,7 @@ public class TypeSelectorAssertions
             .Where(type => !type.IsDecoratedWithOrInherit<TAttribute>())
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesWithoutAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with or inherit {0}{reason}," +
@@ -159,7 +162,7 @@ public class TypeSelectorAssertions
             .Where(type => !type.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesWithoutMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be decorated with or inherit {0} that matches {1}{reason}," +
@@ -188,7 +191,7 @@ public class TypeSelectorAssertions
             .Where(type => type.IsDecoratedWith<TAttribute>())
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesWithAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with {0}{reason}," +
@@ -225,7 +228,7 @@ public class TypeSelectorAssertions
             .Where(type => type.IsDecoratedWith(isMatchingAttributePredicate))
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesWithMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with {0} that matches {1}{reason}," +
@@ -255,7 +258,7 @@ public class TypeSelectorAssertions
             .Where(type => type.IsDecoratedWithOrInherit<TAttribute>())
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesWithAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with or inherit {0}{reason}," +
@@ -292,7 +295,7 @@ public class TypeSelectorAssertions
             .Where(type => type.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesWithMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to not be decorated with or inherit {0} that matches {1}{reason}," +
@@ -318,7 +321,7 @@ public class TypeSelectorAssertions
     {
         var notSealedTypes = Subject.Where(type => !type.IsCSharpSealed()).ToArray();
 
-        assertionChain.ForCondition(notSealedTypes.Length == 0)
+        CurrentAssertionChain.ForCondition(notSealedTypes.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be sealed{reason}, but the following types are not:" + Environment.NewLine + "{0}.",
                 GetDescriptionsFor(notSealedTypes));
@@ -340,7 +343,7 @@ public class TypeSelectorAssertions
     {
         var sealedTypes = Subject.Where(type => type.IsCSharpSealed()).ToArray();
 
-        assertionChain.ForCondition(sealedTypes.Length == 0)
+        CurrentAssertionChain.ForCondition(sealedTypes.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types not to be sealed{reason}, but the following types are:" + Environment.NewLine + "{0}.",
                 GetDescriptionsFor(sealedTypes));
@@ -368,7 +371,7 @@ public class TypeSelectorAssertions
             .Where(t => t.Namespace != @namespace)
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesNotInNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected all types to be in namespace {0}{reason}," +
@@ -399,7 +402,7 @@ public class TypeSelectorAssertions
             .Where(t => t.Namespace == @namespace)
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesInNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected no types to be in namespace {0}{reason}," +
@@ -430,7 +433,7 @@ public class TypeSelectorAssertions
             .Where(t => !t.IsUnderNamespace(@namespace))
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesNotUnderNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected the namespaces of all types to start with {0}{reason}," +
@@ -462,7 +465,7 @@ public class TypeSelectorAssertions
             .Where(t => t.IsUnderNamespace(@namespace))
             .ToArray();
 
-        assertionChain
+        CurrentAssertionChain
             .ForCondition(typesUnderNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected the namespaces of all types to not start with {0}{reason}," +

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1651,6 +1651,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public bool? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
@@ -1667,6 +1668,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(System.DateTime? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
@@ -1717,6 +1719,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(System.DateTimeOffset? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
@@ -1789,6 +1792,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
@@ -1821,6 +1825,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
         public GuidAssertions(System.Guid? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.Guid? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
@@ -1975,6 +1980,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(System.TimeSpan? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -2522,6 +2528,7 @@ namespace FluentAssertions.Types
     public class TypeSelectorAssertions
     {
         public TypeSelectorAssertions(FluentAssertions.Execution.AssertionChain assertionChain, params System.Type[] types) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : System.Attribute { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -1676,6 +1676,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public bool? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
@@ -1692,6 +1693,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.DateOnlyAssertions<TAssertions>
     {
         public DateOnlyAssertions(System.DateOnly? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.DateOnly? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateOnly expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateOnly? expected, string because = "", params object[] becauseArgs) { }
@@ -1725,6 +1727,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(System.DateTime? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
@@ -1775,6 +1778,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(System.DateTimeOffset? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
@@ -1847,6 +1851,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
@@ -1879,6 +1884,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
         public GuidAssertions(System.Guid? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.Guid? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
@@ -2059,6 +2065,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(System.TimeSpan? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -2150,6 +2157,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.TimeOnlyAssertions<TAssertions>
     {
         public TimeOnlyAssertions(System.TimeOnly? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.TimeOnly? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeOnly expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeOnly? expected, string because = "", params object[] becauseArgs) { }
@@ -2652,6 +2660,7 @@ namespace FluentAssertions.Types
     public class TypeSelectorAssertions
     {
         public TypeSelectorAssertions(FluentAssertions.Execution.AssertionChain assertionChain, params System.Type[] types) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : System.Attribute { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1595,6 +1595,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public bool? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
@@ -1611,6 +1612,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(System.DateTime? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
@@ -1661,6 +1663,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(System.DateTimeOffset? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
@@ -1733,6 +1736,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
@@ -1765,6 +1769,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
         public GuidAssertions(System.Guid? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.Guid? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
@@ -1919,6 +1924,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(System.TimeSpan? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -2466,6 +2472,7 @@ namespace FluentAssertions.Types
     public class TypeSelectorAssertions
     {
         public TypeSelectorAssertions(FluentAssertions.Execution.AssertionChain assertionChain, params System.Type[] types) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : System.Attribute { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1651,6 +1651,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public bool? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
@@ -1667,6 +1668,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(System.DateTime? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
@@ -1717,6 +1719,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(System.DateTimeOffset? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
@@ -1789,6 +1792,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
@@ -1821,6 +1825,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
         public GuidAssertions(System.Guid? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.Guid? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
@@ -1975,6 +1980,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(System.TimeSpan? value, FluentAssertions.Execution.AssertionChain assertionChain) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -2524,6 +2530,7 @@ namespace FluentAssertions.Types
     public class TypeSelectorAssertions
     {
         public TypeSelectorAssertions(FluentAssertions.Execution.AssertionChain assertionChain, params System.Type[] types) { }
+        public FluentAssertions.Execution.AssertionChain CurrentAssertionChain { get; }
         public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : System.Attribute { }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,16 @@ sidebar:
 * Add `ForConstraint` to `GivenSelector<T>` allowing further chaining after `.Then` - [#44](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/44)
 * Increase default displayed length in `StringEqualityStrategy` - [#94](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/94)
 * Make displayed length in `StringEqualityStrategy` configurable - [#100](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/100)
+* Provide access to `AssertionChain` that assertion classes were initialized with - [#115](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/115)
+  * `BooleanAssertions`
+  * `DateOnlyAssertions`
+  * `DateTimeAssertions`
+  * `DateTimeOffsetAssertions`
+  * `EnumAssertions`
+  * `GuidAssertions`
+  * `SimpleTimeSpanAssertions`
+  * `TimeOnlyAssertions`
+  * `TypeSelectorAssertions`
 
 ### Improvements
 * Improve `Type` formatting - [#78](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/78)


### PR DESCRIPTION
* Provide access to AssertionChain that assertion classes were initialized with #114.
* This is already available for many assertions, but some were forgotten. Having this property is necessary in order to write extension methods for the respective assertions.

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
