### PR TITLE
Fix line breaks in README FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ If you've verified the changes and decided they are valid, you can accept them  
 
 # FAQ
 
-**Q: Who are the maintainers?**\
+**Q: Who are the maintainers?**<br>
 **A:** The current maintainers of AwesomeAssertions are @cbersch, @IT-VBFK, @jcfnomada, @jupjohn, @lg2de, and @ScarletKuro.
 
-**Q: Will the license change to a more permissive or restrictive license compared to Apache 2.0?**\
+**Q: Will the license change to a more permissive or restrictive license compared to Apache 2.0?**<br>
 **A:** The license will never change, not even to MIT. We will only maintain the original Apache 2.0 license.
 
-**Q: How is it possible that you released version 8 with almost identical changes if version 8 of FluentAssertions is under a commercial license?**\
+**Q: How is it possible that you released version 8 with almost identical changes if version 8 of FluentAssertions is under a commercial license?**<br>
 **A:** This was possible because the license change was made at the final stage of the version 8 release. Any commits made before the license change were free to use, as licenses cannot be applied retroactively. If commits were added to the branch while it was under the Apache 2.0 license, they remain under Apache 2.0. So, any commits before this change [fluentassertions/fluentassertions@df7e9bf](https://github.com/fluentassertions/fluentassertions/commit/df7e9bf8305ef5e26ae58fe4142f8d1b6c4fc4af) can be legally used under the Apache 2.0 terms.
 
-**Q: Where can I find the documentation?**\
+**Q: Where can I find the documentation?**<br>
 **A:** You can find the documentation at https://awesomeassertions.org
 
 # Legal Disclaimer


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
Thanks for this awesome package. 

I spotted this small issue with the line breaks in the FAQ section of the README not rendering.

I would love to help contribute to a few simple issues if possible. Is there a way of identifying issues which would be good to try and pickup?

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
