### PR TITLE
Fix: Remove unnecessary quotes from TypeSelectorAssertions

### DIFF
--- a/Src/AwesomeAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/AwesomeAssertions/Types/TypeSelectorAssertions.cs
@@ -61,10 +61,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesWithoutAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to be decorated with {0}{reason}," +
-                " but the attribute was not found on the following types:" + Environment.NewLine + "{1}.",
-                typeof(TAttribute),
-                GetDescriptionsFor(typesWithoutAttribute));
+            .FailWith($$"""
+                Expected all types to be decorated with {0}{reason}, but the attribute was not found on the following types:
+                {{GetDescriptionsFor(typesWithoutAttribute)}}.
+                """,
+                typeof(TAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -98,11 +99,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesWithoutMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to be decorated with {0} that matches {1}{reason}," +
-                " but no matching attribute was found on the following types:" + Environment.NewLine + "{2}.",
-                typeof(TAttribute),
-                isMatchingAttributePredicate,
-                GetDescriptionsFor(typesWithoutMatchingAttribute));
+            .FailWith($$"""
+                Expected all types to be decorated with {0} that matches {1}{reason}, but no matching attribute was found on the following types:
+                {{GetDescriptionsFor(typesWithoutMatchingAttribute)}}.
+                """,
+                typeof(TAttribute), isMatchingAttributePredicate);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -128,10 +129,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesWithoutAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to be decorated with or inherit {0}{reason}," +
-                " but the attribute was not found on the following types:" + Environment.NewLine + "{1}.",
-                typeof(TAttribute),
-                GetDescriptionsFor(typesWithoutAttribute));
+            .FailWith($$"""
+                Expected all types to be decorated with or inherit {0}{reason}, but the attribute was not found on the following types:
+                {{GetDescriptionsFor(typesWithoutAttribute)}}.
+                """,
+                typeof(TAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -165,11 +167,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesWithoutMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to be decorated with or inherit {0} that matches {1}{reason}," +
-                " but no matching attribute was found on the following types:" + Environment.NewLine + "{2}.",
-                typeof(TAttribute),
-                isMatchingAttributePredicate,
-                GetDescriptionsFor(typesWithoutMatchingAttribute));
+            .FailWith($$"""
+                Expected all types to be decorated with or inherit {0} that matches {1}{reason}, but no matching attribute was found on the following types:
+                {{GetDescriptionsFor(typesWithoutMatchingAttribute)}}.
+                """,
+                typeof(TAttribute), isMatchingAttributePredicate);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -194,10 +196,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesWithAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to not be decorated with {0}{reason}," +
-                " but the attribute was found on the following types:" + Environment.NewLine + "{1}.",
-                typeof(TAttribute),
-                GetDescriptionsFor(typesWithAttribute));
+            .FailWith($$"""
+                Expected all types to not be decorated with {0}{reason}, but the attribute was found on the following types:
+                {{GetDescriptionsFor(typesWithAttribute)}}.
+                """,
+                typeof(TAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -231,11 +234,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesWithMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to not be decorated with {0} that matches {1}{reason}," +
-                " but a matching attribute was found on the following types:" + Environment.NewLine + "{2}.",
-                typeof(TAttribute),
-                isMatchingAttributePredicate,
-                GetDescriptionsFor(typesWithMatchingAttribute));
+            .FailWith($$"""
+                Expected all types to not be decorated with {0} that matches {1}{reason}, but a matching attribute was found on the following types:
+                {{GetDescriptionsFor(typesWithMatchingAttribute)}}.
+                """,
+                typeof(TAttribute), isMatchingAttributePredicate);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -261,10 +264,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesWithAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to not be decorated with or inherit {0}{reason}," +
-                " but the attribute was found on the following types:" + Environment.NewLine + "{1}.",
-                typeof(TAttribute),
-                GetDescriptionsFor(typesWithAttribute));
+            .FailWith($$"""
+                Expected all types to not be decorated with or inherit {0}{reason}, but the attribute was found on the following types:
+                {{GetDescriptionsFor(typesWithAttribute)}}.
+                """,
+                typeof(TAttribute));
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -298,11 +302,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesWithMatchingAttribute.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to not be decorated with or inherit {0} that matches {1}{reason}," +
-                " but a matching attribute was found on the following types:" + Environment.NewLine + "{2}.",
-                typeof(TAttribute),
-                isMatchingAttributePredicate,
-                GetDescriptionsFor(typesWithMatchingAttribute));
+            .FailWith($$"""
+                Expected all types to not be decorated with or inherit {0} that matches {1}{reason}, but a matching attribute was found on the following types:
+                {{GetDescriptionsFor(typesWithMatchingAttribute)}}.
+                """,
+                typeof(TAttribute), isMatchingAttributePredicate);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -323,8 +327,10 @@ public class TypeSelectorAssertions
 
         CurrentAssertionChain.ForCondition(notSealedTypes.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to be sealed{reason}, but the following types are not:" + Environment.NewLine + "{0}.",
-                GetDescriptionsFor(notSealedTypes));
+            .FailWith($$"""
+                Expected all types to be sealed{reason}, but the following types are not:
+                {{GetDescriptionsFor(notSealedTypes)}}.
+                """);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -345,8 +351,10 @@ public class TypeSelectorAssertions
 
         CurrentAssertionChain.ForCondition(sealedTypes.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types not to be sealed{reason}, but the following types are:" + Environment.NewLine + "{0}.",
-                GetDescriptionsFor(sealedTypes));
+            .FailWith($$"""
+                Expected all types not to be sealed{reason}, but the following types are:
+                {{GetDescriptionsFor(sealedTypes)}}.
+                """);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -374,10 +382,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesNotInNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected all types to be in namespace {0}{reason}," +
-                " but the following types are in a different namespace:" + Environment.NewLine + "{1}.",
-                @namespace,
-                GetDescriptionsFor(typesNotInNamespace));
+            .FailWith($$"""
+                Expected all types to be in namespace {0}{reason}, but the following types are in a different namespace:
+                {{GetDescriptionsFor(typesNotInNamespace)}}.
+                """,
+                @namespace);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -405,10 +414,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesInNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected no types to be in namespace {0}{reason}," +
-                " but the following types are in the namespace:" + Environment.NewLine + "{1}.",
-                @namespace,
-                GetDescriptionsFor(typesInNamespace));
+            .FailWith($$"""
+                Expected no types to be in namespace {0}{reason}, but the following types are in the namespace:
+                {{GetDescriptionsFor(typesInNamespace)}}.
+                """,
+                @namespace);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -436,10 +446,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesNotUnderNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected the namespaces of all types to start with {0}{reason}," +
-                " but the namespaces of the following types do not start with it:" + Environment.NewLine + "{1}.",
-                @namespace,
-                GetDescriptionsFor(typesNotUnderNamespace));
+            .FailWith($$"""
+                Expected the namespaces of all types to start with {0}{reason}, but the namespaces of the following types do not start with it:
+                {{GetDescriptionsFor(typesNotUnderNamespace)}}.
+                """,
+                @namespace);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }
@@ -468,10 +479,11 @@ public class TypeSelectorAssertions
         CurrentAssertionChain
             .ForCondition(typesUnderNamespace.Length == 0)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected the namespaces of all types to not start with {0}{reason}," +
