### PR TITLE
Allow using assertions in a chained assertion

### DIFF
--- a/Src/AwesomeAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/AwesomeAssertions/Collections/GenericCollectionAssertions.cs
@@ -1945,25 +1945,12 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     {
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify inequivalence against a <null> collection.");
 
-        if (Subject is null)
-        {
-            assertionChain
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} not to be equivalent{reason}, but found <null>.");
-        }
-
-        string[] failures;
-
-        using (var scope = new AssertionScope())
-        {
-            BeEquivalentTo(unexpected, config);
-
-            failures = scope.Discard();
-        }
-
         assertionChain
-            .ForCondition(failures.Length > 0)
             .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith("Expected {context:collection} not to be equivalent{reason}, but found <null>.")
+        .Then
+            .NotSatisfy(() => BeEquivalentTo(unexpected, config))
             .FailWith("Expected {context:collection} {0} not to be equivalent to collection {1}{reason}.", Subject,
                 unexpected);
 

--- a/Src/AwesomeAssertions/Execution/GivenSelector.cs
+++ b/Src/AwesomeAssertions/Execution/GivenSelector.cs
@@ -45,6 +45,50 @@ public class GivenSelector<T>
         return this;
     }
 
+    /// <summary>
+    /// Allows combining one or more failing assertions using the other assertion methods that this library offers
+    /// upon the subject selected through a prior selector.
+    /// </summary>
+    /// <remarks>
+    /// This is only evaluated when all previous assertions in the chain have succeeded.
+    /// </remarks>
+    /// <param name="failingAssertion">The element inspector which must not be satisfied by the previously selected subject.</param>
+    /// <returns>The current <see cref="AssertionChain"/> instance, allowing for method chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="failingAssertion"/> is <see langword="null"/>.</exception>
+    public GivenSelector<T> NotSatisfy(Action<T> failingAssertion)
+    {
+        Guard.ThrowIfArgumentIsNull(failingAssertion);
+
+        if (assertionChain.Succeeded)
+        {
+            assertionChain.NotSatisfy(() => failingAssertion(selector));
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Allows combining one or more assertions using the other assertion methods that this library offers
+    /// upon the subject selected through a prior selector.
+    /// </summary>
+    /// <remarks>
+    /// This is only evaluated when all previous assertions in the chain have succeeded.
+    /// </remarks>
+    /// <param name="assertion">The element inspector which must be satisfied by the previously selected subject.</param>
+    /// <returns>The current <see cref="AssertionChain"/> instance, allowing for method chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="assertion"/> is <see langword="null"/>.</exception>
+    public GivenSelector<T> Satisfy(Action<T> assertion)
+    {
+        Guard.ThrowIfArgumentIsNull(assertion);
+
+        if (assertionChain.Succeeded)
+        {
+            assertionChain.Satisfy(() => assertion(selector));
+        }
+
+        return this;
+    }
+
     public GivenSelector<T> ForConstraint(OccurrenceConstraint constraint, Func<T, int> func)
     {
         Guard.ThrowIfArgumentIsNull(func);

--- a/Src/AwesomeAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/ObjectAssertions.cs
@@ -366,16 +366,8 @@ public class ObjectAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
     {
         Guard.ThrowIfArgumentIsNull(config);
 
-        bool hasMismatches;
-
-        using (var scope = new AssertionScope())
-        {
-            BeEquivalentTo(unexpected, config);
-            hasMismatches = scope.Discard().Length > 0;
-        }
-
         assertionChain
-            .ForCondition(hasMismatches)
+            .NotSatisfy(() => BeEquivalentTo(unexpected, config))
             .BecauseOf(because, becauseArgs)
             .WithDefaultIdentifier(Identifier)
             .FailWith("Expected {context} not to be equivalent to {0}{reason}, but they are.", unexpected);

--- a/Src/AwesomeAssertions/Primitives/StringAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/StringAssertions.cs
@@ -182,16 +182,8 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     public AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            BeEquivalentTo(unexpected);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
         assertionChain
-            .ForCondition(notEquivalent)
+            .NotSatisfy(() => BeEquivalentTo(unexpected))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:string} not to be equivalent to {0}{reason}, but they are.", unexpected);
 
@@ -220,16 +212,8 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     {
         Guard.ThrowIfArgumentIsNull(config);
 
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            Subject.Should().BeEquivalentTo(unexpected, config);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
         assertionChain
-            .ForCondition(notEquivalent)
+            .NotSatisfy(() => Subject.Should().BeEquivalentTo(unexpected, config))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected {context:string} not to be equivalent to {0}{reason}, but they are.", unexpected);
 
@@ -1030,18 +1014,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     {
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare start of string with <null>.");
 
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            Subject.Should().StartWith(unexpected);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
         assertionChain
-            .ForCondition(Subject != null && notEquivalent)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:string} not to start with {0}{reason}, but found {1}.", unexpected, Subject);
+            .WithExpectation("Expected {context:string} not to start with {0}{reason}, ", unexpected, chain => chain
+                .ForCondition(Subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .NotSatisfy(() => Subject.Should().StartWith(unexpected))
+                .FailWith("but found {0}.", Subject));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -1126,19 +1106,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     {
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare start of string with <null>.");
 
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            Subject.Should().StartWithEquivalentOf(unexpected);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
         assertionChain
-            .ForCondition(Subject != null && notEquivalent)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:string} not to start with equivalent of {0}{reason}, but found {1}.", unexpected,
-                Subject);
+            .WithExpectation("Expected {context:string} not to start with equivalent of {0}{reason}, ", unexpected, chain => chain
+                .ForCondition(Subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .NotSatisfy(() => Subject.Should().StartWithEquivalentOf(unexpected))
+                .FailWith("but found {0}.", Subject));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -1165,19 +1140,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare start of string with <null>.");
         Guard.ThrowIfArgumentIsNull(config);
 
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            Subject.Should().StartWithEquivalentOf(unexpected, config);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
         assertionChain
-            .ForCondition(Subject != null && notEquivalent)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:string} not to start with equivalent of {0}{reason}, but found {1}.", unexpected,
-                Subject);
+            .WithExpectation("Expected {context:string} not to start with equivalent of {0}{reason}, but found <null>.", unexpected, chain => chain
+                .ForCondition(Subject is not null)
+                .FailWith(", but found <null>.")
+                .Then
+                .NotSatisfy(() => Subject.Should().StartWithEquivalentOf(unexpected, config))
+                .FailWith(", but found {0}.", unexpected, Subject));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -1227,18 +1197,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     {
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare end of string with <null>.");
 
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            Subject.Should().EndWith(unexpected);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
         assertionChain
-            .ForCondition(Subject != null && notEquivalent)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:string} not to end with {0}{reason}, but found {1}.", unexpected, Subject);
+            .WithExpectation("Expected {context:string} not to end with {0}{reason}, ", unexpected, chain => chain
+                .ForCondition(Subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .NotSatisfy(() => Subject.Should().EndWith(unexpected))
+                .FailWith("but found {0}.", Subject));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -1323,18 +1289,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
     {
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare end of string with <null>.");
 
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            Subject.Should().EndWithEquivalentOf(unexpected);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
         assertionChain
-            .ForCondition(Subject != null && notEquivalent)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:string} not to end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
+            .WithExpectation("Expected {context:string} not to end with equivalent of {0}{reason}, ", unexpected, chain => chain
+                .ForCondition(Subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .NotSatisfy(() => Subject.Should().EndWithEquivalentOf(unexpected))
+                .FailWith("but found {0}.", Subject));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -1361,18 +1323,14 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare end of string with <null>.");
         Guard.ThrowIfArgumentIsNull(config);
 
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            Subject.Should().EndWithEquivalentOf(unexpected, config);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
         assertionChain
-            .ForCondition(Subject != null && notEquivalent)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {context:string} not to end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
+            .WithExpectation("Expected {context:string} not to end with equivalent of {0}{reason}, ", unexpected, chain => chain
+                .ForCondition(Subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .NotSatisfy(() => Subject.Should().EndWithEquivalentOf(unexpected, config))
+                .FailWith("but found {0}.", Subject));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -1782,24 +1740,13 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         assertionChain
-            .ForCondition(!string.IsNullOrEmpty(unexpected) && Subject != null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Did not expect {context:string} to contain the equivalent of {0}{reason}, but found {1}.", unexpected,
-                Subject);
-
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            Subject.Should().ContainEquivalentOf(unexpected);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
-        assertionChain
-            .ForCondition(notEquivalent)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Did not expect {context:string} to contain the equivalent of {0}{reason} but found {1}.", unexpected,
-                Subject);
+            .WithExpectation("Did not expect {context:string} to contain the equivalent of {0}{reason}", unexpected, chain => chain
+                .ForCondition(!string.IsNullOrEmpty(unexpected) && Subject != null)
+                .FailWith(", but found {0}.", Subject)
+                .Then
+                .NotSatisfy(() => Subject.Should().ContainEquivalentOf(unexpected))
+                .FailWith(", but found {0}.", Subject));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -1825,24 +1772,13 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         Guard.ThrowIfArgumentIsNull(config);
 
         assertionChain
-            .ForCondition(!string.IsNullOrEmpty(unexpected) && Subject != null)
             .BecauseOf(because, becauseArgs)
-            .FailWith("Did not expect {context:string} to contain the equivalent of {0}{reason}, but found {1}.", unexpected,
-                Subject);
-
-        bool notEquivalent;
-
-        using (var scope = new AssertionScope())
-        {
-            Subject.Should().ContainEquivalentOf(unexpected, config);
-            notEquivalent = scope.Discard().Length > 0;
-        }
-
-        assertionChain
-            .ForCondition(notEquivalent)
-            .BecauseOf(because, becauseArgs)
-            .FailWith("Did not expect {context:string} to contain the equivalent of {0}{reason}, but found {1}.", unexpected,
-                Subject);
+            .WithExpectation("Did not expect {context:string} to contain the equivalent of {0}{reason}", unexpected, chain => chain
+                .ForCondition(!string.IsNullOrEmpty(unexpected) && Subject != null)
+                .FailWith(", but found {0}.", Subject)
+                .Then
+                .NotSatisfy(() => Subject.Should().ContainEquivalentOf(unexpected, config))
+                .FailWith(", but found {0}.", Subject));
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
@@ -1230,8 +1230,10 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public AwesomeAssertions.Execution.AssertionChain NotSatisfy(System.Action failingAssertion) { }
         public void OverrideCallerIdentifier(System.Func<string> getCallerIdentifier) { }
         public void ReuseOnce() { }
+        public AwesomeAssertions.Execution.AssertionChain Satisfy(System.Action assertion) { }
         public AwesomeAssertions.Execution.AssertionChain WithCallerPostfix(string postfix) { }
         public AwesomeAssertions.Execution.AssertionChain WithDefaultIdentifier(string identifier) { }
         public AwesomeAssertions.Execution.Continuation WithExpectation(string message, System.Action<AwesomeAssertions.Execution.AssertionChain> chain) { }
@@ -1285,6 +1287,8 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
         public AwesomeAssertions.Execution.GivenSelector<T> ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, System.Func<T, int> func) { }
         public AwesomeAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> NotSatisfy(System.Action<T> failingAssertion) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> Satisfy(System.Action<T> assertion) { }
     }
     public interface IAssertionStrategy
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
@@ -1248,8 +1248,10 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public AwesomeAssertions.Execution.AssertionChain NotSatisfy(System.Action failingAssertion) { }
         public void OverrideCallerIdentifier(System.Func<string> getCallerIdentifier) { }
         public void ReuseOnce() { }
+        public AwesomeAssertions.Execution.AssertionChain Satisfy(System.Action assertion) { }
         public AwesomeAssertions.Execution.AssertionChain WithCallerPostfix(string postfix) { }
         public AwesomeAssertions.Execution.AssertionChain WithDefaultIdentifier(string identifier) { }
         public AwesomeAssertions.Execution.Continuation WithExpectation(string message, System.Action<AwesomeAssertions.Execution.AssertionChain> chain) { }
@@ -1303,6 +1305,8 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
         public AwesomeAssertions.Execution.GivenSelector<T> ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, System.Func<T, int> func) { }
         public AwesomeAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> NotSatisfy(System.Action<T> failingAssertion) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> Satisfy(System.Action<T> assertion) { }
     }
     public interface IAssertionStrategy
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -1248,8 +1248,10 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public AwesomeAssertions.Execution.AssertionChain NotSatisfy(System.Action failingAssertion) { }
         public void OverrideCallerIdentifier(System.Func<string> getCallerIdentifier) { }
         public void ReuseOnce() { }
+        public AwesomeAssertions.Execution.AssertionChain Satisfy(System.Action assertion) { }
         public AwesomeAssertions.Execution.AssertionChain WithCallerPostfix(string postfix) { }
         public AwesomeAssertions.Execution.AssertionChain WithDefaultIdentifier(string identifier) { }
         public AwesomeAssertions.Execution.Continuation WithExpectation(string message, System.Action<AwesomeAssertions.Execution.AssertionChain> chain) { }
@@ -1303,6 +1305,8 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
         public AwesomeAssertions.Execution.GivenSelector<T> ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, System.Func<T, int> func) { }
         public AwesomeAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> NotSatisfy(System.Action<T> failingAssertion) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> Satisfy(System.Action<T> assertion) { }
     }
     public interface IAssertionStrategy
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -1174,8 +1174,10 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public AwesomeAssertions.Execution.AssertionChain NotSatisfy(System.Action failingAssertion) { }
         public void OverrideCallerIdentifier(System.Func<string> getCallerIdentifier) { }
         public void ReuseOnce() { }
