### PR TITLE
Hide internal exception throwing details in stacktrace

### DIFF
--- a/Src/AwesomeAssertions/AwesomeAssertions.csproj
+++ b/Src/AwesomeAssertions/AwesomeAssertions.csproj
@@ -33,6 +33,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+  </PropertyGroup>
+
   <ItemGroup Label="Internals visible to">
     <InternalsVisibleTo Include="AwesomeAssertions.Specs" />
     <InternalsVisibleTo Include="AwesomeAssertions.Equivalency.Specs" />

--- a/Src/AwesomeAssertions/Execution/AssertionChain.cs
+++ b/Src/AwesomeAssertions/Execution/AssertionChain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -221,21 +222,25 @@ public sealed class AssertionChain
         return new GivenSelector<T>(selector, this);
     }
 
+    [StackTraceHidden]
     internal Continuation FailWithPreFormatted(string formattedFailReason)
     {
         return FailWith(() => formattedFailReason);
     }
 
+    [StackTraceHidden]
     public Continuation FailWith(string message)
     {
         return FailWith(() => new FailReason(message));
     }
 
+    [StackTraceHidden]
     public Continuation FailWith(string message, params object[] args)
     {
         return FailWith(() => new FailReason(message, args));
     }
 
+    [StackTraceHidden]
     public Continuation FailWith(string message, params Func<object>[] argProviders)
     {
         return FailWith(
@@ -244,6 +249,7 @@ public sealed class AssertionChain
                 argProviders.Select(a => a()).ToArray()));
     }
 
+    [StackTraceHidden]
     public Continuation FailWith(Func<FailReason> getFailureReason)
     {
         return FailWith(() =>
@@ -260,6 +266,7 @@ public sealed class AssertionChain
         });
     }
 
+    [StackTraceHidden]
     private Continuation FailWith(Func<string> getFailureReason)
     {
         if (PreviousAssertionSucceeded)
@@ -341,6 +348,7 @@ public sealed class AssertionChain
     /// <summary>
     /// Registers a failure in the chain that doesn't need any parsing or formatting anymore.
     /// </summary>
+    [StackTraceHidden]
     internal void AddPreFormattedFailure(string failure)
     {
         getCurrentScope().AddPreFormattedFailure(failure);

--- a/Src/AwesomeAssertions/Execution/AssertionScope.cs
+++ b/Src/AwesomeAssertions/Execution/AssertionScope.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -163,6 +164,7 @@ public sealed class AssertionScope : IDisposable
     /// <summary>
     /// Adds a pre-formatted failure message to the current scope.
     /// </summary>
+    [StackTraceHidden]
     public void AddPreFormattedFailure(string formattedFailureMessage)
     {
         assertionStrategy.HandleFailure(formattedFailureMessage);
@@ -210,6 +212,7 @@ public sealed class AssertionScope : IDisposable
     }
 
     /// <inheritdoc/>
+    [StackTraceHidden]
     public void Dispose()
     {
         CurrentScope.Value = parent;

--- a/Src/AwesomeAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/AwesomeAssertions/Execution/CollectingAssertionStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -28,6 +29,7 @@ internal class CollectingAssertionStrategy : IAssertionStrategy
     /// <summary>
     /// Will throw a combined exception for any failures have been collected.
     /// </summary>
+    [StackTraceHidden]
     public void ThrowIfAny(IDictionary<string, object> context)
     {
         if (failureMessages.Count > 0)

--- a/Src/AwesomeAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/AwesomeAssertions/Execution/DefaultAssertionStrategy.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace AwesomeAssertions.Execution;
@@ -14,6 +15,7 @@ internal class DefaultAssertionStrategy : IAssertionStrategy
     /// <summary>
     /// Instructs the strategy to handle a assertion failure.
     /// </summary>
+    [StackTraceHidden]
     public void HandleFailure(string message)
     {
         AssertionEngine.TestFramework.Throw(message);

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
@@ -1158,9 +1158,13 @@ namespace AwesomeAssertions.Execution
         public void AddReportable(string key, string value) { }
         public AwesomeAssertions.Execution.AssertionChain BecauseOf(AwesomeAssertions.Execution.Reason reason) { }
         public AwesomeAssertions.Execution.AssertionChain BecauseOf(string because, params object[] becauseArgs) { }
+        [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(System.Func<AwesomeAssertions.Execution.FailReason> getFailureReason) { }
+        [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(string message) { }
+        [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
+        [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
@@ -1188,9 +1192,11 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public System.Func<string> Name { get; }
         public static AwesomeAssertions.Execution.AssertionScope Current { get; }
+        [System.Diagnostics.StackTraceHidden]
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AppendTracing(string tracingBlock) { }
         public string[] Discard() { }
+        [System.Diagnostics.StackTraceHidden]
         public void Dispose() { }
         public bool HasFailures() { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -1158,9 +1158,13 @@ namespace AwesomeAssertions.Execution
         public void AddReportable(string key, string value) { }
         public AwesomeAssertions.Execution.AssertionChain BecauseOf(AwesomeAssertions.Execution.Reason reason) { }
         public AwesomeAssertions.Execution.AssertionChain BecauseOf(string because, params object[] becauseArgs) { }
+        [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(System.Func<AwesomeAssertions.Execution.FailReason> getFailureReason) { }
+        [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(string message) { }
+        [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
+        [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
@@ -1188,9 +1192,11 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public System.Func<string> Name { get; }
         public static AwesomeAssertions.Execution.AssertionScope Current { get; }
+        [System.Diagnostics.StackTraceHidden]
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AppendTracing(string tracingBlock) { }
         public string[] Discard() { }
+        [System.Diagnostics.StackTraceHidden]
         public void Dispose() { }
         public bool HasFailures() { }
     }

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -367,6 +367,40 @@ namespace AwesomeAssertions.Specs.Execution
                     "*Expected value to be 23, but found 42*");
         }
 
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void No_internal_assertion_defails_appear_in_stacktrace_of_scope_with_failures()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var scope = new AssertionScope();
+                AssertionChain.GetOrCreate().FailWith("Failure message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .Which.StackTrace.Should().NotContainAny(
+                    "AssertionScope.",
+                    "AssertionStrategy.",
+                    "AssertionChain.");
+        }
+
+        [Fact]
+        public void No_internal_assertion_defails_appear_in_stacktrace_of_failing_chain()
+        {
+            // Act
+            Action act = () => AssertionChain.GetOrCreate().FailWith("Failure message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .Which.StackTrace.Should().NotContainAny(
+                    "AssertionScope.",
+                    "AssertionStrategy.",
+                    "AssertionChain.");
+        }
+#endif
+
         public class CustomAssertionStrategy : IAssertionStrategy
         {
             private readonly List<string> failureMessages = [];

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 * Add `ExcludingMembersNamed` to `BeEquivalentTo`'s options which enables excluding members with specified name - [#317](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/317)
 
 ### Improvements
+* Hide irrelevant exception throwing details in stacktrace - [#327](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/327)
 * Improve tabulator handling in string difference visualization - [#313](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/313)
 
 ### Fixes


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Fixes #326 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
