### PR TITLE
Improve string matching failures for long or multiline strings

### DIFF
--- a/Src/AwesomeAssertions/Common/Mismatch/MismatchRenderer.cs
+++ b/Src/AwesomeAssertions/Common/Mismatch/MismatchRenderer.cs
@@ -30,9 +30,9 @@ internal static class MismatchRenderer
             CreateLocationDescription(rendererOptions.Subject, rendererOptions.SubjectIndexOfMismatch, rendererOptions.MismatchLocationDescription);
 
         return $$"""
-                 {{rendererOptions.ExpectationDescription}}the same string{reason}, but they differ {{locationDescription}}:
-                 {{mismatchSegment}}.
-                 """;
+            {{rendererOptions.ExpectationDescription}} the same string{reason}, but they differ {{locationDescription}}:
+            {{mismatchSegment}}.
+            """;
     }
 
     /// <summary>

--- a/Src/AwesomeAssertions/Common/StringExtensions.cs
+++ b/Src/AwesomeAssertions/Common/StringExtensions.cs
@@ -139,7 +139,7 @@ internal static class StringExtensions
     public static bool IsLongOrMultiline(this string value)
     {
         const int humanReadableLength = 8;
-        return value.Length > humanReadableLength || value.Contains(Environment.NewLine, StringComparison.Ordinal);
+        return value is not null && (value.Length > humanReadableLength || value.Contains(Environment.NewLine, StringComparison.Ordinal));
     }
 
     public static bool IsNullOrEmpty([NotNullWhen(false)] this string value)

--- a/Src/AwesomeAssertions/Primitives/StringComparisonBaseStrategy.cs
+++ b/Src/AwesomeAssertions/Primitives/StringComparisonBaseStrategy.cs
@@ -1,3 +1,4 @@
+using AwesomeAssertions.Common;
 using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Primitives;
@@ -29,8 +30,26 @@ internal abstract class StringComparisonBaseStrategy
 
         assertionChain
             .ForCondition(subject is not null && expected is not null)
-            .FailWith($"{ExpectationDescription}{{0}}{{reason}}, but found {{1}}.", expected, subject);
+            .FailWith(() => GetFailureDescription(subject, expected));
 
         return assertionChain.Succeeded;
+    }
+
+    private FailReason GetFailureDescription(string subject, string expected)
+    {
+        if (subject.IsLongOrMultiline() || expected.IsLongOrMultiline())
+        {
+            return new FailReason($$"""
+                {{ExpectationDescription}}
+
+                  {0}
+
+                {reason}, but found
+
+                  {1}.
+                """, expected, subject);
+        }
+
+        return new FailReason($"{ExpectationDescription} {{0}}{{reason}}, but found {{1}}.", expected, subject);
     }
 }

--- a/Src/AwesomeAssertions/Primitives/StringContainsStrategy.cs
+++ b/Src/AwesomeAssertions/Primitives/StringContainsStrategy.cs
@@ -21,8 +21,27 @@ internal class StringContainsStrategy : IStringComparisonStrategy
 
         assertionChain
             .ForConstraint(occurrenceConstraint, actual)
-            .FailWith(
-                $"Expected {{context:string}} {{0}} to contain the equivalent of {{1}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
-                subject, expected);
+            .FailWith(() => GetFailureDescription(subject, expected, actual));
+    }
+
+    private static FailReason GetFailureDescription(string subject, string expected, int actualOccurrences)
+    {
+        if (subject.IsLongOrMultiline() || expected.IsLongOrMultiline())
+        {
+            return new($$"""
+                Expected {context:string}
+
+                  {0}
+
+                to contain the equivalent of
+
+                  {1}
+
+                {expectedOccurrence}{reason}, but found it {{actualOccurrences.Times()}}.
+                """, subject, expected);
+        }
+
+        return new($"Expected {{context:string}} {{0}} to contain the equivalent of {{1}} {{expectedOccurrence}}{{reason}}, but found it {actualOccurrences.Times()}.",
+            subject, expected);
     }
 }

--- a/Src/AwesomeAssertions/Primitives/StringEndStrategy.cs
+++ b/Src/AwesomeAssertions/Primitives/StringEndStrategy.cs
@@ -16,7 +16,7 @@ internal class StringEndStrategy : StringComparisonBaseStrategy, IStringComparis
         this.predicateDescription = predicateDescription;
     }
 
-    protected override string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
+    protected override string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription}";
 
     public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
     {

--- a/Src/AwesomeAssertions/Primitives/StringEqualityStrategy.cs
+++ b/Src/AwesomeAssertions/Primitives/StringEqualityStrategy.cs
@@ -16,7 +16,7 @@ internal class StringEqualityStrategy : StringComparisonBaseStrategy, IStringCom
         this.predicateDescription = predicateDescription;
     }
 
-    protected override string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
+    protected override string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription}";
 
     public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
     {

--- a/Src/AwesomeAssertions/Primitives/StringStartStrategy.cs
+++ b/Src/AwesomeAssertions/Primitives/StringStartStrategy.cs
@@ -16,7 +16,7 @@ internal class StringStartStrategy : StringComparisonBaseStrategy, IStringCompar
         this.predicateDescription = predicateDescription;
     }
 
-    protected override string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription} ";
+    protected override string ExpectationDescription => $"Expected {{context:string}} to {predicateDescription}";
 
     public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
     {

--- a/Src/AwesomeAssertions/Primitives/StringWildcardMatchingStrategy.cs
+++ b/Src/AwesomeAssertions/Primitives/StringWildcardMatchingStrategy.cs
@@ -10,7 +10,7 @@ internal class StringWildcardMatchingStrategy : StringComparisonBaseStrategy, IS
 {
     protected override string ExpectationDescription =>
         $"{(Negate ? "Did not expect" : "Expected")}" +
-        $" {{context:string}} {(IgnoreCase ? "to match the equivalent of" : "to match")} ";
+        $" {{context:string}} {(IgnoreCase ? "to match the equivalent of" : "to match")}";
 
     public void ValidateAgainstMismatch(AssertionChain assertionChain, string subject, string expected)
     {
@@ -26,14 +26,28 @@ internal class StringWildcardMatchingStrategy : StringComparisonBaseStrategy, IS
             return;
         }
 
-        if (Negate)
+        assertionChain.FailWith(() => GetFailureDescription(subject, expected));
+    }
+
+    private FailReason GetFailureDescription(string subject, string expected)
+    {
+        string butDescription = Negate ? "matches" : "does not";
+        if (subject.IsLongOrMultiline() || expected.IsLongOrMultiline())
         {
-            assertionChain.FailWith($"{ExpectationDescription}{{0}}{{reason}}, but {{1}} matches.", expected, subject);
+            return new($$"""
+                {{ExpectationDescription}}
+
+                  {0},
+
+                {reason}, but
+
+                  {1}
+
+                {{butDescription}}.
+                """, expected, subject);
         }
-        else
-        {
-            assertionChain.FailWith($"{ExpectationDescription}{{0}}{{reason}}, but {{1}} does not.", expected, subject);
-        }
+
+        return new($"{ExpectationDescription} {{0}}{{reason}}, but {{1}} {butDescription}.", expected, subject);
     }
 
     private bool IsMatch(string subject, string expected)

--- a/Tests/AwesomeAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
@@ -37,7 +37,7 @@ public class OuterExceptionSpecs
         {
             // Assert
             ex.Message.Should().Match(
-                "Expected exception message to match the equivalent of*\"some message\", but*\"some\" does not*");
+                "Expected exception message to match the equivalent of*\"some message\",*but*\"some\"*does not*");
         }
     }
 
@@ -71,7 +71,7 @@ public class OuterExceptionSpecs
         // Assert
         action.Should().Throw<Exception>()
             .WithMessage(
-                "Expected exception message to match the equivalent of*\"Expected mes*\", but*\"OxpectOd message\" does not*");
+                "Expected exception message to match the equivalent of*\"Expected mes*\",*but*\"OxpectOd message\"*does not*");
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class OuterExceptionSpecs
         // Assert
         action.Should().Throw<Exception>()
             .WithMessage(
-                "Expected exception message to match the equivalent of*\"expected mes*\", but*\"OxpectOd message\" does not*");
+                "Expected exception message to match the equivalent of*\"expected mes*\",*but*\"OxpectOd message\"*does not*");
     }
 
     [Fact]
@@ -127,8 +127,8 @@ public class OuterExceptionSpecs
         catch (XunitException ex)
         {
             // Assert
-            ex.Message.Should().Match(
-                "Expected exception message to match the equivalent of \"message2\" because we want to test the failure message, but \"message1\" does not*");
+            ex.Message.Should()
+                .Be("Expected exception message to match the equivalent of \"message2\" because we want to test the failure message, but \"message1\" does not.");
         }
     }
 
@@ -152,7 +152,7 @@ public class OuterExceptionSpecs
         {
             // Assert
             ex.Message.Should().Match(
-                "Expected exception message to match the equivalent of \"message2\"*, but \"\"*");
+                "Expected exception message to match the equivalent of*\"message2\"*,*but*\"\"*");
         }
     }
 
@@ -177,7 +177,7 @@ public class OuterExceptionSpecs
         {
             // Assert
             ex.Message.Should().Match(
-                "Expected exception message to match the equivalent of*\"message2\", but*message2*someParam*");
+                "Expected exception message to match the equivalent of*\"message2\",*but*message2*someParam*");
         }
     }
 
@@ -249,7 +249,7 @@ public class OuterExceptionSpecs
         {
             // Assert
             ex.Message.Should().Match(
-                "Expected exception message to match the equivalent of*\"message without\"*, but*\"message with {}*");
+                "Expected exception message to match the equivalent of*\"message without\"*,*but*\"message with {}*");
         }
     }
 

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -1,4 +1,5 @@
 using System;
+using AwesomeAssertions.Common;
 using Xunit;
 using Xunit.Sdk;
 
@@ -365,39 +366,38 @@ public partial class StringAssertionSpecs
         [Fact]
         public void Mismatches_in_multiline_text_includes_the_line_number()
         {
-            var expectedIndex = 100 + (4 * Environment.NewLine.Length);
-
             var subject = """