+        public AwesomeAssertions.Execution.AssertionChain Satisfy(System.Action assertion) { }
         public AwesomeAssertions.Execution.AssertionChain WithCallerPostfix(string postfix) { }
         public AwesomeAssertions.Execution.AssertionChain WithDefaultIdentifier(string identifier) { }
         public AwesomeAssertions.Execution.Continuation WithExpectation(string message, System.Action<AwesomeAssertions.Execution.AssertionChain> chain) { }
@@ -1229,6 +1231,8 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
         public AwesomeAssertions.Execution.GivenSelector<T> ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, System.Func<T, int> func) { }
         public AwesomeAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> NotSatisfy(System.Action<T> failingAssertion) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> Satisfy(System.Action<T> assertion) { }
     }
     public interface IAssertionStrategy
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -1230,8 +1230,10 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public AwesomeAssertions.Execution.AssertionChain NotSatisfy(System.Action failingAssertion) { }
         public void OverrideCallerIdentifier(System.Func<string> getCallerIdentifier) { }
         public void ReuseOnce() { }
+        public AwesomeAssertions.Execution.AssertionChain Satisfy(System.Action assertion) { }
         public AwesomeAssertions.Execution.AssertionChain WithCallerPostfix(string postfix) { }
         public AwesomeAssertions.Execution.AssertionChain WithDefaultIdentifier(string identifier) { }
         public AwesomeAssertions.Execution.Continuation WithExpectation(string message, System.Action<AwesomeAssertions.Execution.AssertionChain> chain) { }