-                " but the namespaces of the following types start with it:" + Environment.NewLine + "{1}.",
-                @namespace,
-                GetDescriptionsFor(typesUnderNamespace));
+            .FailWith($$"""
+                Expected the namespaces of all types to not start with {0}{reason}, but the namespaces of the following types start with it:
+                {{GetDescriptionsFor(typesUnderNamespace)}}.
+                """,
+                @namespace);
 
         return new AndConstraint<TypeSelectorAssertions>(this);
     }

--- a/Tests/AwesomeAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
@@ -41,7 +41,7 @@ public class TypeSelectorAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected all types to be sealed *failure message*, but the following types are not:*\"*.Abstract\".");
+                    "Expected all types to be sealed *failure message*, but the following types are not:*.Abstract.");
         }
     }
 
@@ -75,7 +75,7 @@ public class TypeSelectorAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types not to be sealed *failure message*, but the following types are:*\"*.Sealed\".");
+                .WithMessage("Expected all types not to be sealed *failure message*, but the following types are:*.Sealed.");
         }
     }
 
@@ -114,7 +114,7 @@ public class TypeSelectorAssertionSpecs
                 .WithMessage(
                     "Expected all types to be decorated with *.DummyClassAttribute *failure message*" +
                     ", but the attribute was not found on the following types:" +
-                    "*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+                    "**.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
         }
 
         [Fact]
@@ -154,7 +154,7 @@ public class TypeSelectorAssertionSpecs
                 .WithMessage(
                     "Expected all types to be decorated with *.DummyClassAttribute that matches " +
                     "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but no matching attribute was found on " +
-                    "the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+                    "the following types:*.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
         }
     }
 
@@ -193,7 +193,7 @@ public class TypeSelectorAssertionSpecs
                 .WithMessage(
                     "Expected all types to be decorated with or inherit *.DummyClassAttribute *failure message*" +
                     ", but the attribute was not found on the following types:" +
-                    "*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+                    "*.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
         }
 
         [Fact]
