### PR TITLE
Add CustomAssertionsAttribute #116

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -139,11 +139,24 @@ public static class CallerIdentifier
         {
             return
                 getMethod.IsDecoratedWithOrInherit<CustomAssertionAttribute>() ||
+                IsCustomAssertionClass(getMethod.DeclaringType) ||
                 getMethod.ReflectedType?.Assembly.IsDefined(typeof(CustomAssertionsAssemblyAttribute)) == true;
         }
 
         return false;
     }
+
+    /// <summary>
+    /// Check if <paramref name="type"/> is a custom assertion class.
+    /// </summary>
+    /// <remarks>
+    /// Checking also explicitly the declaring type is necessary for DisplayClasses, which can't be marked
+    /// themselves like normal nested classes.
+    /// </remarks>
+    /// <param name="type">The class type to check</param>
+    /// <returns>True if type is a custom assertion class, or nested inside such a class.</returns>
+    private static bool IsCustomAssertionClass(Type type)
+        => type is not null && (type.IsDecoratedWithOrInherit<CustomAssertionsAttribute>() || IsCustomAssertionClass(type.DeclaringType));
 
     private static bool IsDynamic(StackFrame frame)
     {

--- a/Src/FluentAssertions/CustomAssertionAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionAttribute.cs
@@ -3,7 +3,7 @@
 namespace FluentAssertions;
 
 /// <summary>
-/// Marks a method as an extension to Fluent Assertions that either uses the built-in assertions
+/// Marks a method as an extension to Awesome Assertions that either uses the built-in assertions
 /// internally, or directly uses <c>AssertionChain</c>.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]

--- a/Src/FluentAssertions/CustomAssertionsAssemblyAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionsAssemblyAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace FluentAssertions;
 
 /// <summary>
-/// Marks an assembly as containing extensions to Fluent Assertions that either uses the built-in assertions
+/// Marks an assembly as containing extensions to Awesome Assertions that either uses the built-in assertions
 /// internally, or directly uses <c>AssertionChain</c>.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly)]

--- a/Src/FluentAssertions/CustomAssertionsAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionsAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace FluentAssertions;
+
+/// <summary>
+/// Marks a class as containing extensions to Awesome Assertions that either uses the built-in assertions
+/// internally, or directly uses <c>AssertionChain</c>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class CustomAssertionsAttribute : Attribute;

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -203,6 +203,11 @@ namespace FluentAssertions
     {
         public CustomAssertionsAssemblyAttribute() { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public sealed class CustomAssertionsAttribute : System.Attribute
+    {
+        public CustomAssertionsAttribute() { }
+    }
     public static class EnumAssertionsExtensions
     {
         public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -216,6 +216,11 @@ namespace FluentAssertions
     {
         public CustomAssertionsAssemblyAttribute() { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public sealed class CustomAssertionsAttribute : System.Attribute
+    {
+        public CustomAssertionsAttribute() { }
+    }
     public static class EnumAssertionsExtensions
     {
         public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -201,6 +201,11 @@ namespace FluentAssertions
     {
         public CustomAssertionsAssemblyAttribute() { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public sealed class CustomAssertionsAttribute : System.Attribute
+    {
+        public CustomAssertionsAttribute() { }
+    }
     public static class EnumAssertionsExtensions
     {
         public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -203,6 +203,11 @@ namespace FluentAssertions
     {
         public CustomAssertionsAssemblyAttribute() { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public sealed class CustomAssertionsAttribute : System.Attribute
+    {
+        public CustomAssertionsAttribute() { }
+    }
     public static class EnumAssertionsExtensions
     {
         public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentificationSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentificationSpecs.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
+using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/ExtensibilitySpecs.cs
+++ b/Tests/FluentAssertions.Specs/ExtensibilitySpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using ExampleExtensions;
+using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;
 
@@ -36,6 +37,33 @@ public class ExtensibilitySpecs
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected palindrome to be*tneulf*");
+    }
+
+    [Fact]
+    public void Methods_and_generated_methods_in_classes_marked_as_custom_assertions_are_ignored_during_caller_identification()
+    {
+        string expectedSubjectName = "any";
+
+        // Act
+        Action act = () => expectedSubjectName.Should().MethodWithGeneratedDisplayClass();
+
+        // Arrange
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected expectedSubjectName something, failure \"message\"");
+    }
+}
+
+[CustomAssertions]
+public static class CustomAssertionExtensions
+{
+    public static void MethodWithGeneratedDisplayClass(this StringAssertions assertions)
+    {
+        assertions.CurrentAssertionChain
+            .WithExpectation("Expected {context:FallbackIdentifier} something", chain =>
+                chain
+                    .ForCondition(condition: false)
+                    .FailWith(", failure {0}", "message")
+        );
     }
 }
 

--- a/docs/_pages/introduction.md
+++ b/docs/_pages/introduction.md
@@ -149,6 +149,8 @@ myClient.Should().BeActive("because we don't work with old clients");
 
 Without the `[CustomAssertion]` attribute, Awesome Assertions would find the line that calls `Should().BeTrue()` and treat the `customer` variable as the subject-under-test (SUT). But by applying this attribute, it will ignore this invocation and instead find the SUT by looking for a call to `Should().BeActive()` and use the `myClient` variable instead.
 
+For whole assertions classes you can use the `[CustomAssertions]` attribute to mark them as being extensions to Awesome Assertions.
+
 Alternatively, you can add the `[assembly:CustomAssertionsAssembly]` attribute to a file within the project to tell Awesome Assertions that all code in that assembly should be treated as custom assertion code.
 
 ## Assertion Scopes

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,6 +9,10 @@ sidebar:
 
 ## Unreleased
 
+### What's new
+
+* You can mark all assertions in a class as custom assertions using the `[CustomAssertions]` attribute - [#118](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/118)
+
 ### Improvements
 * Provide access to `AssertionChain` that assertion classes were initialized with - [#138](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/138)
   * `DateTimeOffsetRangeAssertions`


### PR DESCRIPTION
* Add CustomAssertionsAttribute to mark whole classes as being extensions to AwesomeAssertions
Fixes #116 
<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
