### PR TITLE
Add more tests for GenericCollectionAssertions.NotEqual

### DIFF
--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
@@ -410,5 +410,27 @@ public partial class CollectionAssertionSpecs
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collections not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
         }
+
+        [Fact]
+        public void When_asserting_two_collections_not_to_be_equal_because_the_actual_collection_contains_more_items_it_should_succeed()
+        {
+            // Arrange
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [1, 2];
+
+            // Act / Assert
+            collection1.Should().NotEqual(collection2);
+        }
+
+        [Fact]
+        public void When_asserting_two_collections_not_to_be_equal_because_the_actual_collection_contains_less_items_it_should_succeed()
+        {
+            // Arrange
+            int[] collection1 = [1, 2, 3];
+            int[] collection2 = [1, 2, 3, 4];
+
+            // Act / Assert
+            collection1.Should().NotEqual(collection2);
+        }
     }
 }


### PR DESCRIPTION
* Add tests for collections of different length

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