@@ -1285,6 +1287,8 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
         public AwesomeAssertions.Execution.GivenSelector<T> ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, System.Func<T, int> func) { }
         public AwesomeAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> NotSatisfy(System.Action<T> failingAssertion) { }
+        public AwesomeAssertions.Execution.GivenSelector<T> Satisfy(System.Action<T> assertion) { }
     }
     public interface IAssertionStrategy
     {

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
@@ -560,7 +560,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect string to contain the equivalent of <null>, but found \"a\".");
+                .Which.Message.Should().Be("Did not expect string to contain the equivalent of <null>, but found \"a\".");
         }
 
         [Fact]
@@ -572,7 +572,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect string to contain the equivalent of \"\", but found \"a\".");
+                .Which.Message.Should().Be("Did not expect string to contain the equivalent of \"\", but found \"a\".");
         }
 
         [Fact]
@@ -584,7 +584,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect string to contain the equivalent of \", worLD!\" but found \"Hello, world!\".");
+                .Which.Message.Should().Be("Did not expect string to contain the equivalent of \", worLD!\", but found \"Hello, world!\".");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.StartWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.StartWith.cs
@@ -142,7 +142,7 @@ public partial class StringAssertionSpecs
                 value.Should().NotStartWith("AB", "because of some reason");
 
             // Assert
-            action.Should().Throw<XunitException>().WithMessage(
+            action.Should().Throw<XunitException>().Which.Message.Should().Be(
                 "Expected value not to start with \"AB\" because of some reason, but found \"ABC\".");
         }
 
@@ -172,7 +172,7 @@ public partial class StringAssertionSpecs
                 value.Should().NotStartWith("");
 
             // Assert
-            action.Should().Throw<XunitException>().WithMessage(
+            action.Should().Throw<XunitException>().Which.Message.Should().Be(
                 "Expected value not to start with \"\", but found \"ABC\".");
         }
 

--- a/docs/_pages/extensibility.md
+++ b/docs/_pages/extensibility.md
@@ -53,7 +53,7 @@ public class DirectoryInfoAssertions :
             .FailWith("You can't assert a file exist if you don't pass a proper name")
             .Then
             .Given(() => Subject.GetFiles())
-            .ForCondition(files => files.Any(fileInfo => fileInfo.Name.Equals(filename)))
+            .Satisfy(files => files.Should().Contain(filename))
             .FailWith("Expected {context:directory} to contain {0}{reason}, but found {1}.",
                 _ => filename, files => files.Select(file => file.Name));
 
@@ -69,7 +69,10 @@ This is quite an elaborate example which shows some of the more advanced extensi
 * The variable `chain` of type `AssertionChain` is the point of entrance into the internal fluent API.
 * The optional `because` parameter can contain `string.Format` style place holders which will be filled using the values provided to the `becauseArgs`. They can be used by the caller to provide a reason why the assertion should succeed. By passing those into the `BecauseOf` method, you can refer to the expanded result using the `{reason}` tag in the `FailWith` method.
 * The `Then` property is just there to chain multiple assertions together. You can have more than one. However, if the first assertion fails, then the successive assertions will not be evaluated anymore.
