### PR TITLE
refactor: fix test name

### DIFF
--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Contain.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.Contain.cs
@@ -413,7 +413,7 @@ public partial class StringAssertionSpecs
             }
 
             [Fact]
-            public void When_string_containment_less_than_once_is_asserted_and_actual_value_is_null_then_it_should_not_throw()
+            public void When_string_containment_less_than_twice_is_asserted_and_actual_value_is_null_then_it_should_not_throw()
             {
                 // Arrange
                 string actual = null;


### PR DESCRIPTION
I just stumbled over this test name by accident and thought to fix it:

The test checks for `LessThan.Twice()` and not `LessThan.Once()` (which does not even exist)


## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