-            @startuml
-            Alice -> Bob : Authentication Request
-            Bob --> Alice : Authentication Response
+                @startuml
+                Alice -> Bob : Authentication Request
+                Bob --> Alice : Authentication Response
 
-            Alice -> Bob : Another authentication Request
-            Alice <-- Bob : Another authentication Response
-            @enduml
-            """;
+                Alice -> Bob : Another authentication Request
+                Alice <-- Bob : Another authentication Response
+                @enduml
+                """.RemoveNewlineStyle();
 
             var expected = """
-            @startuml
-            Alice -> Bob : Authentication Request
-            Bob --> Alice : Authentication Response
+                @startuml
+                Alice -> Bob : Authentication Request
+                Bob --> Alice : Authentication Response
 
-            Alice -> Bob : Invalid authentication Request
-            Alice <-- Bob : Another authentication Response
-            @enduml
-            """;
+                Alice -> Bob : Invalid authentication Request
+                Alice <-- Bob : Another authentication Response
+                @enduml
+                """.RemoveNewlineStyle();
 
             // Act
             Action act = () => subject.Should().Be(expected);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage($"""
-                Expected subject to be the same string, but they differ on line 5 and column 16 (index {expectedIndex}):
-                             ↓ (actual)
-                  "…-> Bob : Another authentication Request*\nAlice <-- Bob :…"
-                  "…-> Bob : Invalid authentication Request*\nAlice <-- Bob :…"
-                             ↑ (expected).
-                """);
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should().Be("""
+                    Expected subject to be the same string, but they differ on line 5 and column 16 (index 104):
+                                 ↓ (actual)
+                      "…-> Bob : Another authentication Request\nAlice <-- Bob :…"
+                      "…-> Bob : Invalid authentication Request\nAlice <-- Bob :…"
+                                 ↑ (expected).
+                    """);
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
@@ -191,7 +191,7 @@ public partial class StringAssertionSpecs
                 // Assert
                 act.Should().Throw<XunitException>()
                     .WithMessage(
-                        "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" exactly 3 times, but found it 2 times.");
+                        "Expected *\"abCDEBcDF\"*to contain the equivalent of*\"Bcd\"*exactly 3 times, but found it 2 times.");
             }
 
             [Fact]
@@ -255,7 +255,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" at least 3 times, but found it 2 times.");
+                .WithMessage("Expected *\"abCDEBcDF\"*to contain the equivalent of*\"Bcd\"*at least 3 times, but found it 2 times.");
         }
 
         [Fact]
@@ -319,7 +319,7 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" more than 2 times, but found it 2 times.");
+                    "Expected *\"abCDEBcDF\"*to contain the equivalent of*\"Bcd\"*more than 2 times, but found it 2 times.");
         }
 
         [Fact]
@@ -382,7 +382,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" at most 1 time, but found it 2 times.");
+                .WithMessage("Expected *\"abCDEBcDF\"*to contain the equivalent of*\"Bcd\"*at most 1 time, but found it 2 times.");
         }
 
         [Fact]
@@ -438,7 +438,7 @@ public partial class StringAssertionSpecs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" less than 2 times, but found it 2 times.");
+                    "Expected *\"abCDEBcDF\"*to contain the equivalent of*\"Bcd\"*less than 2 times, but found it 2 times.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.EndWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.EndWith.cs
@@ -117,15 +117,32 @@ public partial class StringAssertionSpecs
             string someString = null;
 
             // Act
-            Action act = () =>
-            {
-                using var _ = new AssertionScope();
-                someString.Should().EndWith("ABC");
-            };
+            Action act = () => someString.Should().EndWith("ABC");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
+            act.Should().Throw<XunitException>().Which.Message.Should().Be(
                 "Expected someString to end with \"ABC\", but found <null>.");
+        }
+
+        [Fact]
+        public void When_string_ending_is_compared_to_long_string_and_actual_value_is_null_then_it_should_throw()
+        {
+            // Arrange
+            string someString = null;
+
+            // Act
+            Action act = () => someString.Should().EndWith("ABCDEFGHIJ", "failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().Which.Message.Should().Be("""
+                Expected someString to end with
+
+                  "ABCDEFGHIJ"
+
+                because failure message, but found
+
+                  <null>.
+                """);
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Match.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Match.cs
@@ -22,8 +22,17 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected subject to match*\"h*earth!\" because failure message, but*\"hello world!\" does not.");
+                .Which.Message.Should().Be("""
+                    Expected subject to match
+
+                      "h*earth!",
+
+                    because failure message, but
+
+                      "hello world!"
+
+                    does not.
+                    """);
         }
 
         [Fact]
@@ -47,7 +56,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to match*\"What\\? Are you deaf\\?\", but*\"What! Are you deaf!\" does not.");
+                .WithMessage("Expected subject to match*\"What\\? Are you deaf\\?\",*but*\"What! Are you deaf!\"*does not.");
         }
 
         [Fact]
@@ -61,7 +70,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to match*\"*World*\", but*\"hello world\" does not.");
+                .WithMessage("Expected subject to match*\"*World*\",*but*\"hello world\"*does not.");
         }
 
         [Fact]
@@ -132,9 +141,18 @@ public partial class StringAssertionSpecs
             Action act = () => subject.Should().NotMatch("*world*", "because that's illegal");
 
             // Assert
-            act
-                .Should().Throw<XunitException>().WithMessage(
-                    "Did not expect subject to match*\"*world*\" because that's illegal, but*\"hello world\" matches.");
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should().Be("""
+                    Did not expect subject to match
+
+                      "*world*",
+
+                    because that's illegal, but
+
+                      "hello world"
+
+                    matches.
+                    """);
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
@@ -62,12 +62,12 @@ public partial class StringAssertionSpecs
             string subject = "hello world!";
 
             // Act
-            Action act = () => subject.Should().MatchEquivalentOf("h*earth!", "that's the universal greeting");
+            Action act = () => subject.Should().MatchEquivalentOf("h*earth!", "failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to match the equivalent of*\"h*earth!\" " +
-                "because that's the universal greeting, but*\"hello world!\" does not.");
+                "Expected subject to match the equivalent of*\"h*earth!\",*" +
+                "because failure message, but*\"hello world!\"*does not.");
         }
 
         [Fact]
@@ -211,13 +211,21 @@ public partial class StringAssertionSpecs
             string subject = "hello WORLD";
 
             // Act
-            Action act = () => subject.Should().NotMatchEquivalentOf("*world*", "because that's illegal");
+            Action act = () => subject.Should().NotMatchEquivalentOf("*world*", "failure {0}", "message");
 
             // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("Did not expect subject to match the equivalent of*\"*world*\" because that's illegal, " +
-                    "but*\"hello WORLD\" matches.");
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should().Be("""
+                    Did not expect subject to match the equivalent of
+
+                      "*world*",
+
+                    because failure message, but
+
+                      "hello WORLD"
+
+                    matches.
+                    """);
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,7 @@ sidebar:
 
 ### Improvements
 * Improve tabulator handling in string difference visualization - [#313](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/313)
+* Improve failure messages for string matching on long or multiline strings - [#](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/)
 
 ### Fixes
 * Fix failure message when matching a `string null` subject - [#314](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/314)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Fixes #194 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