-* The `Given` method allows you to perform a lazily evaluated projection on whatever you want. In this case I use it to get a list of `FileInfo` objects from the current directory. Notice that the resulting expression is not evaluated until the final call to `FailWith`.
+* The `Given` method allows you to perform a lazily evaluated projection on whatever you want. In this case I use it to get a list of `FileInfo` objects from the current directory.
+* The `ForCondition` specifies the condition which is expected to return `true`.
+* When using `Satisfy`, the given assertion is expected to succeed.
+* When using `NotSatisfy`, the given assertion is expected to fail.
 * `FailWith` will evaluate the condition, and raise the appropriate exception specific for the detected test framework. It again can contain numbered placeholders as well as the special named placeholders `{context}` and `{reason}`. I'll explain the former in a minute, but suffice to say that it displays the text "directory" at that point. The remainder of the place holders will be filled by applying the appropriate type-specific value formatter for the provided arguments. If those arguments involve a non-primitive type such as a collection or complex type, the formatters will use recursion to always use the appropriate formatter.
 * Since we used the `Given` construct to create a projection, the parameters of `FailWith` are formed by a `params` array of `Func<T, object>` that give you access to the projection (such as the `FileInfo[]` in this particular case). But normally, it's just a `params array` of objects.
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 ### What's new
 
 * Added overload for collection's `Contain` to assert the occurrences - [#238](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/238)
+* Allow using assertions in a chained assertion with `[Not]Satisfy` - 
 
 ### Improvements
 * Always use improved string difference visualization independent of the subject's or expectation's string length - [#215](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/215)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
