### PR TITLE
Renovate: Disable update of dotnet sdk

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,7 +26,7 @@
 
         // Disable updates of .NET SDK. We want to update that manually only.
         {
-            "matchSourceUrls": ["https://github.com/dotnet/sdk"],
+            "matchDatasources": ["dotnet-version"],
             "enabled": false
         },
 


### PR DESCRIPTION
Disable dotnet sdk according to discussion in #355.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
