### PR TITLE
Rework and extend the design guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The better a bug report, the faster the problem will be resolved.
 Ideally, a bug report should contain the following information:
 
 * A high-level description of the problem.
-* A _minimal reproduction_, e.g. the smallest size of code/configuration required to reproduce the wrong behavior.
+* A _minimal reproduction_, i.e. the smallest size of code/configuration required to reproduce the wrong behavior.
 * A description of the _expected behavior_, contrasted with the _actual behavior_ observed.
 * Information on the environment: nuget version, .NET version, etc.
 * Additional information, e.g. is it a regression from previous versions? Are there any known workarounds?
@@ -85,7 +85,7 @@ Please do:
 * Target the [Pull Request](https://help.github.com/articles/using-pull-requests) at the `develop` branch.
 * Align with the [Design Guide](./DESIGN-GUIDE.md).
 * Ensure that changes are covered by a new or existing set of unit tests.
-  Also, the code coverage reported by the coveralls must be non-decreasing unless accepted by the authors.
+  Also, the code coverage reported by the coveralls must be non-decreasing unless accepted by the maintainers.
 * If the contribution adds a feature or fixes a bug, please update the
   [**release notes**](./docs/_pages/releases.md),
   which is published on the [website](https://awesomeassertions.org/releases).

--- a/DESIGN-GUIDE.md
+++ b/DESIGN-GUIDE.md
@@ -8,7 +8,7 @@ Start reading the section titles, go in deep if the title is not self-explanator
 
 * Lines should not be wider than 130 characters.
 * Prefer `is null` and `is not null` over `!=/== null`.
-* String formatting should use Invariant culture when formatting non-strings.
+* String formatting should use invariant culture when formatting non-strings.
 * Follow the style presented in the [Coding Guidelines for C#](https://csharpcodingguidelines.com/).
 
 ## Design guidelines
@@ -22,7 +22,7 @@ Start reading the section titles, go in deep if the title is not self-explanator
 * Mind the API fluent design. (Test should be readable like natural human language.)
 * Design the features discoverable.
 
-* ✅ Prefer "Did not expect something to be" over "Expected something not to be".
+* ✅ Prefer "Did not expect something to be [...]" over "Expected something not to be [...]".
 * ✅ Be aware that an assertion might be wrapped in an `AssertionScope` so `FailWith` does not halt execution
   and extra precautions must be taken to avoid e.g. a `NullReferenceException` after verifying that `Subject is not null`.
 
@@ -41,7 +41,7 @@ Start reading the section titles, go in deep if the title is not self-explanator
 * Remember to test the "because formatting" overloads.
   * ✅ Always use the pattern `"we format {0} message", "the"`
     resulting in generated string `"because we format the message""`.
-* ❌ Don't use `Should().NotThrow` in the asserting.
+* ❌ Don't use `Should().NotThrow` in the asserting for tests which are meant to pass.
 
 ### TODO - unsorted
 


### PR DESCRIPTION
I've moved the existing "Coding-Guide" from WIKI to code (after private discussion with @cbersch).
Here, I started to rethink the contribution, style and design guide based on the existing one.
This is currently a work in progress, and discussion (preferably) with the maintainers is welcome.

I do not like the reference of external documentation like the "High-level principles". It tried to extract more concrete guidance.
Please, add suggestions for additional statements you feel really required.

Please help to fill the statements currently under "TODO - unsorted".
So far, I did not understand what the concrete guidance may be.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