@@ -235,7 +235,7 @@ public class TypeSelectorAssertionSpecs
                 .WithMessage(
                     "Expected all types to be decorated with or inherit *.DummyClassAttribute that matches " +
                     "(a.Name == \"Expected\")*a.IsEnabled *failure message*, but no matching attribute was found " +
-                    "on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+                    "on the following types:*.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
         }
     }
 
@@ -273,7 +273,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all types to not be decorated *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was found on the following types:*\"*.ClassWithAttribute\".");
+                    ", but the attribute was found on the following types:*.ClassWithAttribute.");
         }
 
         [Fact]
@@ -312,7 +312,7 @@ public class TypeSelectorAssertionSpecs
                 .WithMessage(
                     "Expected all types to not be decorated with *.DummyClassAttribute that matches " +
                     "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
-                    "on the following types:*\"*.ClassWithAttribute\".");
+                    "on the following types:*.ClassWithAttribute.");
         }
     }
 
@@ -350,7 +350,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all types to not be decorated with or inherit *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was found on the following types:*\"*.ClassWithInheritedAttribute\".");
+                    ", but the attribute was found on the following types:*.ClassWithInheritedAttribute.");
         }
 
         [Fact]
@@ -369,7 +369,7 @@ public class TypeSelectorAssertionSpecs
                 .WithMessage(
                     "Expected all types to not be decorated with or inherit *.DummyClassAttribute that matches " +
                     "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
-                    "on the following types:*\"*.ClassWithInheritedAttribute\".");
+                    "on the following types:*.ClassWithInheritedAttribute.");
         }
 
         [Fact]
@@ -430,7 +430,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all types to be in namespace \"DummyNamespace\" *failure message*, but the following types " +
-                    "are in a different namespace:*\"*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+                    "are in a different namespace:*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace.");
         }
 
         [Fact]
@@ -456,7 +456,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all types to be in namespace \"DummyNamespace\", but the following types " +
-                    "are in a different namespace:*\"ClassInGlobalNamespace\".");
+                    "are in a different namespace:*ClassInGlobalNamespace.");
         }
 
         [Fact]
@@ -477,7 +477,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all types to be in namespace <null>, but the following types are in a different namespace:" +
-                    "*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+                    "*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace.");
         }
     }
 
@@ -522,7 +522,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected no types to be in namespace \"DummyNamespace\" *failure message*" +
-                    ", but the following types are in the namespace:*\"DummyNamespace.ClassInDummyNamespace\".");
+                    ", but the following types are in the namespace:*DummyNamespace.ClassInDummyNamespace.");
         }
     }
 
@@ -596,7 +596,7 @@ public class TypeSelectorAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\" *failure message*" +
-                    ", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespaceTwo\".");
+                    ", but the namespaces of the following types do not start with it:*.ClassInDummyNamespaceTwo.");
         }
 
         [Fact]
@@ -617,7 +617,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected the namespaces of all types to start with \"DummyNamespace.InnerDummyNamespace\"" +
-                    ", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespace\".");
+                    ", but the namespaces of the following types do not start with it:*.ClassInDummyNamespace.");
         }
     }
 
@@ -652,7 +652,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected the namespaces of all types to not start with \"DummyNamespace\" *failure message*" +
-                    ", but the namespaces of the following types start with it:*\"*.ClassInDummyNamespace\".");
+                    ", but the namespaces of the following types start with it:*.ClassInDummyNamespace.");
         }
 
         [Fact]
@@ -669,7 +669,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected the namespaces of all types to not start with \"DummyNamespace.InnerDummyNamespace\"" +
-                    ", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
+                    ", but the namespaces of the following types start with it:*.ClassInInnerDummyNamespace.");
         }
 
         [Fact]
@@ -685,7 +685,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected the namespaces of all types to not start with \"DummyNamespace\"" +
-                    ", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
+                    ", but the namespaces of the following types start with it:*.ClassInInnerDummyNamespace.");
         }
 
         [Fact]
@@ -701,7 +701,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected the namespaces of all types to not start with <null>" +
-                    ", but the namespaces of the following types start with it:*\"ClassInGlobalNamespace\".");
+                    ", but the namespaces of the following types start with it:*ClassInGlobalNamespace.");
         }
 
         [Fact]
@@ -722,7 +722,7 @@ public class TypeSelectorAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected the namespaces of all types to not start with <null>, but the namespaces of the following types " +
-                    "start with it:*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+                    "start with it:*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace.");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,9 @@ sidebar:
 ### What's new
 * Add new assertions for strings: `[Not]BeParsableInto` - [#185](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/185)
 
+### Fixes
+* Remove unnecessary quotes from `TypeSelectorAssertions` failure messages - [#200](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/200)
+
 ## 9.0.0
 
 ### Breaking Changes


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

Fixes #199 
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome
