### PR TITLE
Add TypeSelector filter for access modifier (#141)

### DIFF
--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -287,6 +287,26 @@ public class TypeSelector : IEnumerable<Type>
     }
 
     /// <summary>
+    /// Filters and returns only the types which have access modifier <paramref name="accessModifier"/>.
+    /// </summary>
+    /// <param name="accessModifier">Required access modifier for types</param>
+    public TypeSelector ThatHaveAccessModifier(CSharpAccessModifier accessModifier)
+    {
+        types = types.Where(t => t.GetCSharpAccessModifier() == accessModifier).ToList();
+        return this;
+    }
+
+    /// <summary>
+    /// Filters and returns only the types which don't have access modifier <paramref name="accessModifier"/>.
+    /// </summary>
+    /// <param name="accessModifier">Unwanted access modifier for types</param>
+    public TypeSelector ThatDoNotHaveAccessModifier(CSharpAccessModifier accessModifier)
+    {
+        types = types.Where(t => t.GetCSharpAccessModifier() != accessModifier).ToList();
+        return this;
+    }
+
+    /// <summary>
     /// Returns T for the types which are <see cref="Task{T}"/> or <see cref="ValueTask{T}"/>; the type itself otherwise
     /// </summary>
     public TypeSelector UnwrapTaskTypes()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2530,7 +2530,9 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
         public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
         public System.Type[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net6.0.verified.txt
@@ -2663,7 +2663,9 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
         public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
         public System.Type[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2474,7 +2474,9 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
         public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
         public System.Type[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2532,7 +2532,9 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreValueTypes() { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
         public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
         public System.Type[] ToArray() { }

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
+using FluentAssertions.Common;
 using FluentAssertions.Types;
 using Internal.AbstractAndNotAbstractClasses.Test;
 using Internal.InterfaceAndClasses.Test;
@@ -719,6 +720,40 @@ namespace FluentAssertions.Specs.Types
                 .And.Contain(typeof(InternalNotInterfaceClass))
                 .And.Contain(typeof(InternalAbstractClass));
         }
+
+        [Fact]
+        public void When_selecting_types_by_access_modifier_it_should_return_the_correct_types()
+        {
+            // Arrange
+            Assembly assembly = Assembly.GetExecutingAssembly();
+
+            // Act
+            IEnumerable<Type> types = AllTypes.From(assembly)
+                .ThatAreInNamespace("Internal.PublicAndInternalClasses.Test")
+                .ThatHaveAccessModifier(CSharpAccessModifier.Public);
+
+            // Assert
+            types.Should()
+                .ContainSingle()
+                .Which.Should().Be(typeof(Internal.PublicAndInternalClasses.Test.PublicClass));
+        }
+
+        [Fact]
+        public void When_selecting_types_excluding_access_modifier_it_should_return_the_correct_types()
+        {
+            // Arrange
+            Assembly assembly = Assembly.GetExecutingAssembly();
+
+            // Act
+            IEnumerable<Type> types = AllTypes.From(assembly)
+                .ThatAreInNamespace("Internal.PublicAndInternalClasses.Test")
+                .ThatDoNotHaveAccessModifier(CSharpAccessModifier.Public);
+
+            // Assert
+            types.Should()
+                .ContainSingle()
+                .Which.Should().Be(typeof(Internal.PublicAndInternalClasses.Test.InternalClass));
+        }
     }
 }
 
@@ -868,6 +903,13 @@ namespace Internal.SealedAndNotSealedClasses.Test
     internal sealed class SealedClass;
 
     internal class NotSealedClass;
+}
+
+namespace Internal.PublicAndInternalClasses.Test
+{
+    public class PublicClass;
+
+    internal class InternalClass;
 }
 
 namespace Internal.ValueTypesAndNotValueTypes.Test

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's new
 
 * You can mark all assertions in a class as custom assertions using the `[CustomAssertions]` attribute - [#118](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/118)
+* Added `That[DoNot]HaveAccessModifier` method for filtering types - [#143](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/143)
 
 ### Improvements
 * Provide access to `AssertionChain` that assertion classes were initialized with - [#138](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/138)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Fixes #141 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
