### PR TITLE
Code cleanup in the tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -395,6 +395,9 @@ dotnet_diagnostic.MA0004.severity = none
 #  Use string.Equals instead of Equals operator 
 dotnet_diagnostic.MA0006.severity = none
 
+# Add comma to multi-line initializer. We don't care.
+dotnet_diagnostic.MA0007.severity = none
+
 # Add regex evaluation timeout
 dotnet_diagnostic.MA0009.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -44,6 +44,7 @@ csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
+csharp_indent_raw_literal_string = indent
 
 # avoid this. unless absolutely necessary
 dotnet_style_qualification_for_field = false:suggestion

--- a/DESIGN-GUIDE.md
+++ b/DESIGN-GUIDE.md
@@ -37,7 +37,7 @@ Start reading the section titles, go in deep if the title is not self-explanator
   * ❌ Avoid the use of `When` and `Should` in test names and use concise names like `Exclusion_of_missing_members_works_with_mapping`.
 * Every test method shall follow the AAA rule: Arrange, Act, Assert.
   * ✅ Separate Arrange, Act and Assert with exactly one empty line.
-  * ❌ Additional comments for these blocks are not required.
+  * ❌ Omit AAA comments unless you think they are meaningful.
 * Remember to test the "because formatting" overloads.
   * ✅ Always use the pattern `"we format {0} message", "the"`
     resulting in generated string `"because we format the message""`.

--- a/DESIGN-GUIDE.md
+++ b/DESIGN-GUIDE.md
@@ -39,8 +39,9 @@ Start reading the section titles, go in deep if the title is not self-explanator
   * ✅ Separate Arrange, Act and Assert with exactly one empty line.
   * ❌ Omit AAA comments unless you think they are meaningful.
 * Remember to test the "because formatting" overloads.
-  * ✅ Always use the pattern `"we format {0} message", "the"`
-    resulting in generated string `"because we format the message""`.
+  * ✅ Always use the pattern `"we want to test the {0} message", "failure"`
+    resulting in generated string `"because we want to test the failure message"`.
+    This should be checked with either as full text or with the pattern `"*because*failure message*"`
 * ❌ Don't use `Should().NotThrow` in the asserting for tests which are meant to pass.
 
 ### TODO - unsorted

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -155,6 +155,8 @@ dotnet_diagnostic.SA1005.severity = suggestion
 
 # ReSharper/Rider
 resharper_expression_is_always_null_highlighting = none
+resharper_blank_lines_after_multiline_statements = 0
+resharper_blank_lines_before_multiline_statements = 0
 
 # ReSharper properties
 resharper_keep_user_linebreaks = true

--- a/Tests/AwesomeAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
@@ -12,56 +12,42 @@ public class AssertionRuleSpecs
     [Fact]
     public void When_two_objects_have_the_same_property_values_it_should_succeed()
     {
-        // Arrange
         var subject = new { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "Dennis" };
-
         var other = new { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "Dennis" };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(other);
     }
 
     [Fact]
     public void When_two_objects_have_the_same_nullable_property_values_it_should_succeed()
     {
-        // Arrange
         var subject = new { Age = 36, Birthdate = (DateTime?)new DateTime(1973, 9, 20), Name = "Dennis" };
-
         var other = new { Age = 36, Birthdate = (DateTime?)new DateTime(1973, 9, 20), Name = "Dennis" };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(other);
     }
 
     [Fact]
     public void When_two_objects_have_the_same_properties_but_a_different_value_it_should_throw()
     {
-        // Arrange
         var subject = new { Age = 36 };
-
         var expectation = new { Age = 37 };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation, "because {0} are the same", "they");
+        Action act = () => subject.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
-            "Expected*Age*to be 37 because they are the same, but found 36*");
+            "Expected*Age*to be 37 because we want to test the failure message, but found 36*");
     }
 
     [Fact]
     public void
         When_subject_has_a_valid_property_that_is_compared_with_a_null_property_it_should_throw_with_descriptive_message()
     {
-        // Arrange
         var subject = new { Name = "Dennis" };
-
         var other = new { Name = (string)null };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(other, "we want to test the failure {0}", "message");
+        Action act = () => subject.Should().BeEquivalentTo(other, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected property subject.Name to be <null>*we want to test the failure message*, but found \"Dennis\"*");
     }
@@ -69,45 +55,32 @@ public class AssertionRuleSpecs
     [Fact]
     public void When_two_collection_properties_dont_match_it_should_throw_and_specify_the_difference()
     {
-        // Arrange
         var subject = new { Values = new[] { 1, 2, 3 } };
-
         var other = new { Values = new[] { 1, 4, 3 } };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(other);
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected*Values[1]*to be 4, but found 2*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Values[1]*to be 4, but found 2*");
     }
 
     [Fact]
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
     public void When_two_string_properties_do_not_match_it_should_throw_and_state_the_difference()
     {
-        // Arrange
         var subject = new { Name = "Dennes" };
-
         var other = new { Name = "Dennis" };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(other, options => options.Including(d => d.Name));
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected*Name to be*index 4*\"Dennes\"*\"Dennis\"*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Name to be*index 4*\"Dennes\"*\"Dennis\"*");
     }
 
     [Fact]
     public void When_two_properties_are_of_derived_types_but_are_equal_it_should_succeed()
     {
-        // Arrange
         var subject = new { Type = new DerivedCustomerType("123") };
-
         var other = new { Type = new CustomerType("123") };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(other);
     }
 
@@ -115,62 +88,42 @@ public class AssertionRuleSpecs
     public void
         When_two_properties_have_the_same_declared_type_but_different_runtime_types_and_are_equivalent_according_to_the_declared_type_it_should_succeed()
     {
-        // Arrange
         var subject = new { Type = (CustomerType)new DerivedCustomerType("123") };
-
         var other = new { Type = new CustomerType("123") };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(other);
     }
 
     [Fact]
     public void When_a_nested_property_is_equal_based_on_equality_comparer_it_should_not_throw()
     {
-        // Arrange
         var subject = new { Timestamp = 22.March(2020).At(19, 30) };
-
         var expectation = new { Timestamp = 1.January(2020).At(7, 31) };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expectation,
-            opt => opt.Using<DateTime, DateTimeByYearComparer>());
+        subject.Should().BeEquivalentTo(expectation, opt => opt.Using<DateTime, DateTimeByYearComparer>());
     }
 
     [Fact]
     public void When_a_nested_property_is_unequal_based_on_equality_comparer_it_should_throw()
     {
-        // Arrange
         var subject = new { Timestamp = 22.March(2020) };
-
         var expectation = new { Timestamp = 1.January(2021) };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation,
-            opt => opt.Using(new DateTimeByYearComparer()), "we want to test the {0} message", "failure");
+        Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt.Using(new DateTimeByYearComparer()), "we want to test the {0} message", "failure");
 
-        // Assert
-        act.Should()
-            .Throw<XunitException>()
-            .WithMessage("Expected*equal*2021*DateTimeByYearComparer*failure message*2020*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*equal*2021*DateTimeByYearComparer*failure message*2020*");
     }
 
     [Fact]
     public void When_the_subjects_property_type_is_different_from_the_equality_comparer_it_should_throw()
     {
-        // Arrange
         var subject = new { Timestamp = 1L };
-
         var expectation = new { Timestamp = 1.January(2021) };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation,
             opt => opt.Using(new DateTimeByYearComparer()), "we want to test the {0} message", "failure");
 
-        // Assert
-        act.Should()
-            .Throw<XunitException>()
-            .WithMessage("Expected*Timestamp*to be of type *DateTime*failure message*1L*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*to be of type *DateTime*failure message*1L*");
     }
 
     private class DateTimeByYearComparer : IEqualityComparer<DateTime>
@@ -186,81 +139,51 @@ public class AssertionRuleSpecs
     [Fact]
     public void When_an_invalid_equality_comparer_is_provided_it_should_throw()
     {
-        // Arrange
         var subject = new { Timestamp = 22.March(2020) };
-
         var expectation = new { Timestamp = 1.January(2021) };
-
         IEqualityComparer<DateTime> equalityComparer = null;
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation,
-            opt => opt.Using(equalityComparer));
+        Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt.Using(equalityComparer));
 
-        // Assert
-        act.Should()
-            .Throw<ArgumentNullException>()
-            .WithMessage("*comparer*");
+        act.Should().Throw<ArgumentNullException>().WithMessage("*comparer*");
     }
 
     [Fact]
     public void When_the_compile_time_type_does_not_match_the_equality_comparer_type_it_should_use_the_default_mechanics()
     {
-        // Arrange
         var subject = new { Property = (IInterface)new ConcreteClass("SomeString") };
-
         var expectation = new { Property = (IInterface)new ConcreteClass("SomeOtherString") };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expectation, opt =>
-            opt.Using<ConcreteClass, ConcreteClassEqualityComparer>());
+        subject.Should().BeEquivalentTo(expectation, opt => opt.Using<ConcreteClass, ConcreteClassEqualityComparer>());
     }
 
     [Fact]
     public void When_the_runtime_type_does_match_the_equality_comparer_type_it_should_use_the_default_mechanics()
     {
-        // Arrange
         var subject = new { Property = (IInterface)new ConcreteClass("SomeString") };
-
         var expectation = new { Property = (IInterface)new ConcreteClass("SomeOtherString") };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt
             .PreferringRuntimeMemberTypes()
             .Using<ConcreteClass, ConcreteClassEqualityComparer>());
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("*ConcreteClassEqualityComparer*");
     }
 
     [Fact]
     public void When_several_properties_do_not_match_they_are_all_reported_after_an_other_successful_assertion()
     {
-        // Arrange
-        var test = new Test
-        {
-            Id = 42,
-            Text = "some-text",
-        };
-        var actualTest = new Test
-        {
-            Id = 32,
-            Text = "some-other-text",
-        };
+        var test = new Test { Id = 42, Text = "some-text" };
+        var actualTest = new Test { Id = 32, Text = "some-other-text" };
 
-        // Act
         Action act = () =>
         {
             actualTest.Text.Should().Be("some-other-text");
             actualTest.Should().BeEquivalentTo(test);
         };
 
-        // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage(
-                $"Expected property actualTest.Id to be*{Environment.NewLine}" +
-                "*Expected property actualTest.Text to be*"
-            );
+            .WithMessage($"Expected property actualTest.Id to be*{Environment.NewLine}*Expected property actualTest.Text to be*");
     }
 
     private sealed class Test
@@ -275,44 +198,32 @@ public class AssertionRuleSpecs
         [Fact]
         public void An_equality_comparer_of_non_nullable_type_is_not_invoked_on_nullable_member()
         {
-            // Arrange
             var subject = new { Timestamp = (DateTime?)22.March(2020) };
-
             var expectation = new { Timestamp = (DateTime?)1.January(2020) };
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(expectation,
-                opt => opt.Using(new DateTimeByYearComparer()));
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt.Using(new DateTimeByYearComparer()));
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
         }
 
         [Fact]
         public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_member()
         {
-            // Arrange
             var subject = new { Timestamp = 22.March(2020) };
-
             var expectation = new { Timestamp = 1.January(2020) };
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(expectation,
-                opt => opt.Using(new NullableDateTimeByYearComparer()));
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expectation, opt => opt.Using(new NullableDateTimeByYearComparer()));
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
         }
 
         [Fact]
         public void An_equality_comparer_of_non_nullable_type_is_invoked_on_non_nullable_data()
         {
-            // Arrange
             var subject = new { Timestamp = (DateTime?)22.March(2020) };
-
             var expectation = new { Timestamp = (DateTime?)1.January(2020) };
 
-            // Act
             subject.Should().BeEquivalentTo(expectation, opt => opt
                 .PreferringRuntimeMemberTypes()
                 .Using(new DateTimeByYearComparer()));
@@ -321,17 +232,13 @@ public class AssertionRuleSpecs
         [Fact]
         public void An_equality_comparer_of_nullable_type_is_not_invoked_on_non_nullable_data()
         {
-            // Arrange
             var subject = new { Timestamp = (DateTime?)22.March(2020) };
-
             var expectation = new { Timestamp = (DateTime?)1.January(2020) };
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt
                 .PreferringRuntimeMemberTypes()
                 .Using(new NullableDateTimeByYearComparer()));
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected*Timestamp*2020*");
         }
     }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -12,61 +12,44 @@ public class BasicSpecs
     [Fact]
     public void A_null_configuration_is_invalid()
     {
-        // Arrange
         var actual = new { };
         var expectation = new { };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation, config: null);
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("config");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("config");
     }
 
     [Fact]
     public void A_null_as_the_configuration_is_not_valid_for_inequivalency_assertions()
     {
-        // Arrange
         var actual = new { };
         var expectation = new { };
 
-        // Act
         Action act = () => actual.Should().NotBeEquivalentTo(expectation, config: null);
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("config");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("config");
     }
 
     [Fact]
     public void When_expectation_is_null_it_should_throw()
     {
-        // Arrange
         var subject = new { };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo<object>(null);
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected subject to be <null>, but found { }*");
+        act.Should().Throw<XunitException>().WithMessage("Expected subject to be <null>, but found { }*");
     }
 
     [Fact]
     public void When_comparing_nested_collection_with_a_null_value_it_should_fail_with_the_correct_message()
     {
-        // Arrange
-        MyClass[] subject = [new MyClass { Items = ["a"] }];
+        MyClass[] subject = [new() { Items = ["a"] }];
+        MyClass[] expectation = [new()];
 
-        MyClass[] expectation = [new MyClass()];
-
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected*subject[0].Items*null*, but found*\"a\"*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*subject[0].Items*null*, but found*\"a\"*");
     }
 
     public class MyClass
@@ -77,98 +60,72 @@ public class BasicSpecs
     [Fact]
     public void When_subject_is_null_it_should_throw()
     {
-        // Arrange
         SomeDto subject = null;
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(new { });
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected subject*to be*, but found <null>*");
+        act.Should().Throw<XunitException>().WithMessage("Expected subject*to be*, but found <null>*");
     }
 
     [Fact]
     public void When_subject_and_expectation_are_null_it_should_not_throw()
     {
-        // Arrange
         SomeDto subject = null;
 
-        // Act / Assert
         subject.Should().BeEquivalentTo<object>(null);
     }
 
     [Fact]
     public void When_subject_and_expectation_are_compared_for_equivalence_it_should_allow_chaining()
     {
-        // Arrange
         SomeDto subject = null;
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo<object>(null)
-            .And.BeNull();
+        subject.Should().BeEquivalentTo<object>(null).And.BeNull();
     }
 
     [Fact]
     public void When_subject_and_expectation_are_compared_for_equivalence_with_config_it_should_allow_chaining()
     {
-        // Arrange
         SomeDto subject = null;
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo<object>(null, opt => opt)
-            .And.BeNull();
+        subject.Should().BeEquivalentTo<object>(null, opt => opt).And.BeNull();
     }
 
     [Fact]
     public void When_subject_and_expectation_are_compared_for_non_equivalence_it_should_allow_chaining()
     {
-        // Arrange
         SomeDto subject = null;
 
-        // Act / Assert
-        subject.Should().NotBeEquivalentTo<object>(new { })
-            .And.BeNull();
+        subject.Should().NotBeEquivalentTo<object>(new { }).And.BeNull();
     }
 
     [Fact]
     public void When_subject_and_expectation_are_compared_for_non_equivalence_with_config_it_should_allow_chaining()
     {
-        // Arrange
         SomeDto subject = null;
 
-        // Act / Assert
-        subject.Should().NotBeEquivalentTo<object>(new { }, opt => opt)
-            .And.BeNull();
+        subject.Should().NotBeEquivalentTo<object>(new { }, opt => opt).And.BeNull();
     }
 
     [Fact]
     public void When_asserting_equivalence_on_a_value_type_from_system_it_should_not_do_a_structural_comparision()
     {
-        // Arrange
-
         // DateTime is used as an example because the current implementation
         // would hit the recursion-depth limit if structural equivalence were attempted.
         var date1 = new { Property = 1.January(2011) };
-
         var date2 = new { Property = 1.January(2011) };
 
-        // Act / Assert
         date1.Should().BeEquivalentTo(date2);
     }
 
     [Fact]
     public void When_an_object_hides_object_equals_it_should_be_compared_using_its_members()
     {
-        // Arrange
         var actual = new VirtualClassOverride { Property = "Value", OtherProperty = "Actual" };
-
         var expected = new VirtualClassOverride { Property = "Value", OtherProperty = "Expected" };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>("*OtherProperty*Expected*Actual*");
     }
 
@@ -190,48 +147,37 @@ public class BasicSpecs
     [Fact]
     public void When_treating_a_value_type_in_a_collection_as_a_complex_type_it_should_compare_them_by_members()
     {
-        // Arrange
         ClassWithValueSemanticsOnSingleProperty[] subject = [new() { Key = "SameKey", NestedProperty = "SomeValue" }];
         ClassWithValueSemanticsOnSingleProperty[] expected = [new() { Key = "SameKey", NestedProperty = "OtherValue" }];
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected,
             options => options.ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>());
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("*NestedProperty*SomeValue*OtherValue*");
     }
 
     [Fact]
     public void When_treating_a_value_type_as_a_complex_type_it_should_compare_them_by_members()
     {
-        // Arrange
         var subject = new ClassWithValueSemanticsOnSingleProperty { Key = "SameKey", NestedProperty = "SomeValue" };
-
         var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "SameKey", NestedProperty = "OtherValue" };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected,
             options => options.ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>());
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("*NestedProperty*SomeValue*OtherValue*");
     }
 
     [Fact]
     public void When_treating_a_type_as_value_type_but_it_was_already_marked_as_reference_type_it_should_throw()
     {
-        // Arrange
         var subject = new ClassWithValueSemanticsOnSingleProperty { Key = "Don't care" };
-
         var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "Don't care" };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected, options => options
             .ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>()
             .ComparingByValue<ClassWithValueSemanticsOnSingleProperty>());
 
-        // Assert
         act.Should().Throw<InvalidOperationException>().WithMessage(
             $"*compare {nameof(ClassWithValueSemanticsOnSingleProperty)}*value*already*members*");
     }
@@ -239,17 +185,13 @@ public class BasicSpecs
     [Fact]
     public void When_treating_a_type_as_reference_type_but_it_was_already_marked_as_value_type_it_should_throw()
     {
-        // Arrange
         var subject = new ClassWithValueSemanticsOnSingleProperty { Key = "Don't care" };
-
         var expected = new ClassWithValueSemanticsOnSingleProperty { Key = "Don't care" };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected, options => options
             .ComparingByValue<ClassWithValueSemanticsOnSingleProperty>()
             .ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>());
 
-        // Assert
         act.Should().Throw<InvalidOperationException>().WithMessage(
             $"*compare {nameof(ClassWithValueSemanticsOnSingleProperty)}*members*already*value*");
     }
@@ -257,97 +199,71 @@ public class BasicSpecs
     [Fact]
     public void When_treating_a_complex_type_in_a_collection_as_a_value_type_it_should_compare_them_by_value()
     {
-        // Arrange
         var subject = new[] { new { Address = IPAddress.Parse("1.2.3.4"), Word = "a" } };
-
         var expected = new[] { new { Address = IPAddress.Parse("1.2.3.4"), Word = "a" } };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expected,
-            options => options.ComparingByValue<IPAddress>());
+        subject.Should().BeEquivalentTo(expected, options => options.ComparingByValue<IPAddress>());
     }
 
     [Fact]
     public void When_treating_a_complex_type_as_a_value_type_it_should_compare_them_by_value()
     {
-        // Arrange
         var subject = new { Address = IPAddress.Parse("1.2.3.4"), Word = "a" };
-
         var expected = new { Address = IPAddress.Parse("1.2.3.4"), Word = "a" };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expected,
-            options => options.ComparingByValue<IPAddress>());
+        subject.Should().BeEquivalentTo(expected, options => options.ComparingByValue<IPAddress>());
     }
 
     [Fact]
     public void When_treating_a_null_type_as_value_type_it_should_throw()
     {
-        // Arrange
         var subject = new object();
         var expected = new object();
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
-            .ComparingByValue(null));
+        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt.ComparingByValue(null));
 
-        // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("type");
+        act.Should().Throw<ArgumentNullException>().WithParameterName("type");
     }
 
     [Fact]
     public void When_treating_a_null_type_as_reference_type_it_should_throw()
     {
-        // Arrange
         var subject = new object();
         var expected = new object();
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
-            .ComparingByMembers(null));
+        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt.ComparingByMembers(null));
 
-        // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("type");
+        act.Should().Throw<ArgumentNullException>().WithParameterName("type");
     }
 
     [Fact]
     public void When_comparing_an_open_type_by_members_it_should_succeed()
     {
-        // Arrange
         var subject = new Option<int[]>([1, 3, 2]);
         var expected = new Option<int[]>([1, 2, 3]);
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expected, opt => opt
-            .ComparingByMembers(typeof(Option<>)));
+        subject.Should().BeEquivalentTo(expected, opt => opt.ComparingByMembers(typeof(Option<>)));
     }
 
     [Fact]
     public void When_treating_open_type_as_reference_type_and_a_closed_type_as_value_type_it_should_compare_by_value()
     {
-        // Arrange
         var subject = new Option<int[]>([1, 3, 2]);
         var expected = new Option<int[]>([1, 2, 3]);
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
             .ComparingByMembers(typeof(Option<>))
             .ComparingByValue<Option<int[]>>());
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
     [Fact]
     public void When_treating_open_type_as_value_type_and_a_closed_type_as_reference_type_it_should_compare_by_members()
     {
-        // Arrange
         var subject = new Option<int[]>([1, 3, 2]);
         var expected = new Option<int[]>([1, 2, 3]);
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expected, opt => opt
             .ComparingByValue(typeof(Option<>))
             .ComparingByMembers<Option<int[]>>());
@@ -363,11 +279,9 @@ public class BasicSpecs
             Value = value;
         }
 
-        public bool Equals(Option<T> other) =>
-            EqualityComparer<T>.Default.Equals(Value, other.Value);
+        public bool Equals(Option<T> other) => EqualityComparer<T>.Default.Equals(Value, other.Value);
 
-        public override bool Equals(object obj) =>
-            obj is Option<T> other && Equals(other);
+        public override bool Equals(object obj) => obj is Option<T> other && Equals(other);
 
         public override int GetHashCode() => Value?.GetHashCode() ?? 0;
     }
@@ -375,63 +289,44 @@ public class BasicSpecs
     [Fact]
     public void When_treating_any_type_as_reference_type_it_should_exclude_primitive_types()
     {
-        // Arrange
         var subject = new { Value = 1 };
         var expected = new { Value = 2 };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
-            .ComparingByMembers<object>());
+        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt.ComparingByMembers<object>());
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*be 2*found 1*");
+        act.Should().Throw<XunitException>().WithMessage("*be 2*found 1*");
     }
 
     [Fact]
     public void When_treating_an_open_type_as_reference_type_it_should_exclude_primitive_types()
     {
-        // Arrange
         var subject = new { Value = 1 };
         var expected = new { Value = 2 };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
-            .ComparingByMembers(typeof(IEquatable<>)));
+        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt.ComparingByMembers(typeof(IEquatable<>)));
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*be 2*found 1*");
+        act.Should().Throw<XunitException>().WithMessage("*be 2*found 1*");
     }
 
     [Fact]
     public void When_treating_a_primitive_type_as_a_reference_type_it_should_throw()
     {
-        // Arrange
         var subject = new { Value = 1 };
         var expected = new { Value = 2 };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
-            .ComparingByMembers<int>());
+        Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt.ComparingByMembers<int>());
 
-        // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("*Cannot compare a primitive type* int *");
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Cannot compare a primitive type* int *");
     }
 
     [Fact]
     public void When_a_type_originates_from_the_System_namespace_it_should_be_treated_as_a_value_type()
     {
-        // Arrange
         var subject = new { UriBuilder = new UriBuilder("http://localhost:9001/api"), };
-
         var expected = new { UriBuilder = new UriBuilder("https://localhost:9002/bapi"), };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("Expected*UriBuilder* to be https://localhost:9002/bapi, but found http://localhost:9001/api*");
     }
@@ -439,14 +334,11 @@ public class BasicSpecs
     [Fact]
     public void When_asserting_equivalence_on_a_string_it_should_use_string_specific_failure_messages()
     {
-        // Arrange
         string s1 = "hello";
         string s2 = "good-bye";
 
-        // Act
         Action act = () => s1.Should().BeEquivalentTo(s2);
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("""*be equivalent to *differ at index 0:*(actual)*"hello"*"good-bye"*(expected).""");
     }
@@ -454,120 +346,92 @@ public class BasicSpecs
     [Fact]
     public void When_asserting_equivalence_of_strings_typed_as_objects_it_should_compare_them_as_strings()
     {
-        // Arrange
-
         // The convoluted construction is so the compiler does not optimize the two objects to be the same.
         object s1 = new string('h', 2);
         object s2 = "hh";
 
-        // Act / Assert
         s1.Should().BeEquivalentTo(s2);
     }
 
     [Fact]
     public void When_asserting_equivalence_of_ints_typed_as_objects_it_should_use_the_runtime_type()
     {
-        // Arrange
         object s1 = 1;
         object s2 = 1;
 
-        // Act
         s1.Should().BeEquivalentTo(s2);
     }
 
     [Fact]
     public void When_all_field_of_the_object_are_equal_equivalency_should_pass()
     {
-        // Arrange
         var object1 = new ClassWithOnlyAField { Value = 1 };
         var object2 = new ClassWithOnlyAField { Value = 1 };
 
-        // Act / Assert
         object1.Should().BeEquivalentTo(object2);
     }
 
     [Fact]
     public void When_number_values_are_convertible_it_should_treat_them_as_equivalent()
     {
-        // Arrange
         var actual = new Dictionary<string, long> { ["001"] = 1L, ["002"] = 2L };
-
         var expected = new Dictionary<string, int> { ["001"] = 1, ["002"] = 2 };
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public void When_all_field_of_the_object_are_not_equal_equivalency_should_fail()
     {
-        // Arrange
         var object1 = new ClassWithOnlyAField { Value = 1 };
         var object2 = new ClassWithOnlyAField { Value = 101 };
 
-        // Act
         Action act = () => object1.Should().BeEquivalentTo(object2);
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
     [Fact]
     public void When_a_field_on_the_subject_matches_a_property_the_members_should_match_for_equivalence()
     {
-        // Arrange
         var onlyAField = new ClassWithOnlyAField { Value = 1 };
         var onlyAProperty = new ClassWithOnlyAProperty { Value = 101 };
 
-        // Act
         Action act = () => onlyAField.Should().BeEquivalentTo(onlyAProperty);
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected property onlyAField.Value*to be 101, but found 1.*");
     }
 
     [Fact]
     public void When_asserting_equivalence_including_only_fields_it_should_not_match_properties()
     {
-        // Arrange
         var onlyAField = new ClassWithOnlyAField { Value = 1 };
         object onlyAProperty = new ClassWithOnlyAProperty { Value = 101 };
 
-        // Act
         Action act = () => onlyAProperty.Should().BeEquivalentTo(onlyAField, opts => opts.ExcludingProperties());
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expectation has field Value that the other object does not have.*");
+        act.Should().Throw<XunitException>().WithMessage("Expectation has field Value that the other object does not have.*");
     }
 
     [Fact]
     public void When_asserting_equivalence_including_only_properties_it_should_not_match_fields()
     {
-        // Arrange
         var onlyAField = new ClassWithOnlyAField { Value = 1 };
         var onlyAProperty = new ClassWithOnlyAProperty { Value = 101 };
 
-        // Act
         Action act = () => onlyAField.Should().BeEquivalentTo(onlyAProperty, opts => opts.IncludingAllDeclaredProperties());
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expectation has property Value that the other object does not have*");
+        act.Should().Throw<XunitException>().WithMessage("Expectation has property Value that the other object does not have*");
     }
 
     [Fact]
     public void When_asserting_equivalence_of_objects_including_enumerables_it_should_print_the_failure_message_only_once()
     {
-        // Arrange
         var record = new { Member1 = "", Member2 = new[] { "", "" } };
-
         var record2 = new { Member1 = "different", Member2 = new[] { "", "" } };
 
-        // Act
         Action act = () => record.Should().BeEquivalentTo(record2);
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
             """Expected property record.Member1 to be the same string* differ at index 0:*(actual)*""*"different"*(expected).*""");
     }
@@ -575,38 +439,28 @@ public class BasicSpecs
     [Fact]
     public void When_asserting_object_equivalence_against_a_null_value_it_should_properly_throw()
     {
-        // Act
         Action act = () => ((object)null).Should().BeEquivalentTo("foo");
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("*foo*null*");
     }
 
     [Fact]
     public void When_the_graph_contains_guids_it_should_properly_format_them()
     {
-        // Arrange
-        var actual =
-            new[] { new { Id = Guid.NewGuid(), Name = "Name" } };
+        var actual = new[] { new { Id = Guid.NewGuid(), Name = "Name" } };
+        var expected = new[] { new { Id = Guid.NewGuid(), Name = "Name" } };
 
-        var expected =
-            new[] { new { Id = Guid.NewGuid(), Name = "Name" } };
-
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected property actual[0].Id*to be *-*, but found *-*");
     }
 
     [Fact]
     public void Empty_array_segments_can_be_compared_for_equivalency()
     {
-        // Arrange
         var actual = new ClassWithArraySegment();
         var expected = new ClassWithArraySegment();
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expected);
     }
 

--- a/Tests/AwesomeAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -175,38 +175,24 @@ public class CollectionSpecs
     [Fact]
     public void When_the_expectation_is_an_array_of_interface_type_it_should_respect_declared_types()
     {
-        // Arrange
-        var actual = new IInterface[]
-        {
-            new MyClass { InterfaceProperty = 1, ClassProperty = 42 }
-        };
+        var actual = new IInterface[] { new MyClass { InterfaceProperty = 1, ClassProperty = 42 } };
+        var expected = new IInterface[] { new MyClass { InterfaceProperty = 1, ClassProperty = 1337 } };
 
-        var expected = new IInterface[]
-        {
-            new MyClass { InterfaceProperty = 1, ClassProperty = 1337 }
-        };
-
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().NotThrow<XunitException>("it should respect the declared types on IInterface");
     }
 
     [Fact]
     public void When_the_expectation_has_fewer_dimensions_than_a_multi_dimensional_subject_it_should_fail()
     {
-        // Arrange
         object objectA = new();
         object objectB = new();
-
         object[][] actual = [[objectA, objectB]];
         var expected = actual[0];
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("*be a collection with 2 item(s)*contains 1 item(s) less than*",
                 "adding a `params object[]` overload cannot distinguish 'an array of objects' from 'an element which is an array of objects'");
@@ -215,111 +201,76 @@ public class CollectionSpecs
     [Fact]
     public void When_the_expectation_is_an_array_of_anonymous_types_it_should_respect_runtime_types()
     {
-        // Arrange
         var actual = new[] { new { A = 1, B = 2 }, new { A = 1, B = 2 } };
         var expected = new object[] { new { A = 1 }, new { B = 2 } };
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public void When_a_byte_array_does_not_match_strictly_it_should_throw()
     {
-        // Arrange
         var subject = new byte[] { 1, 2, 3, 4, 5, 6 };
-
         var expectation = new byte[] { 6, 5, 4, 3, 2, 1 };
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("Expected*subject[0]*6*1*");
+        action.Should().Throw<XunitException>().WithMessage("Expected*subject[0]*6*1*");
     }
 
     [Fact]
     public void When_a_byte_array_does_not_match_strictly_and_order_is_not_strict_it_should_throw()
     {
-        // Arrange
         var subject = new byte[] { 1, 2, 3, 4, 5, 6 };
-
         var expectation = new byte[] { 6, 5, 4, 3, 2, 1 };
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation, options => options.WithoutStrictOrdering());
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("Expected*subject[0]*6*1*");
+        action.Should().Throw<XunitException>().WithMessage("Expected*subject[0]*6*1*");
     }
 
     [Fact]
     public void
         When_a_collection_property_is_a_byte_array_which_does_not_match_strictly_and_order_is_not_strict_it_should_throw()
     {
-        // Arrange
         var subject = new { bytes = new byte[] { 1, 2, 3, 4, 5, 6 } };
-
         var expectation = new { bytes = new byte[] { 6, 5, 4, 3, 2, 1 } };
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation, options => options.WithoutStrictOrdering());
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("Expected *bytes[0]*6*1*");
+        action.Should().Throw<XunitException>().WithMessage("Expected *bytes[0]*6*1*");
     }
 
     [Fact]
     public void When_a_collection_does_not_match_it_should_include_items_in_message()
     {
-        // Arrange
         int[] subject = [1, 2];
-
         int[] expectation = [3, 2, 1];
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("Expected*but*{1, 2}*1 item(s) less than*{3, 2, 1}*");
+        action.Should().Throw<XunitException>().WithMessage("Expected*but*{1, 2}*1 item(s) less than*{3, 2, 1}*");
     }
 
     [Fact]
     public void When_collection_of_same_count_does_not_match_it_should_include_at_most_10_items_in_message()
     {
-        // Arrange
-        // Subjects contains different values, because we want to distinguish them in the assertion message
+        // Subjects contain different values because we want to distinguish them in the assertion message
         var subject = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         var expectation = Enumerable.Repeat(20, subject.Length).ToArray();
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        action.Should().Throw<XunitException>().Which
-            .Message.Should().Contain("[9]").And.NotContain("[10]");
+        action.Should().Throw<XunitException>().Which.Message.Should().Contain("[9]").And.NotContain("[10]");
     }
 
     [Fact]
     public void When_a_nullable_collection_does_not_match_it_should_throw()
     {
-        // Arrange
-        var subject = new
-        {
-            Values = (ImmutableArray<int>?)ImmutableArray.Create(1, 2, 3)
-        };
+        var subject = new { Values = (ImmutableArray<int>?)ImmutableArray.Create(1, 2, 3) };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(new
-        {
-            Values = (ImmutableArray<int>?)ImmutableArray.Create(1, 2, 4)
-        });
+        Action act = () => subject.Should().BeEquivalentTo(new { Values = (ImmutableArray<int>?)ImmutableArray.Create(1, 2, 4) });
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected*Values[2]*to be 4, but found 3*");
     }
 
@@ -327,29 +278,21 @@ public class CollectionSpecs
     public void
         When_a_collection_contains_a_reference_to_an_object_that_is_also_in_its_parent_it_should_not_be_treated_as_a_cyclic_reference()
     {
-        // Arrange
         var logbook = new LogbookCode("SomeKey");
-
         var logbookEntry = new LogbookEntryProjection
-        {
-            Logbook = logbook,
-            LogbookRelations = [new LogbookRelation { Logbook = logbook }]
-        };
-
+            { Logbook = logbook, LogbookRelations = [new LogbookRelation { Logbook = logbook }] };
         var equivalentLogbookEntry = new LogbookEntryProjection
         {
             Logbook = logbook,
             LogbookRelations = [new LogbookRelation { Logbook = logbook }]
         };
 
-        // Act / Assert
         logbookEntry.Should().BeEquivalentTo(equivalentLogbookEntry);
     }
 
     [Fact]
     public void When_a_collection_contains_less_items_than_expected_it_should_throw()
     {
-        // Arrange
         var expected = new
         {
             Customers = new[]
@@ -358,27 +301,21 @@ public class CollectionSpecs
                 new Customer { Age = 38, Birthdate = 20.September(1973), Name = "Jane" }
             }
         };
-
         var subject = new
         {
             Customers = new[] { new CustomerDto { Age = 24, Birthdate = 21.September(1973), Name = "John" } }
         };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage(
-                "*Customers*to be a collection with 2 item(s), but*contains 1 item(s) less than*");
+            .WithMessage("*Customers*to be a collection with 2 item(s), but*contains 1 item(s) less than*");
     }
 
     [Fact]
     public void When_a_collection_contains_more_items_than_expected_it_should_throw()
     {
-        // Arrange
         var expected = new { Customers = new[] { new Customer { Age = 38, Birthdate = 20.September(1973), Name = "John" } } };
-
         var subject = new
         {
             Customers = new[]
@@ -388,19 +325,15 @@ public class CollectionSpecs
             }
         };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage(
-                "*Customers*to be a collection with 1 item(s), but*contains 1 item(s) more than*");
+            .WithMessage("*Customers*to be a collection with 1 item(s), but*contains 1 item(s) more than*");
     }
 
     [Fact]
     public void When_a_collection_property_contains_objects_with_matching_properties_in_any_order_it_should_not_throw()
     {
-        // Arrange
         var expected = new
         {
             Customers = new[]
@@ -409,7 +342,6 @@ public class CollectionSpecs
                 new Customer { Age = 38, Birthdate = 20.September(1973), Name = "John" }
             }
         };
-
         var subject = new
         {
             Customers = new[]
@@ -419,85 +351,62 @@ public class CollectionSpecs
             }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expected, o => o.ExcludingMissingMembers());
     }
 
     [Fact]
     public void When_two_deeply_nested_collections_are_equivalent_while_ignoring_the_order_it_should_not_throw()
     {
-        // Arrange
         int[][] subject = [[], [42]];
         int[][] expectation = [[42], []];
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_a_collection_property_contains_objects_with_mismatching_properties_it_should_throw()
     {
-        // Arrange
         var expected = new { Customers = new[] { new Customer { Age = 38, Birthdate = 20.September(1973), Name = "John" } } };
+        var subject = new { Customers = new[] { new CustomerDto { Age = 38, Birthdate = 20.September(1973), Name = "Jane" } } };
 
-        var subject = new
-        {
-            Customers = new[] { new CustomerDto { Age = 38, Birthdate = 20.September(1973), Name = "Jane" } }
-        };
-
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*Customers[0].Name*Jane*John*");
+        act.Should().Throw<XunitException>().WithMessage("*Customers[0].Name*Jane*John*");
     }
 
     [Fact]
     public void When_the_subject_is_a_non_generic_collection_it_should_still_work()
     {
-        // Arrange
         object item = new();
         object[] array = [item];
         IList readOnlyList = ArrayList.ReadOnly(array);
 
-        // Act / Assert
         readOnlyList.Should().BeEquivalentTo(array);
     }
 
     [Fact]
     public void When_a_collection_property_was_expected_but_the_property_is_not_a_collection_it_should_throw()
     {
-        // Arrange
         var subject = new { Customers = "Jane, John" };
-
         var expected = new { Customers = new[] { new Customer { Age = 38, Birthdate = 20.September(1973), Name = "John" } } };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected*Customers*collection*String*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Customers*collection*String*");
     }
 
     [Fact]
     public void When_a_complex_object_graph_with_collections_matches_expectations_it_should_not_throw()
     {
-        // Arrange
         var subject = new { Bytes = new byte[] { 1, 2, 3, 4 }, Object = new { A = 1, B = 2 } };
-
         var expected = new { Bytes = new byte[] { 1, 2, 3, 4 }, Object = new { A = 1, B = 2 } };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public void When_a_deeply_nested_property_of_a_collection_with_an_invalid_value_is_excluded_it_should_not_throw()
     {
-        // Arrange
         var subject = new
         {
             Text = "Root",
@@ -508,7 +417,6 @@ public class CollectionSpecs
                 Collection = new[] { new { Number = 1, Text = "Text" }, new { Number = 2, Text = "Actual" } }
             }
         };
-
         var expected = new
         {
             Text = "Root",
@@ -520,7 +428,6 @@ public class CollectionSpecs
             }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expected,
             options => options.Excluding(x => x.Level.Collection[1].Number).Excluding(x => x.Level.Collection[1].Text));
     }
@@ -530,23 +437,14 @@ public class CollectionSpecs
         [Fact]
         public void When_property_in_collection_is_excluded_it_should_not_throw()
         {
-            // Arrange
             var subject = new
             {
                 Level = new
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 2,
-                            Text = "Actual"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 2, Text = "Actual" }
                     }
                 }
             };
@@ -557,21 +455,12 @@ public class CollectionSpecs
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 3,
-                            Text = "Actual"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 3, Text = "Actual" }
                     }
                 }
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected,
                 options => options
                     .For(x => x.Level.Collection)
@@ -581,48 +470,29 @@ public class CollectionSpecs
         [Fact]
         public void When_property_in_collection_is_excluded_it_should_not_throw_if_root_is_a_collection()
         {
-            // Arrange
             var subject = new
             {
                 Level = new
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 2,
-                            Text = "Actual"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 2, Text = "Actual" }
                     }
                 }
             };
-
             var expected = new
             {
                 Level = new
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 3,
-                            Text = "Actual"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 3, Text = "Actual" }
                     }
                 }
             };
 
-            // Act / Assert
             new[] { subject }.Should().BeEquivalentTo([expected],
                 options => options
                     .For(x => x.Level.Collection)
@@ -632,7 +502,6 @@ public class CollectionSpecs
         [Fact]
         public void When_collection_in_collection_is_excluded_it_should_not_throw()
         {
-            // Arrange
             var subject = new
             {
                 Level = new
@@ -642,29 +511,16 @@ public class CollectionSpecs
                         new
                         {
                             Number = 1,
-                            NextCollection = new[]
-                            {
-                                new
-                                {
-                                    Text = "Text"
-                                }
-                            }
+                            NextCollection = new[] { new { Text = "Text" } }
                         },
                         new
                         {
                             Number = 2,
-                            NextCollection = new[]
-                            {
-                                new
-                                {
-                                    Text = "Actual"
-                                }
-                            }
+                            NextCollection = new[] { new { Text = "Actual" } }
                         }
                     }
                 }
             };
-
             var expected = new
             {
                 Level = new
@@ -674,30 +530,17 @@ public class CollectionSpecs
                         new
                         {
                             Number = 1,
-                            NextCollection = new[]
-                            {
-                                new
-                                {
-                                    Text = "Text"
-                                }
-                            }
+                            NextCollection = new[] { new { Text = "Text" } }
                         },
                         new
                         {
                             Number = 2,
-                            NextCollection = new[]
-                            {
-                                new
-                                {
-                                    Text = "Expected"
-                                }
-                            }
+                            NextCollection = new[] { new { Text = "Expected" } }
                         }
                     }
                 }
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected,
                 options => options
                     .For(x => x.Level.Collection)
@@ -707,7 +550,6 @@ public class CollectionSpecs
         [Fact]
         public void When_property_in_collection_in_collection_is_excluded_it_should_not_throw()
         {
-            // Arrange
             var subject = new
             {
                 Text = "Text",
@@ -718,29 +560,16 @@ public class CollectionSpecs
                         new
                         {
                             Number = 1,
-                            NextCollection = new[]
-                            {
-                                new
-                                {
-                                    Text = "Text"
-                                }
-                            }
+                            NextCollection = new[] { new { Text = "Text" } }
                         },
                         new
                         {
                             Number = 2,
-                            NextCollection = new[]
-                            {
-                                new
-                                {
-                                    Text = "Actual"
-                                }
-                            }
+                            NextCollection = new[] { new { Text = "Actual" } }
                         }
                     }
                 }
             };
-
             var expected = new
             {
                 Text = "Text",
@@ -751,30 +580,17 @@ public class CollectionSpecs
                         new
                         {
                             Number = 1,
-                            NextCollection = new[]
-                            {
-                                new
-                                {
-                                    Text = "Text"
-                                }
-                            }
+                            NextCollection = new[] { new { Text = "Text" } }
                         },
                         new
                         {
                             Number = 2,
-                            NextCollection = new[]
-                            {
-                                new
-                                {
-                                    Text = "Expected"
-                                }
-                            }
+                            NextCollection = new[] { new { Text = "Expected" } }
                         }
                     }
                 }
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected,
                 options => options
                     .For(x => x.Level.Collection)
@@ -786,47 +602,18 @@ public class CollectionSpecs
         [Fact]
         public void When_property_in_object_in_collection_is_excluded_it_should_not_throw()
         {
-            // Arrange
-            var subject = new
-            {
-                Collection = new[]
-                {
-                    new
-                    {
-                        Level = new
-                        {
-                            Text = "Actual"
-                        }
-                    }
-                }
-            };
+            var subject = new { Collection = new[] { new { Level = new { Text = "Actual" } } } };
+            var expected = new { Collection = new[] { new { Level = new { Text = "Expected" } } } };
 
-            var expected = new
-            {
-                Collection = new[]
-                {
-                    new
-                    {
-                        Level = new
-                        {
-                            Text = "Expected"
-                        }
-                    }
-                }
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected,
                 options => options
                     .For(x => x.Collection)
-                    .Exclude(x => x.Level.Text)
-            );
+                    .Exclude(x => x.Level.Text));
         }
 
         [Fact]
         public void When_property_in_object_in_collection_in_object_in_collection_is_excluded_it_should_not_throw()
         {
-            // Arrange
             var subject = new
             {
                 Collection = new[]
@@ -835,21 +622,11 @@ public class CollectionSpecs
                     {
                         Level = new
                         {
-                            Collection = new[]
-                            {
-                                new
-                                {
-                                    Level = new
-                                    {
-                                        Text = "Actual"
-                                    }
-                                }
-                            }
+                            Collection = new[] { new { Level = new { Text = "Actual" } } }
                         }
                     }
                 }
             };
-
             var expected = new
             {
                 Collection = new[]
@@ -858,22 +635,12 @@ public class CollectionSpecs
                     {
                         Level = new
                         {
-                            Collection = new[]
-                            {
-                                new
-                                {
-                                    Level = new
-                                    {
-                                        Text = "Expected"
-                                    }
-                                }
-                            }
+                            Collection = new[] { new { Level = new { Text = "Expected" } } }
                         }
                     }
                 }
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected,
                 options => options
                     .For(x => x.Collection)
@@ -885,7 +652,6 @@ public class CollectionSpecs
         [Fact]
         public void A_nested_exclusion_can_be_followed_by_a_root_level_exclusion()
         {
-            // Arrange
             var subject = new
             {
                 Text = "Actual",
@@ -893,16 +659,8 @@ public class CollectionSpecs
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 2,
-                            Text = "Actual"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 2, Text = "Actual" }
                     }
                 }
             };
@@ -914,21 +672,12 @@ public class CollectionSpecs
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 2,
-                            Text = "Expected"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 2, Text = "Expected" }
                     }
                 }
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected,
                 options => options
                     .For(x => x.Level.Collection).Exclude(x => x.Text)
@@ -938,7 +687,6 @@ public class CollectionSpecs
         [Fact]
         public void A_nested_exclusion_can_be_preceded_by_a_root_level_exclusion()
         {
-            // Arrange
             var subject = new
             {
                 Text = "Actual",
@@ -946,20 +694,11 @@ public class CollectionSpecs
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 2,
-                            Text = "Actual"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 2, Text = "Actual" }
                     }
                 }
             };
-
             var expected = new
             {
                 Text = "Expected",
@@ -967,21 +706,12 @@ public class CollectionSpecs
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 2,
-                            Text = "Expected"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 2, Text = "Expected" }
                     }
                 }
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected,
                 options => options
                     .Excluding(x => x.Text)
@@ -991,7 +721,6 @@ public class CollectionSpecs
         [Fact]
         public void A_nested_exclusion_can_be_followed_by_a_nested_exclusion()
         {
-            // Arrange
             var subject = new
             {
                 Text = "Actual",
@@ -999,20 +728,11 @@ public class CollectionSpecs
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 2,
-                            Text = "Actual"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 2, Text = "Actual" }
                     }
                 }
             };
-
             var expected = new
             {
                 Text = "Actual",
@@ -1020,21 +740,12 @@ public class CollectionSpecs
                 {
                     Collection = new[]
                     {
-                        new
-                        {
-                            Number = 1,
-                            Text = "Text"
-                        },
-                        new
-                        {
-                            Number = 3,
-                            Text = "Expected"
-                        }
+                        new { Number = 1, Text = "Text" },
+                        new { Number = 3, Text = "Expected" }
                     }
                 }
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected,
                 options => options
                     .For(x => x.Level.Collection).Exclude(x => x.Text)
@@ -1045,43 +756,32 @@ public class CollectionSpecs
     [Fact]
     public void When_a_dictionary_property_is_detected_it_should_ignore_the_order_of_the_pairs()
     {
-        // Arrange
         var expected = new { Customers = new Dictionary<string, string> { ["Key2"] = "Value2", ["Key1"] = "Value1" } };
-
         var subject = new { Customers = new Dictionary<string, string> { ["Key1"] = "Value1", ["Key2"] = "Value2" } };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public void When_injecting_a_null_config_it_should_throw()
     {
-        // Arrange
         IEnumerable<string> collection1 = new EnumerableOfStringAndObject();
         IEnumerable<string> collection2 = new EnumerableOfStringAndObject();
 
-        // Act
         Action act = () => collection1.Should().BeEquivalentTo(collection2, config: null);
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("config");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("config");
     }
 
     [Fact]
     public void
         When_a_object_implements_multiple_IEnumerable_interfaces_but_the_declared_type_is_assignable_to_only_one_and_runtime_checking_is_configured_it_should_fail()
     {
-        // Arrange
         IEnumerable<string> collection1 = new EnumerableOfStringAndObject();
         IEnumerable<string> collection2 = new EnumerableOfStringAndObject();
 
-        // Act
-        Action act =
-            () => collection1.Should().BeEquivalentTo(collection2, opts => opts.PreferringRuntimeMemberTypes());
+        Action act = () => collection1.Should().BeEquivalentTo(collection2, opts => opts.PreferringRuntimeMemberTypes());
 
-        // Assert
         act.Should().Throw<XunitException>("the runtime type is assignable to two IEnumerable interfaces")
             .WithMessage("*cannot determine which one*");
     }
@@ -1089,12 +789,9 @@ public class CollectionSpecs
     [Fact]
     public void When_a_specific_property_is_included_it_should_ignore_the_rest_of_the_properties()
     {
-        // Arrange
         var result = new[] { new { A = "aaa", B = "bbb" } };
-
         var expected = new { A = "aaa", B = "ccc" };
 
-        // Act / Assert
         result.Should().BeEquivalentTo([expected], options => options.Including(x => x.A));
     }
 
@@ -1102,49 +799,39 @@ public class CollectionSpecs
     public void
         When_a_strongly_typed_collection_is_declared_as_an_untyped_collection_and_runtime_checking_is_configured_is_should_use_the_runtime_type()
     {
-        // Arrange
         ICollection collection1 = new List<Car> { new() };
         ICollection collection2 = new List<Customer> { new() };
 
-        // Act
-        Action act =
-            () => collection1.Should().BeEquivalentTo(collection2, opts => opts.PreferringRuntimeMemberTypes());
+        Action act = () => collection1.Should().BeEquivalentTo(collection2, opts => opts.PreferringRuntimeMemberTypes());
 
-        // Assert
         act.Should().Throw<XunitException>("the items have different runtime types");
     }
 
     [Fact]
     public void When_all_strings_in_the_collection_are_equal_to_the_expected_string_it_should_succeed()
     {
-        // Arrange
         var subject = new List<string> { "one", "one", "one" };
 
-        // Act / Assert
         subject.Should().AllBe("one");
     }
 
     [Fact]
     public void When_all_strings_in_the_collection_are_equal_to_the_expected_string_it_should_allow_chaining()
     {
-        // Arrange
         var subject = new List<string> { "one", "one", "one" };
 
-        // Act
-        Action action = () => subject.Should().AllBe("one").And.HaveCount(3);
+        subject.Should().AllBe("one").And.HaveCount(3);
     }
 
     [Fact]
     public void When_some_string_in_the_collection_is_not_equal_to_the_expected_string_it_should_throw()
     {
-        // Arrange
         string[] subject = ["one", "two", "six"];
 
-        // Act
         Action action = () => subject.Should().AllBe("one");
 
-        // Assert
-        action.Should().Throw<XunitException>().WithMessage("""
+        action.Should().Throw<XunitException>().WithMessage(
+            """
             Expected subject[1]*to be *"two"*"one"*
             Expected subject[2]*to be *"six"*"one"*
             """);
@@ -1153,14 +840,12 @@ public class CollectionSpecs
     [Fact]
     public void When_some_string_in_the_collection_is_in_different_case_than_expected_string_it_should_throw()
     {
-        // Arrange
         string[] subject = ["one", "One", "ONE"];
 
-        // Act
         Action action = () => subject.Should().AllBe("one");
 
-        // Assert
-        action.Should().Throw<XunitException>().WithMessage("""
+        action.Should().Throw<XunitException>().WithMessage(
+            """
             Expected subject[1]*to be *"One"*"one"*
             Expected subject[2]*to be *"ONE"*"one"*
             """);
@@ -1169,15 +854,13 @@ public class CollectionSpecs
     [Fact]
     public void When_more_than_10_strings_in_the_collection_are_not_equal_to_expected_string_only_10_are_reported()
     {
-        // Arrange
         var subject = Enumerable.Repeat("two", 11);
 
-        // Act
         Action action = () => subject.Should().AllBe("one");
 
-        // Assert
         action.Should().Throw<XunitException>().Which
-            .Message.Should().Contain("""
+            .Message.Should().Contain(
+                """
                 subject[9] to be the same string, but they differ at index 0:
                    ↓ (actual)
                   "two"
@@ -1191,16 +874,13 @@ public class CollectionSpecs
     public void
         When_some_strings_in_the_collection_are_not_equal_to_expected_string_for_huge_table_execution_time_should_still_be_short()
     {
-        // Arrange
         const int N = 100000;
         var subject = new List<string>(N) { "one" };
-
         for (int i = 1; i < N; i++)
         {
             subject.Add("two");
         }
 
-        // Act
         Action action = () =>
         {
             try
@@ -1213,14 +893,12 @@ public class CollectionSpecs
             }
         };
 
-        // Assert
         action.ExecutionTime().Should().BeLessThan(1.Seconds());
     }
 
     [Fact]
     public void When_all_subject_items_are_equivalent_to_expectation_object_it_should_succeed()
     {
-        // Arrange
         var subject = new List<SomeDto>
         {
             new() { Name = "someDto", Age = 1 },
@@ -1228,7 +906,6 @@ public class CollectionSpecs
             new() { Name = "someDto", Age = 1 }
         };
 
-        // Act / Assert
         subject.Should().AllBeEquivalentTo(new
         {
             Name = "someDto",
@@ -1240,7 +917,6 @@ public class CollectionSpecs
     [Fact]
     public void When_all_subject_items_are_equivalent_to_expectation_object_it_should_allow_chaining()
     {
-        // Arrange
         var subject = new List<SomeDto>
         {
             new() { Name = "someDto", Age = 1 },
@@ -1254,20 +930,16 @@ public class CollectionSpecs
             Birthdate = default(DateTime)
         };
 
-        // Act / Assert
         subject.Should().AllBeEquivalentTo(expectation).And.HaveCount(3);
     }
 
     [Fact]
     public void When_some_subject_items_are_not_equivalent_to_expectation_object_it_should_throw()
     {
-        // Arrange
         int[] subject = [1, 2, 3];
 
-        // Act
         Action action = () => subject.Should().AllBeEquivalentTo(1);
 
-        // Assert
         action.Should().Throw<XunitException>().WithMessage(
             "Expected subject[1]*to be 1, but found 2.*Expected subject[2]*to be 1, but found 3*");
     }
@@ -1275,13 +947,10 @@ public class CollectionSpecs
     [Fact]
     public void When_more_than_10_subjects_items_are_not_equivalent_to_expectation_only_10_are_reported()
     {
-        // Arrange
         var subject = Enumerable.Repeat(2, 11);
 
-        // Act
         Action action = () => subject.Should().AllBeEquivalentTo(1);
 
-        // Assert
         action.Should().Throw<XunitException>().Which
             .Message.Should().Contain("subject[9] to be 1, but found 2")
             .And.NotContain("item[10]");
@@ -1291,16 +960,13 @@ public class CollectionSpecs
     public void
         When_some_subject_items_are_not_equivalent_to_expectation_for_huge_table_execution_time_should_still_be_short()
     {
-        // Arrange
         const int N = 100000;
         var subject = new List<int>(N) { 1 };
-
         for (int i = 1; i < N; i++)
         {
             subject.Add(2);
         }
 
-        // Act
         Action action = () =>
         {
             try
@@ -1313,7 +979,6 @@ public class CollectionSpecs
             }
         };
 
-        // Assert
         action.ExecutionTime().Should().BeLessThan(1.Seconds());
     }
 
@@ -1321,60 +986,49 @@ public class CollectionSpecs
     public void
         When_an_object_implements_multiple_IEnumerable_interfaces_but_the_declared_type_is_assignable_to_only_one_it_should_respect_the_declared_type()
     {
-        // Arrange
         IEnumerable<string> collection1 = new EnumerableOfStringAndObject();
         IEnumerable<string> collection2 = new EnumerableOfStringAndObject();
 
-        // Act
         Action act = () => collection1.Should().BeEquivalentTo(collection2);
 
-        // Assert
         act.Should().NotThrow("the declared type is assignable to only one IEnumerable interface");
     }
 
     [Fact]
     public void When_an_unordered_collection_must_be_strict_using_a_predicate_it_should_throw()
     {
-        // Arrange
         var subject = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 1, 2, 3, 4, 5 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
-
         var expectation = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 5, 4, 3, 2, 1 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation, options =>
             options.WithStrictOrderingFor(s => s.Path.Contains("UnorderedCollection")));
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("*Expected*[0].UnorderedCollection*5 item(s)*empty collection*");
+        action.Should().Throw<XunitException>().WithMessage("*Expected*[0].UnorderedCollection*5 item(s)*empty collection*");
     }
 
     [Fact]
     public void
         When_an_unordered_collection_must_be_strict_using_a_predicate_and_order_was_reset_to_not_strict_it_should_not_throw()
     {
-        // Arrange
         var subject = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 1, 2, 3, 4, 5 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
-
         var expectation = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 5, 4, 3, 2, 1 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, options =>
             options
                 .WithStrictOrderingFor(s => s.Path.Contains("UnorderedCollection"))
@@ -1384,28 +1038,20 @@ public class CollectionSpecs
     [Fact]
     public void When_an_unordered_collection_must_be_strict_using_an_expression_it_should_throw()
     {
-        // Arrange
         var subject = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 1, 2, 3, 4, 5 } },
             new { Name = "Jane", UnorderedCollection = new int[0] }
         };
-
         var expectation = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 5, 4, 3, 2, 1 } },
             new { Name = "Jane", UnorderedCollection = new int[0] }
         };
 
-        // Act
-        Action action =
-            () =>
-                subject.Should().BeEquivalentTo(expectation,
-                    options => options
-                        .WithStrictOrderingFor(
-                            s => s.UnorderedCollection));
+        Action action = () => subject.Should().BeEquivalentTo(expectation,
+            options => options.WithStrictOrderingFor(s => s.UnorderedCollection));
 
-        // Assert
         action.Should().Throw<XunitException>()
             .WithMessage(
                 "*Expected*[0].UnorderedCollection*5 item(s)*empty collection*");
@@ -1414,46 +1060,38 @@ public class CollectionSpecs
     [Fact]
     public void Can_force_strict_ordering_based_on_the_parent_type_of_an_unordered_collection()
     {
-        // Arrange
         var subject = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 1, 2, 3, 4, 5 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
-
         var expectation = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 5, 4, 3, 2, 1 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation, options => options
             .WithStrictOrderingFor(oi => oi.ParentType == expectation[0].GetType()));
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("*Expected*[0].UnorderedCollection*5 item(s)*empty collection*");
+        action.Should().Throw<XunitException>().WithMessage("*Expected*[0].UnorderedCollection*5 item(s)*empty collection*");
     }
 
     [Fact]
     public void
         When_an_unordered_collection_must_be_strict_using_an_expression_and_order_is_reset_to_not_strict_it_should_not_throw()
     {
-        // Arrange
         var subject = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 1, 2, 3, 4, 5 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
-
         var expectation = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 5, 4, 3, 2, 1 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation,
             options => options
                 .WithStrictOrderingFor(s => s.UnorderedCollection)
@@ -1463,20 +1101,17 @@ public class CollectionSpecs
     [Fact]
     public void When_an_unordered_collection_must_not_be_strict_using_a_predicate_it_should_not_throw()
     {
-        // Arrange
         var subject = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 1, 2, 3, 4, 5 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
-
         var expectation = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 5, 4, 3, 2, 1 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, options => options
             .WithStrictOrdering()
             .WithoutStrictOrderingFor(s => s.Path.Contains("UnorderedCollection")));
@@ -1485,20 +1120,17 @@ public class CollectionSpecs
     [Fact]
     public void When_an_unordered_collection_must_not_be_strict_using_an_expression_it_should_not_throw()
     {
-        // Arrange
         var subject = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 1, 2, 3, 4, 5 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
-
         var expectation = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 5, 4, 3, 2, 1 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, options => options
             .WithStrictOrdering()
             .WithoutStrictOrderingFor(x => x.UnorderedCollection));
@@ -1508,26 +1140,22 @@ public class CollectionSpecs
     public void
         When_an_unordered_collection_must_not_be_strict_using_a_predicate_and_order_was_reset_to_strict_it_should_throw()
     {
-        // Arrange
         var subject = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 1, 2 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
-
         var expectation = new[]
         {
             new { Name = "John", UnorderedCollection = new[] { 2, 1 } },
-            new { Name = "Jane", UnorderedCollection = new int[0] }
+            new { Name = "Jane", UnorderedCollection = Array.Empty<int>() }
         };
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation, options => options
             .WithStrictOrdering()
             .WithoutStrictOrderingFor(s => s.Path.Contains("UnorderedCollection"))
             .WithStrictOrdering());
 
-        // Assert
         action.Should().Throw<XunitException>()
             .WithMessage(
                 "*Expected*subject[0].UnorderedCollection[0]*to be 2, but found 1.*Expected subject[0].UnorderedCollection[1]*to be 1, but found 2*");
@@ -1536,33 +1164,20 @@ public class CollectionSpecs
     [Fact]
     public void When_an_unordered_collection_must_not_be_strict_using_an_expression_and_collection_is_not_equal_it_should_throw()
     {
-        // Arrange
-        var subject = new
-        {
-            UnorderedCollection = new[] { 1 }
-        };
+        var subject = new { UnorderedCollection = new[] { 1 } };
+        var expectation = new { UnorderedCollection = new[] { 2 } };
 
-        var expectation = new
-        {
-            UnorderedCollection = new[] { 2 }
-        };
-
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation, options => options
             .WithStrictOrdering()
             .WithoutStrictOrderingFor(x => x.UnorderedCollection));
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("*not strict*");
+        action.Should().Throw<XunitException>().WithMessage("*not strict*");
     }
 
     [Fact]
     public void Can_request_strict_ordering_using_an_expression_that_points_to_the_collection_items()
     {
-        // Arrange
         var subject = new List<string> { "first", "second" };
-
         var expectation = new List<string> { "second", "first" };
 
         var act = () => subject.Should().BeEquivalentTo(expectation,
@@ -1575,163 +1190,126 @@ public class CollectionSpecs
     public void
         When_asserting_equivalence_of_collections_and_configured_to_use_runtime_properties_it_should_respect_the_runtime_type()
     {
-        // Arrange
         ICollection collection1 = new NonGenericCollection([new Customer()]);
         ICollection collection2 = new NonGenericCollection([new Car()]);
 
-        // Act
-        Action act =
-            () =>
-                collection1.Should().BeEquivalentTo(collection2,
-                    opts => opts.PreferringRuntimeMemberTypes());
+        Action act = () => collection1.Should().BeEquivalentTo(collection2, opts => opts.PreferringRuntimeMemberTypes());
 
-        // Assert
         act.Should().Throw<XunitException>("the types have different properties");
     }
 
     [Fact]
     public void When_asserting_equivalence_of_generic_collections_it_should_respect_the_declared_type()
     {
-        // Arrange
         var collection1 = new Collection<CustomerType> { new DerivedCustomerType("123") };
         var collection2 = new Collection<CustomerType> { new("123") };
 
-        // Act
         Action act = () => collection1.Should().BeEquivalentTo(collection2);
 
-        // Assert
         act.Should().NotThrow("the objects are equivalent according to the members on the declared type");
     }
 
     [Fact]
     public void When_asserting_equivalence_of_non_generic_collections_it_should_respect_the_runtime_type()
     {
-        // Arrange
         ICollection subject = new NonGenericCollection([new Customer()]);
         ICollection expectation = new NonGenericCollection([new Car()]);
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*Wheels*not have*VehicleId*not have*");
+        act.Should().Throw<XunitException>().WithMessage("*Wheels*not have*VehicleId*not have*");
     }
 
     [Fact]
     public void When_custom_assertion_rules_are_utilized_the_rules_should_be_respected()
     {
-        // Arrange
         var subject = new[]
         {
             new { Value = new Customer { Name = "John", Age = 31, Id = 1 } },
             new { Value = new Customer { Name = "Jane", Age = 24, Id = 2 } }
         };
-
         var expectation = new[]
         {
             new { Value = new CustomerDto { Name = "John", Age = 30 } },
             new { Value = new CustomerDto { Name = "Jane", Age = 24 } }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, opts => opts
             .Using<int>(ctx => ctx.Subject.Should().BeInRange(ctx.Expectation - 1, ctx.Expectation + 1))
-            .WhenTypeIs<int>()
-        );
+            .WhenTypeIs<int>());
     }
 
     [Fact]
     public void When_expectation_is_null_enumerable_it_should_throw()
     {
-        // Arrange
         IEnumerable<object> subject = [];
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo((IEnumerable<object>)null);
+        Action act = () => subject.Should().BeEquivalentTo<object>(null);
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected subject*to be <null>, but found*");
+        act.Should().Throw<XunitException>().WithMessage("Expected subject*to be <null>, but found*");
     }
 
     [Fact]
     public void When_nested_objects_are_excluded_from_collections_it_should_use_simple_equality_semantics()
     {
-        // Arrange
         var actual = new MyObject
         {
             MyString = "identical string",
             Child = new ClassIdentifiedById { Id = 1, MyChildString = "identical string" }
         };
-
         var expectation = new MyObject
         {
             MyString = "identical string",
             Child = new ClassIdentifiedById { Id = 1, MyChildString = "DIFFERENT STRING" }
         };
-
         IList<MyObject> actualList = new List<MyObject> { actual };
         IList<MyObject> expectationList = new List<MyObject> { expectation };
 
-        // Act / Assert
         actualList.Should().BeEquivalentTo(expectationList, opt => opt.WithoutRecursing());
     }
 
     [Fact]
     public void When_no_collection_item_matches_it_should_report_the_closest_match()
     {
-        // Arrange
         var subject = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 30, Id = 2 }
         };
-
         var expectation = new List<Customer>
         {
             new() { Name = "Jane", Age = 30, Id = 2 },
             new() { Name = "John", Age = 28, Id = 1 }
         };
 
-        // Act
-        Action action =
-            () => subject.Should().BeEquivalentTo(expectation);
+        Action action = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("Expected*[1].Age*28*27*");
+        action.Should().Throw<XunitException>().WithMessage("Expected*[1].Age*28*27*");
     }
 
     [Fact]
     public void When_only_a_deeply_nested_property_is_included_it_should_exclude_the_other_properties()
     {
-        // Arrange
         var actualObjects = new[]
         {
             new { SubObject = new { Property1 = "John", Property2 = "John" } },
             new { SubObject = new { Property1 = "John", Property2 = "John" } }
         };
-
         var expectedObjects = new[]
         {
             new { SubObject = new { Property1 = "John", Property2 = "John" } },
             new { SubObject = new { Property1 = "John", Property2 = "Jane" } }
         };
 
-        // Act / Assert
-        actualObjects.Should().BeEquivalentTo(expectedObjects, options =>
-            options.Including(order => order.SubObject.Property1));
+        actualObjects.Should().BeEquivalentTo(expectedObjects, options => options.Including(order => order.SubObject.Property1));
     }
 
     [Fact]
     public void When_selection_rules_are_configured_they_should_be_evaluated_from_last_to_first()
     {
-        // Arrange
         var list1 = new[] { new { Value = 3 } };
         var list2 = new[] { new { Value = 2 } };
 
-        // Act
         Action act = () => list1.Should().BeEquivalentTo(list2, config =>
         {
             config.WithoutSelectionRules();
@@ -1740,222 +1318,169 @@ public class CollectionSpecs
             return config;
         });
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("*to be 2, but found 3*");
     }
 
     [Fact]
     public void When_injecting_a_null_config_to_generic_overload_it_should_throw()
     {
-        // Arrange
         var list1 = new[] { new { Value = 3 } };
         var list2 = new[] { new { Value = 2 } };
 
-        // Act
         Action act = () => list1.Should().BeEquivalentTo(list2, config: null);
 
-        // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("config");
+        act.Should().Throw<ArgumentNullException>().WithParameterName("config");
     }
 
     [Fact]
     public void When_subject_and_expectation_are_null_enumerable_it_should_succeed()
     {
-        // Arrange
         IEnumerable<object> subject = null;
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo((IEnumerable<int>)null);
+        subject.Should().BeEquivalentTo<int>(null);
     }
 
     [Fact]
     public void When_string_collection_subject_is_empty_and_expectation_is_object_succeed()
     {
-        // Arrange
         var subject = new List<string>();
 
-        // Act / Assert
         subject.Should().AllBe("one");
     }
 
     [Fact]
     public void When_injecting_a_null_config_to_AllBe_for_string_collection_it_should_throw()
     {
-        // Arrange
         var subject = new List<string>();
 
-        // Act
         Action action = () => subject.Should().AllBe("one", config: null);
 
-        // Assert
-        action.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("config");
+        action.Should().ThrowExactly<ArgumentNullException>().WithParameterName("config");
     }
 
     [Fact]
     public void When_all_string_subject_items_are_equal_to_expectation_object_with_a_config_it_should_succeed()
     {
-        // Arrange
         var subject = new List<string> { "one", "one" };
 
-        // Act / Assert
         subject.Should().AllBe("one", opt => opt);
     }
 
     [Fact]
     public void When_not_all_string_subject_items_are_equal_to_expectation_object_with_a_config_it_should_fail()
     {
-        // Arrange
         var subject = new List<string> { "one", "two" };
 
-        // Act
-        Action action = () => subject.Should().AllBe("one", opt => opt, "we want to test the failure {0}", "message");
+        Action action = () => subject.Should().AllBe("one", opt => opt, "we want to test the {0} message", "failure");
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("*we want to test the failure message*");
+        action.Should().Throw<XunitException>().WithMessage("*because we want to test the failure message*");
     }
 
     [Fact]
     public void When_all_string_subject_items_are_equal_to_expectation_object_with_a_config_it_should_allow_chaining()
     {
-        // Arrange
         var subject = new List<string> { "one", "one" };
 
-        // Act / Assert
-        subject.Should().AllBe("one", opt => opt)
-            .And.HaveCount(2);
+        subject.Should().AllBe("one", opt => opt).And.HaveCount(2);
     }
 
     [Fact]
     public void When_subject_is_empty_and_expectation_is_object_succeed()
     {
-        // Arrange
         var subject = new List<char>();
 
-        // Act / Assert
         subject.Should().AllBeEquivalentTo('g');
     }
 
     [Fact]
     public void When_injecting_a_null_config_to_AllBeEquivalentTo_it_should_throw()
     {
-        // Arrange
         var subject = new List<char>();
 
-        // Act
         Action action = () => subject.Should().AllBeEquivalentTo('g', config: null);
 
-        // Assert
-        action.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("config");
+        action.Should().ThrowExactly<ArgumentNullException>().WithParameterName("config");
     }
 
     [Fact]
     public void When_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_succeed()
     {
-        // Arrange
         var subject = new List<char> { 'g', 'g' };
 
-        // Act / Assert
         subject.Should().AllBeEquivalentTo('g', opt => opt);
     }
 
     [Fact]
     public void When_not_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_fail()
     {
-        // Arrange
         var subject = new List<char> { 'g', 'a' };
 
-        // Act
         Action action = () =>
-            subject.Should().AllBeEquivalentTo('g', opt => opt, "we want to test the failure {0}", "message");
+            subject.Should().AllBeEquivalentTo('g', opt => opt, "we want to test the {0} message", "failure");
 
-        // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*we want to test the failure message*");
+            .WithMessage("*because we want to test the failure message*");
     }
 
     [Fact]
     public void When_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_allow_chaining()
     {
-        // Arrange
         var subject = new List<char> { 'g', 'g' };
 
-        // Act / Assert
-        subject.Should().AllBeEquivalentTo('g', opt => opt)
-            .And.HaveCount(2);
+        subject.Should().AllBeEquivalentTo('g', opt => opt).And.HaveCount(2);
     }
 
     [Fact]
     public void When_subject_is_null_and_expectation_is_enumerable_it_should_throw()
     {
-        // Arrange
         IEnumerable<object> subject = null;
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(Enumerable.Empty<object>());
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected subject*not to be <null>*");
+        act.Should().Throw<XunitException>().WithMessage("Expected subject*not to be <null>*");
     }
 
     [Fact]
     public void When_the_expectation_is_null_it_should_throw()
     {
-        // Arrange
         int[,] actual =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo<object>(null);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected actual*to be <null>*{{1, 2, 3}, {4, 5, 6}}*");
+        act.Should().Throw<XunitException>().WithMessage("Expected actual*to be <null>*{{1, 2, 3}, {4, 5, 6}}*");
     }
 
     [Fact]
     public void When_a_multi_dimensional_array_is_compared_to_null_it_should_throw()
     {
-        // Arrange
         Array actual = null;
-
         int[,] expectation =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Cannot compare a multi-dimensional array to <null>*failure message*");
+        act.Should().Throw<XunitException>().WithMessage("Cannot compare a multi-dimensional array to <null>*failure message*");
     }
 
     [Fact]
     public void When_a_multi_dimensional_array_is_compared_to_a_non_array_it_should_throw()
     {
-        // Arrange
         var actual = new object();
-
         int[,] expectation =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("Cannot compare a multi-dimensional array to something else*failure message*");
     }
@@ -1963,38 +1488,33 @@ public class CollectionSpecs
     [Fact]
     public void When_a_multi_dimensional_array_is_compared_to_another_array_of_different_rank_it_should_throw()
     {
-        // Arrange
         int[,] expected =
         {
             { 1, 2 },
-            { 3, 4 },
+            { 3, 4 }
         };
         Array actual = new[] { 1, 2 };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*to have 2 dimension(s)*failure message*but it has 1*");
+        act.Should().Throw<XunitException>().WithMessage("*to have 2 dimension(s)*failure message*but it has 1*");
     }
 
     [Fact]
     public void When_the_length_of_the_2nd_dimension_differs_between_the_arrays_it_should_throw()
     {
-        // Arrange
         int[,] actual =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
+        int[,] expectation =
+        {
+            { 1, 2, 3 }
+        };
 
-        int[,] expectation = { { 1, 2, 3 } };
-
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("Expected dimension 0 to contain 1 item(s)*failure message*, but found 2*");
     }
@@ -2002,31 +1522,25 @@ public class CollectionSpecs
     [Fact]
     public void When_the_length_of_the_first_dimension_differs_between_the_arrays_it_should_throw()
     {
-        // Arrange
         int[,] actual =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
-
         int[,] expectation =
         {
             { 1, 2 },
             { 4, 5 }
         };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected dimension 1 to contain 2 item(s), but found 3*");
+        act.Should().Throw<XunitException>().WithMessage("Expected dimension 1 to contain 2 item(s), but found 3*");
     }
 
     [Fact]
     public void When_the_number_of_dimensions_of_the_arrays_are_not_the_same_it_should_throw()
     {
-        // Arrange
 #pragma warning disable format // VS and Rider disagree on how to format a multidimensional array initializer
         int[,,] actual =
         {
@@ -2042,133 +1556,102 @@ public class CollectionSpecs
             }
         };
 #pragma warning restore format
-
         int[,] expectation =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected actual*2 dimension(s)*but it has 3*");
+        act.Should().Throw<XunitException>().WithMessage("Expected actual*2 dimension(s)*but it has 3*");
     }
 
     [Fact]
     public void When_the_other_dictionary_does_not_contain_enough_items_it_should_throw()
     {
-        // Arrange
         var expected = new { Customers = new Dictionary<string, string> { ["Key1"] = "Value1", ["Key2"] = "Value2" } };
-
         var subject = new { Customers = new Dictionary<string, string> { ["Key1"] = "Value1" } };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected*Customers*dictionary*2 item(s)*but*misses*Key2*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Customers*dictionary*2 item(s)*but*misses*Key2*");
     }
 
     [Fact]
     public void When_the_other_property_is_not_a_dictionary_it_should_throw()
     {
-        // Arrange
         var expected = new { Customers = "I am a string" };
-
         var subject = new { Customers = new Dictionary<string, string> { ["Key2"] = "Value2", ["Key1"] = "Value1" } };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*property*Customers*String*found*Dictionary*");
+        act.Should().Throw<XunitException>().WithMessage("*property*Customers*String*found*Dictionary*");
     }
 
     [Fact]
     public void
         When_the_root_object_is_referenced_from_an_object_in_a_nested_collection_it_should_treat_it_as_a_cyclic_reference()
     {
-        // Arrange
         var company1 = new MyCompany { Name = "Company" };
         var user1 = new MyUser { Name = "User", Company = company1 };
         company1.Users = [user1];
         company1.Logo = new MyCompanyLogo { Url = "blank", Company = company1, CreatedBy = user1 };
-
         var company2 = new MyCompany { Name = "Company" };
         var user2 = new MyUser { Name = "User", Company = company2 };
         company2.Users = [user2];
         company2.Logo = new MyCompanyLogo { Url = "blank", Company = company2, CreatedBy = user2 };
 
-        // Act / Assert
         company1.Should().BeEquivalentTo(company2, o => o.IgnoringCyclicReferences());
     }
 
     [Fact]
     public void When_the_subject_contains_less_items_than_expected_it_should_throw()
     {
-        // Arrange
         var subject = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 }
         };
-
         var expectation = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
-        // Act
-        Action action =
-            () => subject.Should().BeEquivalentTo(expectation);
+        Action action = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage(
-                "*subject*to be a collection with 2 item(s), but*contains 1 item(s) less than*");
+            .WithMessage("*subject*to be a collection with 2 item(s), but*contains 1 item(s) less than*");
     }
 
     [Fact]
     public void When_the_subject_contains_more_items_than_expected_it_should_throw()
     {
-        // Arrange
         var subject = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 24, Id = 2 }
         };
-
         var expectation = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 }
         };
 
-        // Act
-        Action action =
-            () => subject.Should().BeEquivalentTo(expectation);
+        Action action = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected subject*to be a collection with 1 item(s), but*contains 1 item(s) more than*");
+            .WithMessage("Expected subject*to be a collection with 1 item(s), but*contains 1 item(s) more than*");
     }
 
     [Fact]
     public void When_the_subject_contains_same_number_of_items_and_both_contain_duplicates_it_should_succeed()
     {
-        // Arrange
         var subject = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 24, Id = 2 }
         };
-
         var expectation = new List<Customer>
         {
             new() { Name = "Jane", Age = 24, Id = 2 },
@@ -2176,72 +1659,56 @@ public class CollectionSpecs
             new() { Name = "John", Age = 27, Id = 1 }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_the_subject_contains_same_number_of_items_but_expectation_contains_duplicates_it_should_throw()
     {
-        // Arrange
         var subject = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 24, Id = 2 },
         };
-
         var expectation = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "John", Age = 27, Id = 1 },
         };
 
-        // Act
-        Action action =
-            () => subject.Should().BeEquivalentTo(expectation);
+        Action action = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected property subject[1].Name*to be *actual*\"Jane\" *\"John\"*expected*");
+            .WithMessage("Expected property subject[1].Name*to be *actual*\"Jane\" *\"John\"*expected*");
     }
 
     [Fact]
     public void When_the_subject_contains_same_number_of_items_but_subject_contains_duplicates_it_should_throw()
     {
-        // Arrange
         var subject = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "John", Age = 27, Id = 1 }
         };
-
         var expectation = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
-        // Act
-        Action action =
-            () => subject.Should().BeEquivalentTo(expectation);
+        Action action = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected property subject[1].Name*to be *actual*\"John\" *\"Jane\"*expected*");
+            .WithMessage("Expected property subject[1].Name*to be *actual*\"John\" *\"Jane\"*expected*");
     }
 
     [Fact]
     public void
         When_two_collections_have_nested_members_of_the_contained_equivalent_but_not_equal_it_should_not_throw()
     {
-        // Arrange
         var list1 = new[] { new { Nested = new ClassWithOnlyAProperty { Value = 1 } } };
-
         var list2 = new[] { new { Nested = new { Value = 1 } } };
 
-        // Act / Assert
         list1.Should().BeEquivalentTo(list2, opts => opts);
     }
 
@@ -2249,16 +1716,13 @@ public class CollectionSpecs
     public void
         When_two_collections_have_properties_of_the_contained_items_excluded_but_still_differ_it_should_throw()
     {
-        // Arrange
         KeyValuePair<int, int>[] list1 = [new(1, 123)];
         KeyValuePair<int, int>[] list2 = [new(2, 321)];
 
-        // Act
         Action act = () => list1.Should().BeEquivalentTo(list2, config => config
             .Excluding(ctx => ctx.Key)
             .ComparingByMembers<KeyValuePair<int, int>>());
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected property list1[0].Value*to be 321, but found 123.*");
     }
 
@@ -2266,10 +1730,8 @@ public class CollectionSpecs
     public void
         When_two_equivalent_dictionaries_are_compared_directly_as_if_it_is_a_collection_it_should_succeed()
     {
-        // Arrange
         var result = new Dictionary<string, int?> { ["C"] = null, ["B"] = 0, ["A"] = 0 };
 
-        // Act / Assert
         result.Should().BeEquivalentTo(new Dictionary<string, int?>
         {
             ["A"] = 0,
@@ -2281,243 +1743,189 @@ public class CollectionSpecs
     [Fact]
     public void When_two_equivalent_dictionaries_are_compared_directly_it_should_succeed()
     {
-        // Arrange
         var result = new Dictionary<string, int> { ["C"] = 0, ["B"] = 0, ["A"] = 0 };
 
-        // Act / Assert
         result.Should().BeEquivalentTo(new Dictionary<string, int> { ["A"] = 0, ["B"] = 0, ["C"] = 0 });
     }
 
     [Fact]
     public void When_two_lists_dont_contain_the_same_structural_equal_objects_it_should_throw()
     {
-        // Arrange
         var subject = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 24, Id = 2 }
         };
-
         var expectation = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 30, Id = 2 }
         };
 
-        // Act
-        Action action =
-            () => subject.Should().BeEquivalentTo(expectation);
+        Action action = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage("Expected*subject[1].Age*30*24*");
+        action.Should().Throw<XunitException>().WithMessage("Expected*subject[1].Age*30*24*");
     }
 
     [Fact]
     public void When_two_lists_only_differ_in_excluded_properties_it_should_not_throw()
     {
-        // Arrange
         var subject = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 24, Id = 2 }
         };
-
         var expectation = new List<CustomerDto>
         {
             new() { Name = "John", Age = 27 },
             new() { Name = "Jane", Age = 30 }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation,
-                    options => options
-                        .ExcludingMissingMembers()
-                        .Excluding(c => c.Age));
+            options => options
+                .ExcludingMissingMembers()
+                .Excluding(c => c.Age));
     }
 
     [Fact]
     public void When_two_multi_dimensional_arrays_are_equivalent_it_should_not_throw()
     {
-        // Arrange
         int[,] subject =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
-
         int[,] expectation =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_two_multi_dimensional_arrays_are_not_equivalent_it_should_throw()
     {
-        // Arrange
         int[,] actual =
         {
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
-
         int[,] expectation =
         {
             { 1, 2, 4 },
             { 4, -5, 6 }
         };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*actual[0,2]*4*3*actual[1,1]*-5*5*");
+        act.Should().Throw<XunitException>().WithMessage("*actual[0,2]*4*3*actual[1,1]*-5*5*");
     }
 
     [Fact]
     public void When_two_multi_dimensional_arrays_have_empty_dimensions_they_should_be_equivalent()
     {
-        // Arrange
         Array actual = new long[,] { { } };
-
         Array expectation = new long[,] { { } };
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_two_multi_dimensional_arrays_are_empty_they_should_be_equivalent()
     {
-        // Arrange
         Array actual = new long[0, 1] { };
-
         Array expectation = new long[0, 1] { };
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_two_nested_dictionaries_contain_null_values_it_should_not_crash()
     {
-        // Arrange
         var projection = new { ReferencedEquipment = new Dictionary<int, string> { [1] = null } };
-
         var persistedProjection = new { ReferencedEquipment = new Dictionary<int, string> { [1] = null } };
 
-        // Act / Assert
         persistedProjection.Should().BeEquivalentTo(projection);
     }
 
     [Fact]
     public void When_two_nested_dictionaries_contain_null_values_it_should_not_crash2()
     {
-        // Arrange
         var userId = Guid.NewGuid();
-
         var actual = new UserRolesLookupElement();
         actual.Add(userId, "Admin", "Special");
-
         var expected = new UserRolesLookupElement();
         expected.Add(userId, "Admin", "Other");
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected*Roles[*][1]*Special*Other*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Roles[*][1]*Special*Other*");
     }
 
     [Fact]
     public void When_two_nested_dictionaries_do_not_match_it_should_throw()
     {
-        // Arrange
         var projection = new { ReferencedEquipment = new Dictionary<int, string> { [1] = "Bla1" } };
-
         var persistedProjection = new { ReferencedEquipment = new Dictionary<int, string> { [1] = "Bla2" } };
 
-        // Act
         Action act = () => persistedProjection.Should().BeEquivalentTo(projection);
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected*ReferencedEquipment[1]*Bla2*Bla1*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*ReferencedEquipment[1]*Bla2*Bla1*");
     }
 
     [Fact]
     public void When_two_ordered_lists_are_structurally_equivalent_it_should_succeed()
     {
-        // Arrange
         var subject = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 24, Id = 2 }
         };
-
         var expectation = new List<Customer>
         {
             new() { Name = "John", Age = 27, Id = 1 },
             new() { Name = "Jane", Age = 24, Id = 2 }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_two_unordered_lists_are_structurally_equivalent_and_order_is_strict_it_should_fail()
     {
-        // Arrange
         Customer[] subject =
         [
-            new()
-                { Name = "John", Age = 27, Id = 1 },
-            new()
-                { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         ];
-
         var expectation = new Collection<Customer>
         {
             new() { Name = "Jane", Age = 24, Id = 2 },
             new() { Name = "John", Age = 27, Id = 1 }
         };
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(expectation, options => options.WithStrictOrdering());
 
-        // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected property subject[0].Name*John*Jane*subject[1].Name*Jane*John*");
+            .WithMessage("Expected property subject[0].Name*John*Jane*subject[1].Name*Jane*John*");
     }
 
     [Fact]
     public void When_two_unordered_lists_are_structurally_equivalent_and_order_was_reset_to_strict_it_should_fail()
     {
-        // Arrange
         Customer[] subject =
         [
-            new()
-                { Name = "John", Age = 27, Id = 1 },
-            new()
-                { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         ];
-
         var expectation = new Collection<Customer>
         {
             new() { Name = "Jane", Age = 24, Id = 2 },
             new() { Name = "John", Age = 27, Id = 1 }
         };
 
-        // Act
         Action action = () => subject.Should().BeEquivalentTo(
             expectation,
             options => options
@@ -2525,7 +1933,6 @@ public class CollectionSpecs
                 .WithoutStrictOrdering()
                 .WithStrictOrdering());
 
-        // Assert
         action.Should().Throw<XunitException>()
             .WithMessage(
                 "Expected property subject[0].Name*John*Jane*subject[1].Name*Jane*John*");
@@ -2534,86 +1941,67 @@ public class CollectionSpecs
     [Fact]
     public void When_two_unordered_lists_are_structurally_equivalent_and_order_was_reset_to_not_strict_it_should_succeed()
     {
-        // Arrange
         Customer[] subject =
         [
-            new()
-                { Name = "John", Age = 27, Id = 1 },
-            new()
-                { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         ];
-
         var expectation = new Collection<Customer>
         {
             new() { Name = "Jane", Age = 24, Id = 2 },
             new() { Name = "John", Age = 27, Id = 1 }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, x => x.WithStrictOrdering().WithoutStrictOrdering());
     }
 
     [Fact]
     public void When_two_unordered_lists_are_structurally_equivalent_it_should_succeed()
     {
-        // Arrange
         Customer[] subject =
         [
-            new()
-                { Name = "John", Age = 27, Id = 1 },
-            new()
-                { Name = "Jane", Age = 24, Id = 2 }
+            new() { Name = "John", Age = 27, Id = 1 },
+            new() { Name = "Jane", Age = 24, Id = 2 }
         ];
-
         var expectation = new Collection<Customer>
         {
             new() { Name = "Jane", Age = 24, Id = 2 },
             new() { Name = "John", Age = 27, Id = 1 }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_two_unordered_lists_contain_empty_different_objects_it_should_throw()
     {
-        // Arrange
         var actual = new object[] { new() };
         var expected = new object[] { new() };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
     public void When_two_unordered_lists_contain_null_in_subject_it_should_throw()
     {
-        // Arrange
         var actual = new object[] { null };
         var expected = new object[] { new() };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
     [Fact]
     public void When_two_unordered_lists_contain_null_in_expectation_it_should_throw()
     {
-        // Arrange
         var actual = new object[] { new() };
         var expected = new object[] { null };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
@@ -2624,25 +2012,19 @@ public class CollectionSpecs
         TExpected>(TActual[] actual, TExpected[] expected)
 #pragma warning restore xUnit1039
     {
-        // Act / Assert
         actual.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public void When_an_exception_is_thrown_during_data_access_the_stack_trace_contains_the_original_site()
     {
-        // Arrange
         var genericCollectionA = new List<ExceptionThrowingClass> { new() };
-
         var genericCollectionB = new List<ExceptionThrowingClass> { new() };
-
         var expectedTargetSite = typeof(ExceptionThrowingClass)
             .GetProperty(nameof(ExceptionThrowingClass.ExceptionThrowingProperty))!.GetMethod;
 
-        // Act
         Action act = () => genericCollectionA.Should().BeEquivalentTo(genericCollectionB);
 
-        // Assert
         act.Should().Throw<NotImplementedException>().And.TargetSite.Should().Be(expectedTargetSite);
     }
 
@@ -2671,7 +2053,6 @@ public class CollectionSpecs
     [Fact]
     public void Comparing_lots_of_complex_objects_should_still_be_fast()
     {
-        // Arrange
         ClassWithLotsOfProperties GetObject(int i)
         {
             return new ClassWithLotsOfProperties
@@ -2696,19 +2077,15 @@ public class CollectionSpecs
 
         var actual = new List<ClassWithLotsOfProperties>();
         var expectation = new List<ClassWithLotsOfProperties>();
-
         var maxAmount = 100;
-
         for (var i = 0; i < maxAmount; i++)
         {
             actual.Add(GetObject(i));
             expectation.Add(GetObject(maxAmount - 1 - i));
         }
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
 
-        // Assert
         act.ExecutionTime().Should().BeLessThan(20.Seconds());
     }
 

--- a/Tests/AwesomeAssertions.Equivalency.Specs/DateTimePropertiesSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/DateTimePropertiesSpecs.cs
@@ -9,28 +9,18 @@ public class DateTimePropertiesSpecs
     [Fact]
     public void When_two_properties_are_datetime_and_both_are_nullable_and_both_are_null_it_should_succeed()
     {
-        // Arrange
-        var subject =
-            new { Time = (DateTime?)null };
+        var subject = new { Time = (DateTime?)null };
+        var other = new { Time = (DateTime?)null };
 
-        var other =
-            new { Time = (DateTime?)null };
-
-        // Act / Assert
         subject.Should().BeEquivalentTo(other);
     }
 
     [Fact]
     public void When_two_properties_are_datetime_and_both_are_nullable_and_are_equal_it_should_succeed()
     {
-        // Arrange
-        var subject =
-            new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
+        var subject = new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
+        var other = new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
 
-        var other =
-            new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
-
-        // Act / Assert
         subject.Should().BeEquivalentTo(other);
     }
 
@@ -38,17 +28,11 @@ public class DateTimePropertiesSpecs
     public void
         When_two_properties_are_datetime_and_both_are_nullable_and_expectation_is_null_it_should_throw_and_state_the_difference()
     {
-        // Arrange
-        var subject =
-            new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
+        var subject = new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
+        var other = new { Time = (DateTime?)null };
 
-        var other =
-            new { Time = (DateTime?)null };
-
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(other);
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected*Time to be <null>, but found <2013-12-09 15:58:00>.*");
     }
@@ -57,17 +41,11 @@ public class DateTimePropertiesSpecs
     public void
         When_two_properties_are_datetime_and_both_are_nullable_and_subject_is_null_it_should_throw_and_state_the_difference()
     {
-        // Arrange
-        var subject =
-            new { Time = (DateTime?)null };
+        var subject = new { Time = (DateTime?)null };
+        var other = new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
 
-        var other =
-            new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
-
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(other);
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected*Time*to be <2013-12-09 15:58:00>, but found <null>.*");
     }
@@ -75,14 +53,9 @@ public class DateTimePropertiesSpecs
     [Fact]
     public void When_two_properties_are_datetime_and_expectation_is_nullable_and_are_equal_it_should_succeed()
     {
-        // Arrange
-        var subject =
-            new { Time = new DateTime(2013, 12, 9, 15, 58, 0) };
+        var subject = new { Time = new DateTime(2013, 12, 9, 15, 58, 0) };
+        var other = new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
 
-        var other =
-            new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
-
-        // Act / Assert
         subject.Should().BeEquivalentTo(other);
     }
 
@@ -90,17 +63,11 @@ public class DateTimePropertiesSpecs
     public void
         When_two_properties_are_datetime_and_expectation_is_nullable_and_expectation_is_null_it_should_throw_and_state_the_difference()
     {
-        // Arrange
-        var subject =
-            new { Time = new DateTime(2013, 12, 9, 15, 58, 0) };
+        var subject = new { Time = new DateTime(2013, 12, 9, 15, 58, 0) };
+        var other = new { Time = (DateTime?)null };
 
-        var other =
-            new { Time = (DateTime?)null };
-
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(other);
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected*Time*to be <null>, but found <2013-12-09 15:58:00>.*");
     }
@@ -108,14 +75,9 @@ public class DateTimePropertiesSpecs
     [Fact]
     public void When_two_properties_are_datetime_and_subject_is_nullable_and_are_equal_it_should_succeed()
     {
-        // Arrange
-        var subject =
-            new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
+        var subject = new { Time = (DateTime?)new DateTime(2013, 12, 9, 15, 58, 0) };
+        var other = new { Time = new DateTime(2013, 12, 9, 15, 58, 0) };
 
-        var other =
-            new { Time = new DateTime(2013, 12, 9, 15, 58, 0) };
-
-        // Act / Assert
         subject.Should().BeEquivalentTo(other);
     }
 
@@ -123,17 +85,11 @@ public class DateTimePropertiesSpecs
     public void
         When_two_properties_are_datetime_and_subject_is_nullable_and_subject_is_null_it_should_throw_and_state_the_difference()
     {
-        // Arrange
-        var subject =
-            new { Time = (DateTime?)null };
+        var subject = new { Time = (DateTime?)null };
+        var other = new { Time = new DateTime(2013, 12, 9, 15, 58, 0) };
 
-        var other =
-            new { Time = new DateTime(2013, 12, 9, 15, 58, 0) };
-
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(other);
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected*Time*to be <2013-12-09 15:58:00>, but found <null>.*");
     }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -156,11 +156,10 @@ public class DictionarySpecs
         IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
         {
             return
-                ((ICollection<KeyValuePair<int, object>>)this).Select(
-                    item =>
-                        new KeyValuePair<string, object>(
-                            item.Key.ToString(CultureInfo.InvariantCulture),
-                            item.Value)).GetEnumerator();
+                ((ICollection<KeyValuePair<int, object>>)this).Select(item =>
+                    new KeyValuePair<string, object>(
+                        item.Key.ToString(CultureInfo.InvariantCulture),
+                        item.Value)).GetEnumerator();
         }
 
         public void Add(KeyValuePair<string, object> item)
@@ -177,9 +176,8 @@ public class DictionarySpecs
 
         public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
         {
-            ((ICollection<KeyValuePair<int, object>>)this).Select(
-                    item =>
-                        new KeyValuePair<string, object>(item.Key.ToString(CultureInfo.InvariantCulture), item.Value))
+            ((ICollection<KeyValuePair<int, object>>)this).Select(item =>
+                    new KeyValuePair<string, object>(item.Key.ToString(CultureInfo.InvariantCulture), item.Value))
                 .ToArray()
                 .CopyTo(array, arrayIndex);
         }
@@ -295,23 +293,18 @@ public class DictionarySpecs
     [Fact]
     public void When_a_dictionary_does_not_implement_the_dictionary_interface_it_should_still_be_treated_as_a_dictionary()
     {
-        // Arrange
         IDictionary<string, int> dictionary = new GenericDictionaryNotImplementingIDictionary<string, int>
         {
             ["hi"] = 1
         };
+        ICollection<KeyValuePair<string, int>> collection = new List<KeyValuePair<string, int>> { new("hi", 1) };
 
-        ICollection<KeyValuePair<string, int>> collection =
-            new List<KeyValuePair<string, int>> { new("hi", 1) };
-
-        // Act / Assert
         dictionary.Should().BeEquivalentTo(collection);
     }
 
     [Fact]
     public void When_a_read_only_dictionary_matches_the_expectation_it_should_succeed()
     {
-        // Arrange
         IReadOnlyDictionary<string, IEnumerable<string>> dictionary =
             new ReadOnlyDictionary<string, IEnumerable<string>>(
                 new Dictionary<string, IEnumerable<string>>
@@ -320,7 +313,6 @@ public class DictionarySpecs
                     ["Key1"] = ["Value1"]
                 });
 
-        // Act / Assert
         dictionary.Should().BeEquivalentTo(new Dictionary<string, IEnumerable<string>>
         {
             ["Key1"] = ["Value1"],
@@ -331,7 +323,6 @@ public class DictionarySpecs
     [Fact]
     public void When_a_read_only_dictionary_does_not_match_the_expectation_it_should_throw()
     {
-        // Arrange
         IReadOnlyDictionary<string, IEnumerable<string>> dictionary =
             new ReadOnlyDictionary<string, IEnumerable<string>>(
                 new Dictionary<string, IEnumerable<string>>
@@ -340,43 +331,35 @@ public class DictionarySpecs
                     ["Key1"] = ["Value1"]
                 });
 
-        // Act
         Action act = () => dictionary.Should().BeEquivalentTo(new Dictionary<string, IEnumerable<string>>
         {
             ["Key2"] = ["Value3"],
             ["Key1"] = ["Value1"]
         });
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected dictionary[Key2][0]*Value2*Value3*");
     }
 
     [Fact]
     public void When_a_dictionary_is_compared_to_null_it_should_not_throw_a_NullReferenceException()
     {
-        // Arrange
         Dictionary<int, int> subject = null;
         Dictionary<int, int> expectation = [];
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation, "because we do expect a valid dictionary");
+        Action act = () => subject.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expected*not to be*null*valid dictionary*");
+            .WithMessage("Expected*not to be*null*because we want to test the failure message*");
     }
 
     [Fact]
     public void When_a_non_dictionary_is_compared_to_a_generic_dictionary_it_should_fail()
     {
-        // Arrange
         object subject = new();
         Dictionary<int, int> expectation = [];
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("Expected*to be a dictionary or collection of key-value pairs*failure message*");
     }
@@ -384,44 +367,33 @@ public class DictionarySpecs
     [Fact]
     public void When_a_null_dictionary_is_compared_to_null_it_should_not_throw()
     {
-        // Arrange
         Dictionary<int, int> subject = null;
         Dictionary<int, int> expectation = null;
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_a_dictionary_is_compared_to_a_dictionary_it_should_allow_chaining()
     {
-        // Arrange
         Dictionary<int, int> subject = new() { [42] = 1337 };
-
         Dictionary<int, int> expectation = new() { [42] = 1337 };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expectation)
-            .And.ContainKey(42);
+        subject.Should().BeEquivalentTo(expectation).And.ContainKey(42);
     }
 
     [Fact]
     public void When_a_dictionary_is_compared_to_a_dictionary_with_a_config_it_should_allow_chaining()
     {
-        // Arrange
         Dictionary<int, int> subject = new() { [42] = 1337 };
-
         Dictionary<int, int> expectation = new() { [42] = 1337 };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expectation, opt => opt)
-            .And.ContainKey(42);
+        subject.Should().BeEquivalentTo(expectation, opt => opt).And.ContainKey(42);
     }
 
     [Fact]
     public void When_a_dictionary_property_is_detected_it_should_ignore_the_order_of_the_pairs()
     {
-        // Arrange
         var expected = new
         {
             Customers = new Dictionary<string, string>
@@ -430,7 +402,6 @@ public class DictionarySpecs
                 ["Key1"] = "Value1"
             }
         };
-
         var subject = new
         {
             Customers = new Dictionary<string, string>
@@ -440,21 +411,15 @@ public class DictionarySpecs
             }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public void When_a_collection_of_key_value_pairs_is_equivalent_to_the_dictionary_it_should_succeed()
     {
-        // Arrange
         var collection = new List<KeyValuePair<string, int>> { new("hi", 1) };
 
-        // Act / Assert
-        Action act = () => collection.Should().BeEquivalentTo(new Dictionary<string, int>
-        {
-            { "hi", 2 }
-        });
+        Action act = () => collection.Should().BeEquivalentTo(new Dictionary<string, int> { { "hi", 2 } });
 
         act.Should().Throw<XunitException>().WithMessage("Expected collection[hi]*to be 2, but found 1.*");
     }
@@ -463,25 +428,20 @@ public class DictionarySpecs
     public void
         When_a_generic_dictionary_is_typed_as_object_and_runtime_typing_has_is_specified_it_should_use_the_runtime_type()
     {
-        // Arrange
         object object1 = new Dictionary<string, string> { ["greeting"] = "hello" };
         object object2 = new Dictionary<string, string> { ["greeting"] = "hello" };
 
-        // Act
         Action act = () => object1.Should().BeEquivalentTo(object2, opts => opts.PreferringRuntimeMemberTypes());
 
-        // Assert
         act.Should().NotThrow("the runtime type is a dictionary and the dictionaries are equivalent");
     }
 
     [Fact]
     public void When_a_generic_dictionary_is_typed_as_object_it_should_respect_the_runtime_typed()
     {
-        // Arrange
         object object1 = new Dictionary<string, string> { ["greeting"] = "hello" };
         object object2 = new Dictionary<string, string> { ["greeting"] = "hello" };
 
-        // Act / Assert
         object1.Should().BeEquivalentTo(object2);
     }
 
@@ -489,30 +449,23 @@ public class DictionarySpecs
     public void
         When_a_non_generic_dictionary_is_typed_as_object_and_runtime_typing_is_specified_the_runtime_type_should_be_respected()
     {
-        // Arrange
         object object1 = new NonGenericDictionary { ["greeting"] = "hello" };
         object object2 = new NonGenericDictionary { ["greeting"] = "hello" };
 
-        // Act
         Action act = () => object1.Should().BeEquivalentTo(object2, opts => opts.PreferringRuntimeMemberTypes());
 
-        // Assert
         act.Should().NotThrow("the runtime type is a dictionary and the dictionaries are equivalent");
     }
 
     [Fact]
-    public void
-        When_a_non_generic_dictionary_is_decided_to_be_equivalent_to_expected_trace_is_still_written()
+    public void When_a_non_generic_dictionary_is_decided_to_be_equivalent_to_expected_trace_is_still_written()
     {
-        // Arrange
         object object1 = new NonGenericDictionary { ["greeting"] = "hello" };
         object object2 = new NonGenericDictionary { ["greeting"] = "hello" };
         var traceWriter = new StringBuilderTraceWriter();
 
-        // Act
         object1.Should().BeEquivalentTo(object2, opts => opts.PreferringRuntimeMemberTypes().WithTracing(traceWriter));
 
-        // Assert
         string trace = traceWriter.ToString();
         trace.Should().Contain("Recursing into dictionary item greeting at object1");
     }
@@ -520,116 +473,86 @@ public class DictionarySpecs
     [Fact]
     public void When_a_non_generic_dictionary_is_typed_as_object_it_should_respect_the_runtime_type()
     {
-        // Arrange
         object object1 = new NonGenericDictionary();
         object object2 = new NonGenericDictionary();
 
-        // Act / Assert
         object1.Should().BeEquivalentTo(object2);
     }
 
     [Fact]
     public void When_an_object_implements_two_IDictionary_interfaces_it_should_fail_descriptively()
     {
-        // Arrange
         var object1 = (object)new ClassWithTwoDictionaryImplementations();
         var object2 = (object)new ClassWithTwoDictionaryImplementations();
 
-        // Act
         Action act = () => object1.Should().BeEquivalentTo(object2);
 
-        // Assert
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("*expectation*implements multiple dictionary types*");
+        act.Should().Throw<ArgumentException>().WithMessage("*expectation*implements multiple dictionary types*");
     }
 
     [Fact]
     public void
         When_asserting_equivalence_of_dictionaries_and_configured_to_respect_runtime_type_it_should_respect_the_runtime_type()
     {
-        // Arrange
         IDictionary dictionary1 = new NonGenericDictionary { [2001] = new Car() };
         IDictionary dictionary2 = new NonGenericDictionary { [2001] = new Customer() };
 
-        // Act
-        Action act =
-            () =>
-                dictionary1.Should().BeEquivalentTo(dictionary2,
-                    opts => opts.PreferringRuntimeMemberTypes());
+        Action act = () => dictionary1.Should().BeEquivalentTo(dictionary2, opts => opts.PreferringRuntimeMemberTypes());
 
-        // Assert
         act.Should().Throw<XunitException>("the types have different properties");
     }
 
     [Fact]
     public void Can_compare_non_generic_dictionaries_without_recursing()
     {
-        // Arrange
         var expected = new NonGenericDictionary
         {
             ["Key2"] = "Value2",
             ["Key1"] = "Value1"
         };
-
         var subject = new NonGenericDictionary
         {
             ["Key1"] = "Value1",
             ["Key3"] = "Value2"
         };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected, options => options.WithoutRecursing());
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected subject[\"Key2\"] to be \"Value2\", but found <null>*");
     }
 
     [Fact]
     public void When_asserting_equivalence_of_dictionaries_it_should_respect_the_declared_type()
     {
-        // Arrange
         var actual = new Dictionary<int, CustomerType> { [0] = new("123") };
         var expectation = new Dictionary<int, CustomerType> { [0] = new DerivedCustomerType("123") };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
 
-        // Assert
         act.Should().NotThrow("because it should ignore the properties of the derived type");
     }
 
     [Fact]
     public void When_injecting_a_null_config_it_should_throw()
     {
-        // Arrange
         var actual = new Dictionary<int, CustomerType>();
         var expectation = new Dictionary<int, CustomerType>();
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation, config: null);
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("config");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("config");
     }
 
     [Fact]
     public void
         When_asserting_equivalence_of_generic_dictionaries_and_configured_to_use_runtime_properties_it_should_respect_the_runtime_type()
     {
-        // Arrange
         var actual = new Dictionary<int, CustomerType> { [0] = new("123") };
         var expectation = new Dictionary<int, CustomerType> { [0] = new DerivedCustomerType("123") };
 
-        // Act
-        Action act =
-            () =>
-                actual.Should().BeEquivalentTo(expectation, opts => opts
-                    .PreferringRuntimeMemberTypes()
-                    .ComparingByMembers<CustomerType>()
-                );
+        Action act = () => actual.Should().BeEquivalentTo(expectation,
+            opts => opts.PreferringRuntimeMemberTypes().ComparingByMembers<CustomerType>());
 
-        // Assert
         act.Should().Throw<XunitException>("the runtime types have different properties");
     }
 
@@ -637,63 +560,48 @@ public class DictionarySpecs
     public void
         When_asserting_equivalence_of_generic_dictionaries_and_the_expectation_key_type_is_assignable_from_the_subjects_it_should_fail_if_incompatible()
     {
-        // Arrange
         var actual = new Dictionary<object, string> { [new object()] = "hello" };
         var expected = new Dictionary<string, string> { ["greeting"] = "hello" };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected actual*to contain key \"greeting\"*");
+        act.Should().Throw<XunitException>().WithMessage("Expected actual*to contain key \"greeting\"*");
     }
 
     [Fact]
     public void When_the_subjects_key_type_is_compatible_with_the_expected_key_type_it_should_match()
     {
-        // Arrange
         var dictionary1 = new Dictionary<object, string> { ["greeting"] = "hello" };
         var dictionary2 = new Dictionary<string, string> { ["greeting"] = "hello" };
 
-        // Act
         Action act = () => dictionary1.Should().BeEquivalentTo(dictionary2);
 
-        // Assert
         act.Should().NotThrow("the keys are still strings");
     }
 
     [Fact]
     public void When_the_subjects_key_type_is_not_compatible_with_the_expected_key_type_it_should_throw()
     {
-        // Arrange
         var actual = new Dictionary<int, string> { [1234] = "hello" };
         var expectation = new Dictionary<string, string> { ["greeting"] = "hello" };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected actual to be a dictionary or collection of key-value pairs" +
-                " that is keyed to type string*failure message*");
+        act.Should().Throw<XunitException>().WithMessage(
+            "Expected actual to be a dictionary or collection of key-value pairs"
+            + " that is keyed to type string*failure message*");
     }
 
     [Fact]
     public void
         When_asserting_equivalence_of_generic_dictionaries_the_type_information_should_be_preserved_for_other_equivalency_steps()
     {
-        // Arrange
         var userId = Guid.NewGuid();
-
         var dictionary1 = new Dictionary<Guid, IEnumerable<string>> { [userId] = new List<string> { "Admin", "Special" } };
         var dictionary2 = new Dictionary<Guid, IEnumerable<string>> { [userId] = new List<string> { "Admin", "Other" } };
 
-        // Act
         Action act = () => dictionary1.Should().BeEquivalentTo(dictionary2);
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
@@ -701,56 +609,34 @@ public class DictionarySpecs
     public void
         When_asserting_equivalence_of_non_generic_dictionaries_the_lack_of_type_information_should_be_preserved_for_other_equivalency_steps()
     {
-        // Arrange
         var userId = Guid.NewGuid();
-
         var dictionary1 = new NonGenericDictionary { [userId] = new List<string> { "Admin", "Special" } };
         var dictionary2 = new NonGenericDictionary { [userId] = new List<string> { "Admin", "Other" } };
 
-        // Act
         Action act = () => dictionary1.Should().BeEquivalentTo(dictionary2);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*Special*Other*");
+        act.Should().Throw<XunitException>().WithMessage("*Special*Other*");
     }
 
     [Fact]
     public void When_asserting_the_equivalence_of_generic_dictionaries_it_should_respect_the_declared_type()
     {
-        // Arrange
-        var actual = new Dictionary<int, CustomerType>
-        {
-            [0] = new DerivedCustomerType("123")
-        };
-
+        var actual = new Dictionary<int, CustomerType> { [0] = new DerivedCustomerType("123") };
         var expectation = new Dictionary<int, CustomerType> { [0] = new("123") };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expectation);
 
-        // Assert
         act.Should().NotThrow("the objects are equivalent according to the members on the declared type");
     }
 
     [Fact]
     public void When_the_both_properties_are_null_it_should_not_throw()
     {
-        // Arrange
-        var expected = new ClassWithMemberDictionary
-        {
-            Dictionary = null
-        };
+        var expected = new ClassWithMemberDictionary { Dictionary = null };
+        var subject = new ClassWithMemberDictionary { Dictionary = null };
 
-        var subject = new ClassWithMemberDictionary
-        {
-            Dictionary = null
-        };
-
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().NotThrow<XunitException>();
     }
 
@@ -758,27 +644,20 @@ public class DictionarySpecs
     public void
         When_the_dictionary_values_are_handled_by_the_enumerable_equivalency_step_the_type_information_should_be_preserved()
     {
-        // Arrange
         var userId = Guid.NewGuid();
-
         var actual = new UserRolesLookupElement();
         actual.Add(userId, "Admin", "Special");
-
         var expected = new UserRolesLookupElement();
         expected.Add(userId, "Admin", "Other");
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected*Roles[*][1]*Special*Other*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Roles[*][1]*Special*Other*");
     }
 
     [Fact]
     public void When_the_other_dictionary_does_not_contain_enough_items_it_should_throw()
     {
-        // Arrange
         var expected = new
         {
             Customers = new Dictionary<string, string>
@@ -787,7 +666,6 @@ public class DictionarySpecs
                 ["Key2"] = "Value2"
             }
         };
-
         var subject = new
         {
             Customers = new Dictionary<string, string>
@@ -796,23 +674,19 @@ public class DictionarySpecs
             }
         };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expected, "because we are expecting two keys");
+        Action act = () => subject.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected*Customers*dictionary*2 item(s)*expecting two keys*but*misses*");
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected*Customers*dictionary*2 item(s)*because we want to test the failure message*but*misses*");
     }
 
     [Fact]
     public void When_the_other_property_is_not_a_dictionary_it_should_throw()
     {
-        // Arrange
         var subject = new
         {
             Customers = "I am a string"
         };
-
         var expected = new
         {
             Customers = new Dictionary<string, string>
@@ -822,19 +696,15 @@ public class DictionarySpecs
             }
         };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected property subject.Customers to be a dictionary or collection of key-value pairs that is keyed to type string*");
+        act.Should().Throw<XunitException>().WithMessage(
+            "Expected property subject.Customers to be a dictionary or collection of key-value pairs that is keyed to type string*");
     }
 
     [Fact]
     public void When_the_other_property_is_null_it_should_throw()
     {
-        // Arrange
         var subject = new ClassWithMemberDictionary
         {
             Dictionary = new Dictionary<string, string>
@@ -843,39 +713,32 @@ public class DictionarySpecs
                 ["Key1"] = "Value1"
             }
         };
-
         var expected = new ClassWithMemberDictionary
         {
             Dictionary = null
         };
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expected, "because we are not expecting anything");
+        Action act = () => subject.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("*property*Dictionary*to be <null> because we are not expecting anything, but found *{*}*");
+            .WithMessage("*property*Dictionary*to be <null> because we want to test the failure message, but found *{*}*");
     }
 
     [Fact]
     public void When_subject_dictionary_asserted_to_be_equivalent_have_less_elements_fails_describing_missing_keys()
     {
-        // Arrange
         var dictionary1 = new Dictionary<string, string>
         {
             ["greeting"] = "hello"
         };
-
         var dictionary2 = new Dictionary<string, string>
         {
             ["greeting"] = "hello",
             ["farewell"] = "goodbye"
         };
 
-        // Act
         Action action = () => dictionary1.Should().BeEquivalentTo(dictionary2);
 
-        // Assert
         action.Should().Throw<XunitException>()
             .WithMessage("Expected dictionary1*to be a dictionary with 2 item(s), but it misses key(s) {\"farewell\"}*");
     }
@@ -884,22 +747,18 @@ public class DictionarySpecs
     public void
         When_subject_dictionary_with_class_keys_asserted_to_be_equivalent_have_less_elements_other_dictionary_derived_class_keys_fails_describing_missing_keys()
     {
-        // Arrange
         var dictionary1 = new Dictionary<SomeBaseKeyClass, string>
         {
             [new SomeDerivedKeyClass(1)] = "hello"
         };
-
         var dictionary2 = new Dictionary<SomeDerivedKeyClass, string>
         {
             [new SomeDerivedKeyClass(1)] = "hello",
             [new SomeDerivedKeyClass(2)] = "hello"
         };
 
-        // Act
         Action action = () => dictionary1.Should().BeEquivalentTo(dictionary2);
 
-        // Assert
         action.Should().Throw<XunitException>()
             .WithMessage("Expected*to be a dictionary with 2 item(s), but*misses key(s) {BaseKey 2}*");
     }
@@ -907,106 +766,85 @@ public class DictionarySpecs
     [Fact]
     public void When_subject_dictionary_asserted_to_be_equivalent_have_more_elements_fails_describing_additional_keys()
     {
-        // Arrange
-        var expectation = new Dictionary<string, string>
-        {
-            ["greeting"] = "hello"
-        };
-
         var subject = new Dictionary<string, string>
         {
             ["greeting"] = "hello",
             ["farewell"] = "goodbye"
         };
+        var expectation = new Dictionary<string, string>
+        {
+            ["greeting"] = "hello"
+        };
 
-        // Act
-        Action action = () => subject.Should().BeEquivalentTo(expectation, "because we expect one pair");
+        Action action = () => subject.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected subject*to be a dictionary with 1 item(s) because we expect one pair, but*additional key(s) {\"farewell\"}*");
+        action.Should().Throw<XunitException>().WithMessage(
+            "Expected subject*to be a dictionary with 1 item(s) because*failure message, but*additional key(s) {\"farewell\"}*");
     }
 
     [Fact]
     public void
         When_subject_dictionary_with_class_keys_asserted_to_be_equivalent_and_other_dictionary_derived_class_keys_fails_because_of_types_incompatibility()
     {
-        // Arrange
         var dictionary1 = new Dictionary<SomeBaseKeyClass, string>
         {
             [new SomeDerivedKeyClass(1)] = "hello"
         };
-
         var dictionary2 = new Dictionary<SomeDerivedKeyClass, string>
         {
             [new SomeDerivedKeyClass(1)] = "hello",
             [new SomeDerivedKeyClass(2)] = "hello"
         };
 
-        // Act
         Action action = () => dictionary2.Should().BeEquivalentTo(dictionary1);
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected dictionary2 to be a dictionary or collection of key-value pairs that is keyed to type AwesomeAssertions.Equivalency.Specs.DictionarySpecs+SomeBaseKeyClass.*");
+        action.Should().Throw<XunitException>().WithMessage(
+            "Expected dictionary2 to be a dictionary or collection of key-value pairs that is keyed to type AwesomeAssertions.Equivalency.Specs.DictionarySpecs+SomeBaseKeyClass.*");
     }
 
     [Fact]
     public void
         When_subject_dictionary_asserted_to_be_equivalent_have_less_elements_but_some_missing_and_some_additional_elements_fails_describing_missing_and_additional_keys()
     {
-        // Arrange
         var dictionary1 = new Dictionary<string, string>
         {
             ["GREETING"] = "hello"
         };
-
         var dictionary2 = new Dictionary<string, string>
         {
             ["greeting"] = "hello",
             ["farewell"] = "goodbye"
         };
 
-        // Act
         Action action = () => dictionary1.Should().BeEquivalentTo(dictionary2);
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected*to be a dictionary with 2 item(s), but*misses key(s)*{\"greeting\", \"farewell\"}*additional key(s) {\"GREETING\"}*");
+        action.Should().Throw<XunitException>().WithMessage(
+            "Expected*to be a dictionary with 2 item(s), but*misses key(s)*{\"greeting\", \"farewell\"}*additional key(s) {\"GREETING\"}*");
     }
 
     [Fact]
     public void
         When_subject_dictionary_asserted_to_be_equivalent_have_more_elements_but_some_missing_and_some_additional_elements_fails_describing_missing_and_additional_keys()
     {
-        // Arrange
         var dictionary1 = new Dictionary<string, string>
         {
             ["GREETING"] = "hello"
         };
-
         var dictionary2 = new Dictionary<string, string>
         {
             ["greeting"] = "hello",
             ["farewell"] = "goodbye"
         };
 
-        // Act
         Action action = () => dictionary2.Should().BeEquivalentTo(dictionary1);
 
-        // Assert
-        action.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected*to be a dictionary with 1 item(s), but*misses key(s) {\"GREETING\"}*additional key(s) {\"greeting\", \"farewell\"}*");
+        action.Should().Throw<XunitException>().WithMessage(
+            "Expected*to be a dictionary with 1 item(s), but*misses key(s) {\"GREETING\"}*additional key(s) {\"greeting\", \"farewell\"}*");
     }
 
     [Fact]
     public void When_two_equivalent_dictionaries_are_compared_directly_as_if_it_is_a_collection_it_should_succeed()
     {
-        // Arrange
         var result = new Dictionary<string, int?>
         {
             ["C"] = null,
@@ -1014,7 +852,6 @@ public class DictionarySpecs
             ["A"] = 0
         };
 
-        // Act / Assert
         result.Should().BeEquivalentTo(new Dictionary<string, int?>
         {
             ["A"] = 0,
@@ -1026,7 +863,6 @@ public class DictionarySpecs
     [Fact]
     public void When_two_equivalent_dictionaries_are_compared_directly_it_should_succeed()
     {
-        // Arrange
         var result = new Dictionary<string, int>
         {
             ["C"] = 0,
@@ -1034,7 +870,6 @@ public class DictionarySpecs
             ["A"] = 0
         };
 
-        // Act / Assert
         result.Should().BeEquivalentTo(new Dictionary<string, int>
         {
             ["A"] = 0,
@@ -1046,83 +881,57 @@ public class DictionarySpecs
     [Fact]
     public void When_two_nested_dictionaries_contain_null_values_it_should_not_crash()
     {
-        // Arrange
         var projection = new
         {
-            ReferencedEquipment = new Dictionary<int, string>
-            {
-                [1] = null
-            }
+            ReferencedEquipment = new Dictionary<int, string> { [1] = null }
         };
-
         var persistedProjection = new
         {
-            ReferencedEquipment = new Dictionary<int, string>
-            {
-                [1] = null
-            }
+            ReferencedEquipment = new Dictionary<int, string> { [1] = null }
         };
 
-        // Act / Assert
         persistedProjection.Should().BeEquivalentTo(projection);
     }
 
     [Fact]
     public void When_two_nested_dictionaries_do_not_match_it_should_throw()
     {
-        // Arrange
         var projection = new
         {
-            ReferencedEquipment = new Dictionary<int, string>
-            {
-                [1] = "Bla1"
-            }
+            ReferencedEquipment = new Dictionary<int, string> { [1] = "Bla1" }
         };
-
         var persistedProjection = new
         {
-            ReferencedEquipment = new Dictionary<int, string>
-            {
-                [1] = "Bla2"
-            }
+            ReferencedEquipment = new Dictionary<int, string> { [1] = "Bla2" }
         };
 
-        // Act
         Action act = () => persistedProjection.Should().BeEquivalentTo(projection);
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected*ReferencedEquipment[1]*Bla2*Bla1*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*ReferencedEquipment[1]*Bla2*Bla1*");
     }
 
     [Fact]
     public void When_a_dictionary_is_missing_a_key_it_should_report_the_specific_key()
     {
-        // Arrange
         var actual = new Dictionary<string, string>
         {
             { "a", "x" },
-            { "b", "x" },
+            { "b", "x" }
         };
-
         var expected = new Dictionary<string, string>
         {
             { "a", "x" },
-            { "c", "x" }, // key mismatch
+            { "c", "x" } // key mismatch
         };
 
-        // Act
-        Action act = () => actual.Should().BeEquivalentTo(expected, "because we're expecting {0}", "c");
+        Action act = () => actual.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
-        // Assert
-        act.Should().Throw<XunitException>().WithMessage(
-            "Expected actual*key*c*because we're expecting c*");
+        act.Should().Throw<XunitException>().WithMessage("Expected actual*key*c*because we want to test the failure message*");
     }
 
     [Fact]
     public void When_a_nested_dictionary_value_doesnt_match_it_should_throw()
     {
-        // Arrange
         const string json =
             """
             {
@@ -1132,7 +941,6 @@ public class DictionarySpecs
                 }
             }
             """;
-
         var expectedResult = new Dictionary<string, object>
         {
             ["NestedDictionary"] = new Dictionary<string, object>
@@ -1142,19 +950,15 @@ public class DictionarySpecs
             }
         };
 
-        // Act
         var result = JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
         Action act = () => result.Should().BeEquivalentTo(expectedResult);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected*String*JValue*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*String*JValue*");
     }
 
     [Fact]
     public void When_a_custom_rule_is_applied_on_a_dictionary_it_should_apply_it_on_the_values()
     {
-        // Arrange
         var dictOne = new Dictionary<string, double>
         {
             { "a", 1.2345 },
@@ -1162,7 +966,6 @@ public class DictionarySpecs
             { "c", 5.6789 },
             { "s", 3.333 }
         };
-
         var dictTwo = new Dictionary<string, double>
         {
             { "a", 1.2348 },
@@ -1171,29 +974,20 @@ public class DictionarySpecs
             { "s", 3.333 }
         };
 
-        // Act / Assert
         dictOne.Should().BeEquivalentTo(dictTwo, options => options
             .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.1))
-            .WhenTypeIs<double>()
-        );
+            .WhenTypeIs<double>());
     }
 
     [Fact]
     public void Passing_the_reason_to_the_inner_equivalency_assertion_works()
     {
-        var subject = new Dictionary<string, object>
-        {
-            ["a"] = new List<int>()
-        };
+        var subject = new Dictionary<string, object> { ["a"] = new List<int>() };
+        var expected = new Dictionary<string, object> { ["a"] = new List<int> { 42 } };
 
-        var expected = new Dictionary<string, object>
-        {
-            ["a"] = new List<int> { 42 }
-        };
+        Action act = () => subject.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
-        Action act = () => subject.Should().BeEquivalentTo(expected, "FOO {0}", "BAR");
-
-        act.Should().Throw<XunitException>().WithMessage("*FOO BAR*");
+        act.Should().Throw<XunitException>().WithMessage("*because we want to test the failure message*");
     }
 
     [Fact]
@@ -1204,7 +998,6 @@ public class DictionarySpecs
             ["id"] = 22,
             ["CustomerId"] = 33
         };
-
         var expected = new Dictionary<object, object>
         {
             ["id"] = 22,
@@ -1218,7 +1011,6 @@ public class DictionarySpecs
     public void A_non_generic_subject_which_is_null_can_be_compared_with_a_generic_expectation()
     {
         var subject = (ListDictionary)null;
-
         var expected = new Dictionary<object, object>
         {
             ["id"] = 22,
@@ -1238,7 +1030,6 @@ public class DictionarySpecs
             ["id"] = 22,
             ["CustomerId"] = 33
         };
-
         var expected = new Dictionary<object, object>
         {
             ["id"] = 22,
@@ -1256,7 +1047,6 @@ public class DictionarySpecs
             ["id"] = 22,
             ["CustomerId"] = 33
         };
-
         var expected = new Specs.NonGenericDictionary
         {
             ["id"] = 22,
@@ -1274,7 +1064,6 @@ public class DictionarySpecs
             ["id"] = 22,
             ["CustomerId"] = 33
         };
-
         var expected = new NonGenericChildDictionary
         {
             ["id"] = 22,
@@ -1287,28 +1076,22 @@ public class DictionarySpecs
     [Fact]
     public void A_subject_string_key_with_curly_braces_is_formatted_correctly_in_failure_message()
     {
-        // Arrange
         var actual = new Dictionary<string, string> { ["{}"] = "" };
         var expected = new Dictionary<string, string> { ["{}"] = null };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected actual[{}] to be *, but found *.");
     }
 
     [Fact]
     public void A_subject_key_with_braces_in_string_representation_is_formatted_correctly_in_failure_message()
     {
-        // Arrange
         var actual = new Dictionary<RecordStruct, string> { [new()] = "" };
         var expected = new Dictionary<RecordStruct, string> { [new()] = null };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("Expected actual[RecordStruct { }] to be *, but found *.");
     }
 

--- a/Tests/AwesomeAssertions.Equivalency.Specs/EnumSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/EnumSpecs.cs
@@ -9,57 +9,42 @@ public class EnumSpecs
     [Fact]
     public void When_asserting_the_same_enum_member_is_equivalent_it_should_succeed()
     {
-        // Arrange
         object subject = EnumOne.One;
         object expectation = EnumOne.One;
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_the_actual_enum_value_is_null_it_should_report_that_properly()
     {
-        // Arrange
         var subject = new { NullableEnum = (DayOfWeek?)null };
-
         var expectation = new { NullableEnum = DayOfWeek.Friday };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected*5*null*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*5*null*");
     }
 
     [Fact]
     public void When_the_actual_enum_name_is_null_it_should_report_that_properly()
     {
-        // Arrange
         var subject = new { NullableEnum = (DayOfWeek?)null };
-
         var expectation = new { NullableEnum = DayOfWeek.Friday };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, o => o.ComparingEnumsByValue());
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected*5*null*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*5*null*");
     }
 
     [Fact]
     public void When_asserting_different_enum_members_are_equivalent_it_should_fail()
     {
-        // Arrange
         object subject = EnumOne.One;
         object expectation = EnumOne.Two;
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("Expected *EnumOne.Two {value: 3}*but*EnumOne.One {value: 0}*");
     }
@@ -67,30 +52,24 @@ public class EnumSpecs
     [Fact]
     public void Comparing_collections_of_enums_by_value_includes_custom_message()
     {
-        // Arrange
         EnumOne[] subject = [EnumOne.One];
         EnumOne[] expectation = [EnumOne.Two];
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation, "some {0}", "reason");
+        Action act = () => subject.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expected *EnumOne.Two {value: 3}*some reason*but*EnumOne.One {value: 0}*");
+            .WithMessage("Expected *EnumOne.Two {value: 3}*because*failure message*but*EnumOne.One {value: 0}*");
     }
 
     [Fact]
     public void Comparing_collections_of_enums_by_name_includes_custom_message()
     {
-        // Arrange
         EnumOne[] subject = [EnumOne.Two];
         EnumFour[] expectation = [EnumFour.Three];
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByName(),
             "some {0}", "reason");
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("Expected*to equal EnumFour.Three {value: 3} by name*some reason*but found EnumOne.Two {value: 3}*");
     }
@@ -98,51 +77,40 @@ public class EnumSpecs
     [Fact]
     public void Comparing_collections_of_numerics_with_collections_of_enums_includes_custom_message()
     {
-        // Arrange
         int[] actual = [1];
-
         TestEnum[] expected = [TestEnum.First];
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByValue(),
             "some {0}", "reason");
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*some reason*");
+        act.Should().Throw<XunitException>().WithMessage("*some reason*");
     }
 
     [Fact]
     public void When_asserting_members_from_different_enum_types_are_equivalent_it_should_compare_by_value_by_default()
     {
-        // Arrange
         var subject = new ClassWithEnumOne();
         var expectation = new ClassWithEnumTwo();
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_asserting_members_from_different_enum_types_are_equivalent_by_value_it_should_succeed()
     {
-        // Arrange
         var subject = new ClassWithEnumOne { Enum = EnumOne.One };
         var expectation = new ClassWithEnumThree { Enum = EnumThree.ValueZero };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByValue());
     }
 
     [Fact]
     public void When_asserting_members_from_different_enum_types_are_equivalent_by_string_value_it_should_succeed()
     {
-        // Arrange
         var subject = new ClassWithEnumOne { Enum = EnumOne.Two };
 
         var expectation = new ClassWithEnumThree { Enum = EnumThree.Two };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByName());
     }
 
@@ -150,14 +118,11 @@ public class EnumSpecs
     public void
         When_asserting_members_from_different_enum_types_are_equivalent_by_value_but_comparing_by_name_it_should_throw()
     {
-        // Arrange
         var subject = new ClassWithEnumOne { Enum = EnumOne.Two };
         var expectation = new ClassWithEnumFour { Enum = EnumFour.Three };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByName());
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("Expected*to equal EnumFour.Three {value: 3} by name, but found EnumOne.Two {value: 3}*");
     }
@@ -165,91 +130,69 @@ public class EnumSpecs
     [Fact]
     public void When_asserting_members_from_different_char_enum_types_are_equivalent_by_value_it_should_succeed()
     {
-        // Arrange
         var subject = new ClassWithEnumCharOne { Enum = EnumCharOne.B };
         var expectation = new ClassWithEnumCharTwo { Enum = EnumCharTwo.ValueB };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByValue());
     }
 
     [Fact]
     public void When_asserting_enums_typed_as_object_are_equivalent_it_should_succeed()
     {
-        // Arrange
         object e1 = EnumOne.One;
         object e2 = EnumOne.One;
 
-        // Act / Assert
         e1.Should().BeEquivalentTo(e2);
     }
 
     [Fact]
     public void When_a_numeric_member_is_compared_with_an_enum_it_should_throw()
     {
-        // Arrange
         var actual = new { Property = 1 };
-
         var expected = new { Property = TestEnum.First };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByValue());
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
     [Fact]
     public void When_a_string_member_is_compared_with_an_enum_it_should_throw()
     {
-        // Arrange
         var actual = new { Property = "First" };
-
         var expected = new { Property = TestEnum.First };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByName());
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
     [Fact]
     public void When_null_enum_members_are_compared_by_name_it_should_succeed()
     {
-        // Arrange
         var actual = new { Property = null as TestEnum? };
-
         var expected = new { Property = null as TestEnum? };
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByName());
     }
 
     [Fact]
     public void When_null_enum_members_are_compared_by_value_it_should_succeed()
     {
-        // Arrange
         var actual = new { Property = null as TestEnum? };
-
         var expected = new { Property = null as TestEnum? };
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByValue());
     }
 
     [Fact]
     public void When_zero_and_null_enum_are_compared_by_value_it_should_throw()
     {
-        // Arrange
         var actual = new { Property = (TestEnum)0 };
-
         var expected = new { Property = null as TestEnum? };
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByValue());
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
@@ -261,71 +204,60 @@ public class EnumSpecs
     [Fact]
     public void When_subject_is_null_and_enum_has_some_value_it_should_throw()
     {
-        // Arrange
         object subject = null;
         object expectedEnum = EnumULong.UInt64Max;
 
-        // Act
         Action act = () =>
-            subject.Should().BeEquivalentTo(expectedEnum, x => x.ComparingEnumsByName(), "comparing enums should throw");
+            subject.Should().BeEquivalentTo(expectedEnum,
+                x => x.ComparingEnumsByName(), "we want to test the {0} message", "failure");
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected*to be equivalent to EnumULong.UInt64Max {value: 18446744073709551615} because comparing enums should throw, but found <null>*");
+        act.Should().Throw<XunitException>().WithMessage(
+            "Expected*to be equivalent to EnumULong.UInt64Max {value: 18446744073709551615} because*failure message,"
+            + " but found <null>*");
     }
 
     [Fact]
     public void When_expectation_is_null_and_subject_enum_has_some_value_it_should_throw_with_a_useful_message()
     {
-        // Arrange
         object subjectEnum = EnumULong.UInt64Max;
         object expected = null;
 
-        // Act
         Action act = () =>
-            subjectEnum.Should().BeEquivalentTo(expected, x => x.ComparingEnumsByName(), "comparing enums should throw");
+            subjectEnum.Should().BeEquivalentTo(expected,
+                x => x.ComparingEnumsByName(), "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expected*to be <null> because comparing enums should throw, but found EnumULong.UInt64Max*");
+            .WithMessage("Expected*to be <null> because we want to test the failure message, but found EnumULong.UInt64Max*");
     }
 
     [Fact]
     public void When_both_enums_are_equal_and_greater_than_max_long_it_should_not_throw()
     {
-        // Arrange
         object enumOne = EnumULong.UInt64Max;
         object enumTwo = EnumULong.UInt64Max;
 
-        // Act / Assert
         enumOne.Should().BeEquivalentTo(enumTwo);
     }
 
     [Fact]
     public void When_both_enums_are_equal_and_of_different_underlying_types_it_should_not_throw()
     {
-        // Arrange
         object enumOne = EnumLong.Int64Max;
         object enumTwo = EnumULong.Int64Max;
 
-        // Act / Assert
         enumOne.Should().BeEquivalentTo(enumTwo);
     }
 
     [Fact]
     public void When_both_enums_are_large_and_not_equal_it_should_throw()
     {
-        // Arrange
         object subjectEnum = EnumLong.Int64LessOne;
         object expectedEnum = EnumULong.UInt64Max;
 
-        // Act
-        Action act = () => subjectEnum.Should().BeEquivalentTo(expectedEnum, "comparing enums should throw");
+        Action act = () => subjectEnum.Should().BeEquivalentTo(expectedEnum, "we want to test the {0} message", "failure");
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected subjectEnum*to equal EnumULong.UInt64Max {value: 18446744073709551615} by value because comparing enums should throw, but found EnumLong.Int64LessOne {value: 9223372036854775806}*");
+        act.Should().Throw<XunitException>().WithMessage(
+            "Expected subjectEnum*to equal EnumULong.UInt64Max {value: 18446744073709551615} by value because*failure message,"
+            + " but found EnumLong.Int64LessOne {value: 9223372036854775806}*");
     }
 }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -14,1084 +14,742 @@ namespace AwesomeAssertions.Equivalency.Specs;
 /// <summary>
 /// Test Class containing specs over the extensibility points of Should().BeEquivalentTo
 /// </summary>
-public class ExtensibilitySpecs
+public static class ExtensibilitySpecs
 {
-    #region Selection Rules
-
-    [Fact]
-    public void When_a_selection_rule_is_added_it_should_be_evaluated_after_all_existing_rules()
+    public class SelectionRulesSpecs
     {
-        // Arrange
-        var subject = new
+        [Fact]
+        public void When_a_selection_rule_is_added_it_should_be_evaluated_after_all_existing_rules()
         {
-            NameId = "123",
-            SomeValue = "hello"
-        };
+            var subject = new { NameId = "123", SomeValue = "hello" };
+            var expected = new { SomeValue = "hello" };
 
-        var expected = new
-        {
-            SomeValue = "hello"
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(
-            expected,
-            options => options.Using(new ExcludeForeignKeysSelectionRule()));
-    }
-
-    [Fact]
-    public void When_a_selection_rule_is_added_it_should_appear_in_the_exception_message()
-    {
-        // Arrange
-        var subject = new
-        {
-            Name = "123",
-        };
-
-        var expected = new
-        {
-            SomeValue = "hello"
-        };
-
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(
-            expected,
-            options => options.Using(new ExcludeForeignKeysSelectionRule()));
-
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage($"*{nameof(ExcludeForeignKeysSelectionRule)}*");
-    }
-
-    internal class ExcludeForeignKeysSelectionRule : IMemberSelectionRule
-    {
-        public bool OverridesStandardIncludeRules
-        {
-            get { return false; }
+            subject.Should().BeEquivalentTo(
+                expected,
+                options => options.Using(new ExcludeForeignKeysSelectionRule()));
         }
 
-        public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
-            MemberSelectionContext context)
+        [Fact]
+        public void When_a_selection_rule_is_added_it_should_appear_in_the_exception_message()
         {
-            return selectedMembers.Where(pi => !pi.Subject.Name.EndsWith("Id", StringComparison.Ordinal)).ToArray();
+            var subject = new { Name = "123" };
+            var expected = new { SomeValue = "hello" };
+
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, options => options.Using(new ExcludeForeignKeysSelectionRule()));
+
+            act.Should().Throw<XunitException>()
+                .WithMessage($"*{nameof(ExcludeForeignKeysSelectionRule)}*");
         }
 
-        bool IMemberSelectionRule.IncludesMembers
+        private class ExcludeForeignKeysSelectionRule : IMemberSelectionRule
         {
-            get { return OverridesStandardIncludeRules; }
-        }
-    }
-
-    #endregion
-
-    #region Matching Rules
-
-    [Fact]
-    public void When_a_matching_rule_is_added_it_should_precede_all_existing_rules()
-    {
-        // Arrange
-        var subject = new
-        {
-            Name = "123",
-            SomeValue = "hello"
-        };
-
-        var expected = new
-        {
-            NameId = "123",
-            SomeValue = "hello"
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(
-            expected,
-            options => options.Using(new ForeignKeyMatchingRule()));
-    }
-
-    [Fact]
-    public void When_a_matching_rule_is_added_it_should_appear_in_the_exception_message()
-    {
-        // Arrange
-        var subject = new
-        {
-            NameId = "123",
-            SomeValue = "hello"
-        };
-
-        var expected = new
-        {
-            Name = "1234",
-            SomeValue = "hello"
-        };
-
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(
-            expected,
-            options => options.Using(new ForeignKeyMatchingRule()));
-
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage($"*{nameof(ForeignKeyMatchingRule)}*");
-    }
-
-    internal class ForeignKeyMatchingRule : IMemberMatchingRule
-    {
-        public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyOptions options,
-            AssertionChain assertionChain)
-        {
-            string name = expectedMember.Subject.Name;
-
-            if (name.EndsWith("Id", StringComparison.Ordinal))
+            public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
+                MemberSelectionContext context)
             {
-                name = name.Replace("Id", "");
+                return selectedMembers.Where(pi => !pi.Subject.Name.EndsWith("Id", StringComparison.Ordinal)).ToArray();
             }
 
-            PropertyInfo runtimeProperty = subject.GetType().GetRuntimeProperty(name);
-            return runtimeProperty is not null ? new Property(runtimeProperty, parent) : null;
+            bool IMemberSelectionRule.IncludesMembers
+            {
+                get { return false; }
+            }
         }
     }
 
-    #endregion
-
-    #region Ordering Rules
-
-    [Fact]
-    public void When_an_ordering_rule_is_added_it_should_be_evaluated_after_all_existing_rules()
+    public class MatchingRulesSpecs
     {
-        // Arrange
-        string[] subject = ["First", "Second"];
-        string[] expected = ["First", "Second"];
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(
-            expected,
-            options => options.Using(new StrictOrderingRule()));
-    }
-
-    [Fact]
-    public void When_an_ordering_rule_is_added_it_should_appear_in_the_exception_message()
-    {
-        // Arrange
-        string[] subject = ["First", "Second"];
-        string[] expected = ["Second", "First"];
-
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(
-            expected,
-            options => options.Using(new StrictOrderingRule()));
-
-        act.Should().Throw<XunitException>()
-            .WithMessage($"*{nameof(StrictOrderingRule)}*");
-    }
-
-    internal class StrictOrderingRule : IOrderingRule
-    {
-        public OrderStrictness Evaluate(IObjectInfo objectInfo)
+        [Fact]
+        public void When_a_matching_rule_is_added_it_should_precede_all_existing_rules()
         {
-            return OrderStrictness.Strict;
+            var subject = new { Name = "123", SomeValue = "hello" };
+            var expected = new { NameId = "123", SomeValue = "hello" };
+
+            subject.Should().BeEquivalentTo(
+                expected,
+                options => options.Using(new ForeignKeyMatchingRule()));
+        }
+
+        [Fact]
+        public void When_a_matching_rule_is_added_it_should_appear_in_the_exception_message()
+        {
+            var subject = new { NameId = "123", SomeValue = "hello" };
+            var expected = new { Name = "1234", SomeValue = "hello" };
+
+            Action act = () => subject.Should().BeEquivalentTo(
+                expected,
+                options => options.Using(new ForeignKeyMatchingRule()));
+
+            act.Should().Throw<XunitException>()
+                .WithMessage($"*{nameof(ForeignKeyMatchingRule)}*");
+        }
+
+        private class ForeignKeyMatchingRule : IMemberMatchingRule
+        {
+            public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyOptions options,
+                AssertionChain assertionChain)
+            {
+                string name = expectedMember.Subject.Name;
+
+                if (name.EndsWith("Id", StringComparison.Ordinal))
+                {
+                    name = name.Replace("Id", "");
+                }
+
+                PropertyInfo runtimeProperty = subject.GetType().GetRuntimeProperty(name);
+                return runtimeProperty is not null ? new Property(runtimeProperty, parent) : null;
+            }
         }
     }
 
-    #endregion
-
-    #region Assertion Rules
-
-    [Fact]
-    public void When_property_of_other_is_incompatible_with_generic_type_the_message_should_include_generic_type()
+    public class OrderingRulesSpecs
     {
-        // Arrange
-        var subject = new
+        [Fact]
+        public void When_an_ordering_rule_is_added_it_should_be_evaluated_after_all_existing_rules()
         {
-            Id = "foo",
-        };
+            string[] subject = ["First", "Second"];
+            string[] expected = ["First", "Second"];
 
-        var other = new
+            subject.Should().BeEquivalentTo(
+                expected,
+                options => options.Using(new StrictOrderingRule()));
+        }
+
+        [Fact]
+        public void When_an_ordering_rule_is_added_it_should_appear_in_the_exception_message()
         {
-            Id = 0.5d,
-        };
+            string[] subject = ["First", "Second"];
+            string[] expected = ["Second", "First"];
 
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(other,
-            o => o
-                .Using<string>(c => c.Subject.Should().Be(c.Expectation))
-                .When(si => si.Path == "Id"));
+            Action act = () => subject.Should().BeEquivalentTo(
+                expected,
+                options => options.Using(new StrictOrderingRule()));
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*Id*from expectation*string*double*");
-    }
+            act.Should().Throw<XunitException>()
+                .WithMessage($"*{nameof(StrictOrderingRule)}*");
+        }
 
-    [Fact]
-    public void Can_exclude_all_properties_of_the_parent_type()
-    {
-        // Arrange
-        var subject = new
+        private class StrictOrderingRule : IOrderingRule
         {
-            Id = "foo",
-        };
-
-        var expectation = new
-        {
-            Id = "bar",
-        };
-
-        // Act
-        subject.Should().BeEquivalentTo(expectation,
-            o => o
-                .Using<string>(c => c.Subject.Should().HaveLength(c.Expectation.Length))
-                .When(si => si.ParentType == expectation.GetType() && si.Path.EndsWith("Id", StringComparison.Ordinal)));
-    }
-
-    [Fact]
-    public void When_property_of_subject_is_incompatible_with_generic_type_the_message_should_include_generic_type()
-    {
-        // Arrange
-        var subject = new
-        {
-            Id = 0.5d,
-        };
-
-        var other = new
-        {
-            Id = "foo",
-        };
-
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(other,
-            o => o
-                .Using<string>(c => c.Subject.Should().Be(c.Expectation))
-                .When(si => si.Path == "Id"));
-
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*Id*from subject*string*double*");
-    }
-
-    [Fact]
-    public void When_equally_named_properties_are_both_incompatible_with_generic_type_the_message_should_include_generic_type()
-    {
-        // Arrange
-        var subject = new
-        {
-            Id = 0.5d,
-        };
-
-        var other = new
-        {
-            Id = 0.5d,
-        };
-
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(other,
-            o => o
-                .Using<string>(c => c.Subject.Should().Be(c.Expectation))
-                .When(si => si.Path == "Id"));
-
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*Id*from subject*string*double*");
-    }
-
-    [Fact]
-    public void When_property_of_other_is_null_the_failure_message_should_not_complain_about_its_type()
-    {
-        // Arrange
-        var subject = new
-        {
-            Id = "foo",
-        };
-
-        var other = new
-        {
-            Id = null as double?,
-        };
-
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(other,
-            o => o
-                .Using<string>(c => c.Subject.Should().Be(c.Expectation))
-                .When(si => si.Path == "Id"));
-
-        // Assert
-        act.Should().Throw<XunitException>()
-            .Which.Message.Should()
-            .Contain("Expected property subject.Id to be <null>, but found \"foo\"")
-            .And.NotContain("from expectation");
-    }
-
-    [Fact]
-    public void When_property_of_subject_is_null_the_failure_message_should_not_complain_about_its_type()
-    {
-        // Arrange
-        var subject = new
-        {
-            Id = null as double?,
-        };
-
-        var expectation = new
-        {
-            Id = "bar",
-        };
-
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expectation,
-            o => o
-                .Using<string>(c => c.Subject.Should().Be(c.Expectation))
-                .When(si => si.Path == "Id"));
-
-        // Assert
-        act.Should().Throw<XunitException>()
-            .Which.Message.Should()
-            .Contain("Expected property subject.Id to be \"bar\", but found <null>")
-            .And.NotContain("from subject");
-    }
-
-    [Fact]
-    public void When_equally_named_properties_are_both_null_it_should_succeed()
-    {
-        // Arrange
-        var subject = new
-        {
-            Id = null as double?,
-        };
-
-        var other = new
-        {
-            Id = null as string,
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(other,
-            o => o
-                .Using<string>(c => c.Subject.Should().Be(c.Expectation))
-                .When(si => si.Path == "Id"));
-    }
-
-    [Fact]
-    public void When_equally_named_properties_are_type_incompatible_and_assertion_rule_exists_it_should_not_throw()
-    {
-        // Arrange
-        var subject = new
-        {
-            Type = typeof(string),
-        };
-
-        var other = new
-        {
-            Type = typeof(string).AssemblyQualifiedName,
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(other,
-            o => o
-                .Using<object>(c => ((Type)c.Subject).AssemblyQualifiedName.Should().Be((string)c.Expectation))
-                .When(si => si.Path == "Type"));
-    }
-
-    [Fact]
-    public void When_an_assertion_is_overridden_for_a_predicate_it_should_use_the_provided_action()
-    {
-        // Arrange
-        var subject = new
-        {
-            Date = 14.July(2012).At(12, 59, 59)
-        };
-
-        var expectation = new
-        {
-            Date = 14.July(2012).At(13, 0)
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expectation, options => options
-            .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
-            .When(info => info.Path.EndsWith("Date", StringComparison.Ordinal)));
-    }
-
-    [Fact]
-    public void When_an_assertion_is_overridden_for_all_types_it_should_use_the_provided_action_for_all_properties()
-    {
-        // Arrange
-        var subject = new
-        {
-            Date = 21.July(2012).At(11, 8, 59),
-            Nested = new
+            public OrderStrictness Evaluate(IObjectInfo objectInfo)
             {
-                NestedDate = 14.July(2012).At(12, 59, 59)
+                return OrderStrictness.Strict;
             }
-        };
+        }
+    }
 
-        var expectation = new
+    public class AssertionRulesSpecs
+    {
+        [Fact]
+        public void When_property_of_other_is_incompatible_with_generic_type_the_message_should_include_generic_type()
         {
-            Date = 21.July(2012).At(11, 9),
-            Nested = new
-            {
-                NestedDate = 14.July(2012).At(13, 0)
-            }
-        };
+            var subject = new { Id = "foo" };
+            var other = new { Id = 0.5d };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expectation, options =>
-            options
+            Action act = () => subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.Path == "Id"));
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("*Id*from expectation*string*double*");
+        }
+
+        [Fact]
+        public void Can_exclude_all_properties_of_the_parent_type()
+        {
+            var subject = new { Id = "foo" };
+            var expectation = new { Id = "bar" };
+
+            subject.Should().BeEquivalentTo(expectation,
+                o => o
+                    .Using<string>(c => c.Subject.Should().HaveLength(c.Expectation.Length))
+                    .When(si => si.ParentType == expectation.GetType() && si.Path.EndsWith("Id", StringComparison.Ordinal)));
+        }
+
+        [Fact]
+        public void When_property_of_subject_is_incompatible_with_generic_type_the_message_should_include_generic_type()
+        {
+            var subject = new { Id = 0.5d };
+            var other = new { Id = "foo" };
+
+            Action act = () => subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.Path == "Id"));
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("*Id*from subject*string*double*");
+        }
+
+        [Fact]
+        public void
+            When_equally_named_properties_are_both_incompatible_with_generic_type_the_message_should_include_generic_type()
+        {
+            var subject = new { Id = 0.5d };
+            var other = new { Id = 0.5d };
+
+            Action act = () => subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.Path == "Id"));
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("*Id*from subject*string*double*");
+        }
+
+        [Fact]
+        public void When_property_of_other_is_null_the_failure_message_should_not_complain_about_its_type()
+        {
+            var subject = new { Id = "foo" };
+            var other = new { Id = null as double? };
+
+            Action act = () => subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.Path == "Id"));
+
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should()
+                .Contain("Expected property subject.Id to be <null>, but found \"foo\"")
+                .And.NotContain("from expectation");
+        }
+
+        [Fact]
+        public void When_property_of_subject_is_null_the_failure_message_should_not_complain_about_its_type()
+        {
+            var subject = new { Id = null as double? };
+            var expectation = new { Id = "bar" };
+
+            Action act = () => subject.Should().BeEquivalentTo(expectation,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.Path == "Id"));
+
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should()
+                .Contain("Expected property subject.Id to be \"bar\", but found <null>")
+                .And.NotContain("from subject");
+        }
+
+        [Fact]
+        public void When_equally_named_properties_are_both_null_it_should_succeed()
+        {
+            var subject = new { Id = null as double? };
+            var other = new { Id = null as string };
+
+            subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.Path == "Id"));
+        }
+
+        [Fact]
+        public void When_equally_named_properties_are_type_incompatible_and_assertion_rule_exists_it_should_not_throw()
+        {
+            var subject = new { Type = typeof(string) };
+            var other = new { Type = typeof(string).AssemblyQualifiedName };
+
+            subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<object>(c => ((Type)c.Subject).AssemblyQualifiedName.Should().Be((string)c.Expectation))
+                    .When(si => si.Path == "Type"));
+        }
+
+        [Fact]
+        public void When_an_assertion_is_overridden_for_a_predicate_it_should_use_the_provided_action()
+        {
+            var subject = new { Date = 14.July(2012).At(12, 59, 59) };
+            var expectation = new { Date = 14.July(2012).At(13, 0) };
+
+            subject.Should().BeEquivalentTo(expectation, options => options
                 .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
-                .WhenTypeIs<DateTime>());
-    }
+                .When(info => info.Path.EndsWith("Date", StringComparison.Ordinal)));
+        }
 
-    [InlineData(null, 0)]
-    [InlineData(0, null)]
-    [Theory]
-    public void When_subject_or_expectation_is_null_it_should_not_match_a_non_nullable_type(int? subjectValue, int? expectedValue)
-    {
-        // Arrange
-        var actual = new { Value = subjectValue };
-        var expected = new { Value = expectedValue };
-
-        // Act
-        Action act = () => actual.Should().BeEquivalentTo(expected, opt => opt
-            .Using<int>(c => c.Subject.Should().NotBe(c.Expectation))
-            .WhenTypeIs<int>());
-
-        // Assert
-        act.Should().Throw<XunitException>();
-    }
-
-    [InlineData(null, 0)]
-    [InlineData(0, null)]
-    [Theory]
-    public void When_subject_or_expectation_is_null_it_should_match_a_nullable_type(int? subjectValue, int? expectedValue)
-    {
-        // Arrange
-        var actual = new { Value = subjectValue };
-        var expected = new { Value = expectedValue };
-
-        // Act / Assert
-        actual.Should().BeEquivalentTo(expected, opt => opt
-            .Using<int?>(c => c.Subject.Should().NotBe(c.Expectation))
-            .WhenTypeIs<int?>());
-    }
-
-    [InlineData(null, null)]
-    [InlineData(0, 0)]
-    [Theory]
-    public void When_types_are_nullable_it_should_match_a_nullable_type(int? subjectValue, int? expectedValue)
-    {
-        // Arrange
-        var actual = new { Value = subjectValue };
-        var expected = new { Value = expectedValue };
-
-        // Act
-        Action act = () => actual.Should().BeEquivalentTo(expected, opt => opt
-            .Using<int?>(c => c.Subject.Should().NotBe(c.Expectation))
-            .WhenTypeIs<int?>());
-
-        // Assert
-        act.Should().Throw<XunitException>();
-    }
-
-    [Fact]
-    public void When_overriding_with_custom_assertion_it_should_be_chainable()
-    {
-        // Arrange
-        var actual = new { Nullable = (int?)1, NonNullable = 2 };
-        var expected = new { Nullable = (int?)3, NonNullable = 3 };
-
-        // Act / Assert
-        actual.Should().BeEquivalentTo(expected, opt => opt
-            .Using<int>(c => c.Subject.Should().BeCloseTo(c.Expectation, 1))
-            .WhenTypeIs<int>()
-            .Using<int?>(c => c.Subject.Should().NotBe(c.Expectation))
-            .WhenTypeIs<int?>());
-    }
-
-    [Fact]
-    public void When_a_nullable_property_is_overridden_with_a_custom_assertion_it_should_use_it()
-    {
-        // Arrange
-        var actual = new SimpleWithNullable
+        [Fact]
+        public void When_an_assertion_is_overridden_for_all_types_it_should_use_the_provided_action_for_all_properties()
         {
-            NullableIntegerProperty = 1,
-            StringProperty = "I haz a string!"
-        };
-
-        var expected = new SimpleWithNullable
-        {
-            StringProperty = "I haz a string!"
-        };
-
-        // Act / Assert
-        actual.Should().BeEquivalentTo(expected, opt => opt
-            .Using<long?>(c => c.Subject.Should().BeInRange(0, 10))
-            .WhenTypeIs<long?>());
-    }
-
-    internal class SimpleWithNullable
-    {
-        public long? NullableIntegerProperty { get; set; }
-
-        public string StringProperty { get; set; }
-    }
-
-    [Fact]
-    public void When_an_assertion_rule_is_added_it_should_precede_all_existing_rules()
-    {
-        // Arrange
-        var subject = new
-        {
-            Created = 8.July(2012).At(22, 9)
-        };
-
-        var expected = new
-        {
-            Created = 8.July(2012).At(22, 10)
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(
-            expected,
-            options => options.Using(new RelaxingDateTimeEquivalencyStep()));
-    }
-
-    [Fact]
-    public void When_an_assertion_rule_is_added_it_appear_in_the_exception_message()
-    {
-        // Arrange
-        var subject = new
-        {
-            Property = 8.July(2012).At(22, 9)
-        };
-
-        var expected = new
-        {
-            Property = 8.July(2012).At(22, 11)
-        };
-
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(
-            expected,
-            options => options.Using(new RelaxingDateTimeEquivalencyStep()));
-
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage($"*{nameof(RelaxingDateTimeEquivalencyStep)}*");
-    }
-
-    [Fact]
-    public void When_multiple_steps_are_added_they_should_be_evaluated_first_to_last()
-    {
-        // Arrange
-        var subject = new
-        {
-            Created = 8.July(2012).At(22, 9)
-        };
-
-        var expected = new
-        {
-            Created = 8.July(2012).At(22, 10)
-        };
-
-        // Act
-        Action act = () => subject.Should().BeEquivalentTo(expected, opts => opts
-            .Using(new RelaxingDateTimeEquivalencyStep())
-            .Using(new AlwaysFailOnDateTimesEquivalencyStep()));
-
-        // Assert
-        act.Should().NotThrow(
-            "a different assertion rule should handle the comparison before the exception throwing assertion rule is hit");
-    }
-
-    private class AlwaysFailOnDateTimesEquivalencyStep : IEquivalencyStep
-    {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
-            IValidateChildNodeEquivalency valueChildNodes)
-        {
-            if (comparands.Expectation is DateTime)
+            var subject = new
             {
-                throw new Exception("Failed");
-            }
+                Date = 21.July(2012).At(11, 8, 59),
+                Nested = new
+                {
+                    NestedDate = 14.July(2012).At(12, 59, 59)
+                }
+            };
+            var expectation = new
+            {
+                Date = 21.July(2012).At(11, 9),
+                Nested = new
+                {
+                    NestedDate = 14.July(2012).At(13, 0)
+                }
+            };
 
-            return EquivalencyResult.ContinueWithNext;
+            subject.Should().BeEquivalentTo(expectation, options =>
+                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
+                    .WhenTypeIs<DateTime>());
+        }
+
+        [InlineData(null, 0)]
+        [InlineData(0, null)]
+        [Theory]
+        public void When_subject_or_expectation_is_null_it_should_not_match_a_non_nullable_type(
+            int? subjectValue, int? expectedValue)
+        {
+            var actual = new { Value = subjectValue };
+            var expected = new { Value = expectedValue };
+
+            Action act = () => actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<int>(c => c.Subject.Should().NotBe(c.Expectation))
+                .WhenTypeIs<int>());
+
+            act.Should().Throw<XunitException>();
+        }
+
+        [InlineData(null, 0)]
+        [InlineData(0, null)]
+        [Theory]
+        public void When_subject_or_expectation_is_null_it_should_match_a_nullable_type(int? subjectValue, int? expectedValue)
+        {
+            var actual = new { Value = subjectValue };
+            var expected = new { Value = expectedValue };
+
+            actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<int?>(c => c.Subject.Should().NotBe(c.Expectation))
+                .WhenTypeIs<int?>());
+        }
+
+        [InlineData(null, null)]
+        [InlineData(0, 0)]
+        [Theory]
+        public void When_types_are_nullable_it_should_match_a_nullable_type(int? subjectValue, int? expectedValue)
+        {
+            var actual = new { Value = subjectValue };
+            var expected = new { Value = expectedValue };
+
+            Action act = () => actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<int?>(c => c.Subject.Should().NotBe(c.Expectation))
+                .WhenTypeIs<int?>());
+
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_overriding_with_custom_assertion_it_should_be_chainable()
+        {
+            var actual = new { Nullable = (int?)1, NonNullable = 2 };
+            var expected = new { Nullable = (int?)3, NonNullable = 3 };
+
+            actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<int>(c => c.Subject.Should().BeCloseTo(c.Expectation, 1))
+                .WhenTypeIs<int>()
+                .Using<int?>(c => c.Subject.Should().NotBe(c.Expectation))
+                .WhenTypeIs<int?>());
+        }
+
+        [Fact]
+        public void When_a_nullable_property_is_overridden_with_a_custom_assertion_it_should_use_it()
+        {
+            var actual = new SimpleWithNullable
+            {
+                NullableIntegerProperty = 1,
+                StringProperty = "I haz a string!"
+            };
+            var expected = new SimpleWithNullable
+            {
+                StringProperty = "I haz a string!"
+            };
+
+            actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<long?>(c => c.Subject.Should().BeInRange(0, 10))
+                .WhenTypeIs<long?>());
+        }
+
+        private class SimpleWithNullable
+        {
+            public long? NullableIntegerProperty { get; set; }
+
+            public string StringProperty { get; set; }
+        }
+
+        [Fact]
+        public void When_an_assertion_rule_is_added_it_should_precede_all_existing_rules()
+        {
+            var subject = new { Created = 8.July(2012).At(22, 9) };
+            var expected = new { Created = 8.July(2012).At(22, 10) };
+
+            subject.Should().BeEquivalentTo(
+                expected,
+                options => options.Using(new RelaxingDateTimeEquivalencyStep()));
+        }
+
+        [Fact]
+        public void When_an_assertion_rule_is_added_it_appear_in_the_exception_message()
+        {
+            var subject = new { Property = 8.July(2012).At(22, 9) };
+            var expected = new { Property = 8.July(2012).At(22, 11) };
+
+            Action act = () => subject.Should().BeEquivalentTo(
+                expected,
+                options => options.Using(new RelaxingDateTimeEquivalencyStep()));
+
+            act.Should().Throw<XunitException>()
+                .WithMessage($"*{nameof(RelaxingDateTimeEquivalencyStep)}*");
+        }
+
+        [Fact]
+        public void When_multiple_steps_are_added_they_should_be_evaluated_first_to_last()
+        {
+            var subject = new { Created = 8.July(2012).At(22, 9) };
+            var expected = new { Created = 8.July(2012).At(22, 10) };
+
+            Action act = () => subject.Should().BeEquivalentTo(expected, opts => opts
+                .Using(new RelaxingDateTimeEquivalencyStep())
+                .Using(new AlwaysFailOnDateTimesEquivalencyStep()));
+
+            act.Should().NotThrow(
+                "a different assertion rule should handle the comparison before the exception throwing assertion rule is hit");
+        }
+
+        private class AlwaysFailOnDateTimesEquivalencyStep : IEquivalencyStep
+        {
+            public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+                IValidateChildNodeEquivalency valueChildNodes)
+            {
+                if (comparands.Expectation is DateTime)
+                {
+                    throw new Exception("Failed");
+                }
+
+                return EquivalencyResult.ContinueWithNext;
+            }
+        }
+
+        private class RelaxingDateTimeEquivalencyStep : IEquivalencyStep
+        {
+            public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+                IValidateChildNodeEquivalency valueChildNodes)
+            {
+                if (comparands.Expectation is DateTime time)
+                {
+                    ((DateTime)comparands.Subject).Should().BeCloseTo(time, 1.Minutes());
+
+                    return EquivalencyResult.EquivalencyProven;
+                }
+
+                return EquivalencyResult.ContinueWithNext;
+            }
+        }
+
+        [Fact]
+        public void When_multiple_assertion_rules_are_added_with_the_fluent_api_they_should_be_executed_from_right_to_left()
+        {
+            var subject = new ClassWithOnlyAProperty();
+            var expected = new ClassWithOnlyAProperty();
+
+            Action act =
+                () => subject.Should().BeEquivalentTo(expected, opts =>
+                    opts.Using<object>(_ => throw new Exception())
+                        .When(_ => true)
+                        .Using<object>(_ => { })
+                        .When(_ => true));
+
+            act.Should().NotThrow(
+                "a different assertion rule should handle the comparison before the exception throwing assertion rule is hit");
+        }
+
+        [Fact]
+        public void When_using_a_nested_equivalency_api_in_a_custom_assertion_rule_it_should_honor_the_rule()
+        {
+            var subject = new ClassWithSomeFieldsAndProperties
+            {
+                Property1 = "value1",
+                Property2 = "value2"
+            };
+            var expectation = new ClassWithSomeFieldsAndProperties
+            {
+                Property1 = "value1",
+                Property2 = "value3"
+            };
+
+            subject.Should().BeEquivalentTo(expectation, options => options
+                .Using<ClassWithSomeFieldsAndProperties>(ctx =>
+                    ctx.Subject.Should()
+                        .BeEquivalentTo(ctx.Expectation, nestedOptions => nestedOptions.Excluding(x => x.Property2)))
+                .WhenTypeIs<ClassWithSomeFieldsAndProperties>());
+        }
+
+        [Fact]
+        public void When_a_predicate_matches_after_auto_conversion_it_should_execute_the_assertion()
+        {
+            var expectation = new { ThisIsMyDateTime = DateTime.Now };
+            var actual = new
+            {
+                ThisIsMyDateTime = expectation.ThisIsMyDateTime.ToString(CultureInfo.InvariantCulture)
+            };
+
+            actual.Should().BeEquivalentTo(expectation,
+                options => options
+                    .WithAutoConversion()
+                    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
+                    .WhenTypeIs<DateTime>());
         }
     }
 
-    private class RelaxingDateTimeEquivalencyStep : IEquivalencyStep
+    public class EquivalencyStepsSpecs
     {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
-            IValidateChildNodeEquivalency valueChildNodes)
+        [Fact]
+        public void When_an_equivalency_step_handles_the_comparison_later_equivalency_steps_should_not_be_ran()
         {
-            if (comparands.Expectation is DateTime time)
-            {
-                ((DateTime)comparands.Subject).Should().BeCloseTo(time, 1.Minutes());
+            var subject = new ClassWithOnlyAProperty();
+            var expected = new ClassWithOnlyAProperty();
 
+            subject.Should().BeEquivalentTo(expected,
+                opts =>
+                    opts.Using(new AlwaysHandleEquivalencyStep())
+                        .Using(new ThrowExceptionEquivalencyStep<InvalidOperationException>()));
+        }
+
+        [Fact]
+        public void When_a_user_equivalency_step_is_registered_it_should_run_before_the_built_in_steps()
+        {
+            var actual = new { Property = 123 };
+            var expected = new { Property = "123" };
+
+            Action act = () => actual.Should().BeEquivalentTo(expected, options => options
+                .Using(new EqualityEquivalencyStep()));
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*123*123*");
+        }
+
+        [Fact]
+        public void When_an_equivalency_does_not_handle_the_comparison_later_equivalency_steps_should_still_be_ran()
+        {
+            var subject = new ClassWithOnlyAProperty();
+            var expected = new ClassWithOnlyAProperty();
+
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, opts =>
+                    opts.Using(new NeverHandleEquivalencyStep())
+                        .Using(new ThrowExceptionEquivalencyStep<InvalidOperationException>()));
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void When_multiple_equivalency_steps_are_added_they_should_be_executed_in_registration_order()
+        {
+            var subject = new ClassWithOnlyAProperty();
+            var expected = new ClassWithOnlyAProperty();
+
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, opts =>
+                    opts.Using(new ThrowExceptionEquivalencyStep<NotSupportedException>())
+                        .Using(new ThrowExceptionEquivalencyStep<InvalidOperationException>()));
+
+            act.Should().Throw<NotSupportedException>();
+        }
+
+        private class ThrowExceptionEquivalencyStep<TException> : IEquivalencyStep
+            where TException : Exception, new()
+        {
+            public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+                IValidateChildNodeEquivalency valueChildNodes)
+            {
+                throw new TException();
+            }
+        }
+
+        private class AlwaysHandleEquivalencyStep : IEquivalencyStep
+        {
+            public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+                IValidateChildNodeEquivalency valueChildNodes)
+            {
                 return EquivalencyResult.EquivalencyProven;
             }
-
-            return EquivalencyResult.ContinueWithNext;
-        }
-    }
-
-    [Fact]
-    public void When_multiple_assertion_rules_are_added_with_the_fluent_api_they_should_be_executed_from_right_to_left()
-    {
-        // Arrange
-        var subject = new ClassWithOnlyAProperty();
-        var expected = new ClassWithOnlyAProperty();
-
-        // Act
-        Action act =
-            () =>
-                subject.Should().BeEquivalentTo(expected,
-                    opts =>
-                        opts.Using<object>(_ => throw new Exception())
-                            .When(_ => true)
-                            .Using<object>(_ => { })
-                            .When(_ => true));
-
-        // Assert
-        act.Should().NotThrow(
-            "a different assertion rule should handle the comparison before the exception throwing assertion rule is hit");
-    }
-
-    [Fact]
-    public void When_using_a_nested_equivalency_api_in_a_custom_assertion_rule_it_should_honor_the_rule()
-    {
-        // Arrange
-        var subject = new ClassWithSomeFieldsAndProperties
-        {
-            Property1 = "value1",
-            Property2 = "value2"
-        };
-
-        var expectation = new ClassWithSomeFieldsAndProperties
-        {
-            Property1 = "value1",
-            Property2 = "value3"
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expectation, options => options
-            .Using<ClassWithSomeFieldsAndProperties>(ctx =>
-                ctx.Subject.Should().BeEquivalentTo(ctx.Expectation, nestedOptions => nestedOptions.Excluding(x => x.Property2)))
-            .WhenTypeIs<ClassWithSomeFieldsAndProperties>());
-    }
-
-    [Fact]
-    public void When_a_predicate_matches_after_auto_conversion_it_should_execute_the_assertion()
-    {
-        // Arrange
-        var expectation = new
-        {
-            ThisIsMyDateTime = DateTime.Now
-        };
-
-        var actual = new
-        {
-            ThisIsMyDateTime = expectation.ThisIsMyDateTime.ToString(CultureInfo.InvariantCulture)
-        };
-
-        // Assert
-        actual.Should().BeEquivalentTo(expectation,
-            options => options
-                .WithAutoConversion()
-                .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
-                .WhenTypeIs<DateTime>());
-    }
-
-    #endregion
-
-    #region Equivalency Steps
-
-    [Fact]
-    public void When_an_equivalency_step_handles_the_comparison_later_equivalency_steps_should_not_be_ran()
-    {
-        // Arrange
-        var subject = new ClassWithOnlyAProperty();
-        var expected = new ClassWithOnlyAProperty();
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expected,
-            opts =>
-                opts.Using(new AlwaysHandleEquivalencyStep())
-                    .Using(new ThrowExceptionEquivalencyStep<InvalidOperationException>()));
-    }
-
-    [Fact]
-    public void When_a_user_equivalency_step_is_registered_it_should_run_before_the_built_in_steps()
-    {
-        // Arrange
-        var actual = new
-        {
-            Property = 123
-        };
-
-        var expected = new
-        {
-            Property = "123"
-        };
-
-        // Act
-        Action act = () => actual.Should().BeEquivalentTo(expected, options => options
-            .Using(new EqualityEquivalencyStep()));
-
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected*123*123*");
-    }
-
-    [Fact]
-    public void When_an_equivalency_does_not_handle_the_comparison_later_equivalency_steps_should_still_be_ran()
-    {
-        // Arrange
-        var subject = new ClassWithOnlyAProperty();
-        var expected = new ClassWithOnlyAProperty();
-
-        // Act
-        Action act =
-            () =>
-                subject.Should().BeEquivalentTo(expected,
-                    opts =>
-                        opts.Using(new NeverHandleEquivalencyStep())
-                            .Using(new ThrowExceptionEquivalencyStep<InvalidOperationException>()));
-
-        // Assert
-        act.Should().Throw<InvalidOperationException>();
-    }
-
-    [Fact]
-    public void When_multiple_equivalency_steps_are_added_they_should_be_executed_in_registration_order()
-    {
-        // Arrange
-        var subject = new ClassWithOnlyAProperty();
-        var expected = new ClassWithOnlyAProperty();
-
-        // Act
-        Action act =
-            () =>
-                subject.Should().BeEquivalentTo(expected,
-                    opts =>
-                        opts.Using(new ThrowExceptionEquivalencyStep<NotSupportedException>())
-                            .Using(new ThrowExceptionEquivalencyStep<InvalidOperationException>()));
-
-        // Assert
-        act.Should().Throw<NotSupportedException>();
-    }
-
-    private class ThrowExceptionEquivalencyStep<TException> : IEquivalencyStep
-        where TException : Exception, new()
-    {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
-            IValidateChildNodeEquivalency valueChildNodes)
-        {
-            throw new TException();
-        }
-    }
-
-    private class AlwaysHandleEquivalencyStep : IEquivalencyStep
-    {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
-            IValidateChildNodeEquivalency valueChildNodes)
-        {
-            return EquivalencyResult.EquivalencyProven;
-        }
-    }
-
-    private class NeverHandleEquivalencyStep : IEquivalencyStep
-    {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
-            IValidateChildNodeEquivalency valueChildNodes)
-        {
-            return EquivalencyResult.ContinueWithNext;
-        }
-    }
-
-    private class EqualityEquivalencyStep : IEquivalencyStep
-    {
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
-            IValidateChildNodeEquivalency valueChildNodes)
-        {
-            comparands.Subject.Should().Be(comparands.Expectation, context.Reason.FormattedMessage, context.Reason.Arguments);
-            return EquivalencyResult.EquivalencyProven;
-        }
-    }
-
-    internal class DoEquivalencyStep : IEquivalencyStep
-    {
-        private readonly Action doAction;
-
-        public DoEquivalencyStep(Action doAction)
-        {
-            this.doAction = doAction;
         }
 
-        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
-            IValidateChildNodeEquivalency valueChildNodes)
+        private class NeverHandleEquivalencyStep : IEquivalencyStep
         {
-            doAction();
-            return EquivalencyResult.EquivalencyProven;
+            public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+                IValidateChildNodeEquivalency valueChildNodes)
+            {
+                return EquivalencyResult.ContinueWithNext;
+            }
+        }
+
+        private class EqualityEquivalencyStep : IEquivalencyStep
+        {
+            public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+                IValidateChildNodeEquivalency valueChildNodes)
+            {
+                comparands.Subject.Should().Be(comparands.Expectation, context.Reason.FormattedMessage, context.Reason.Arguments);
+                return EquivalencyResult.EquivalencyProven;
+            }
+        }
+
+        [Fact]
+        public void Can_compare_null_against_null_with_custom_comparer_for_nullable_property()
+        {
+            var subject = new ClassWithNullableStructProperty();
+
+            subject.Should().BeEquivalentTo(new ClassWithNullableStructProperty(), o => o
+                .Using<StructWithProperties, StructWithPropertiesComparer>());
+        }
+
+        [Fact]
+        public void Can_compare_null_against_not_null_with_custom_comparer_for_nullable_property()
+        {
+            var subject = new ClassWithNullableStructProperty();
+            var unexpected = new ClassWithNullableStructProperty { Value = new StructWithProperties { Value = 42 } };
+
+            subject.Should().NotBeEquivalentTo(unexpected, o => o
+                .Using<StructWithProperties, StructWithPropertiesComparer>());
+        }
+
+        [Fact]
+        public void Can_compare_not_null_against_null_with_custom_comparer_for_nullable_property()
+        {
+            var subject = new ClassWithNullableStructProperty
+            {
+                Value = new StructWithProperties { Value = 42 },
+            };
+
+            subject.Should().NotBeEquivalentTo(new ClassWithNullableStructProperty(), o => o
+                .Using<StructWithProperties, StructWithPropertiesComparer>());
+        }
+
+        [Fact]
+        public void Can_compare_not_null_against_not_null_with_custom_comparer_for_nullable_property()
+        {
+            var subject = new ClassWithNullableStructProperty { Value = new StructWithProperties { Value = 42 } };
+            var expected = new ClassWithNullableStructProperty { Value = new StructWithProperties { Value = 42 } };
+
+            subject.Should().BeEquivalentTo(expected, o => o
+                .Using<StructWithProperties, StructWithPropertiesComparer>());
+        }
+
+        [Fact]
+        public void Can_compare_null_against_null_with_custom_nullable_comparer_for_nullable_property()
+        {
+            var subject = new ClassWithNullableStructProperty();
+
+            subject.Should().BeEquivalentTo(new ClassWithNullableStructProperty(), o => o
+                .Using<StructWithProperties?, StructWithPropertiesComparer>());
+        }
+
+        [Fact]
+        public void Can_compare_null_against_not_null_with_custom_nullable_comparer_for_nullable_property()
+        {
+            var subject = new ClassWithNullableStructProperty();
+            var unexpected = new ClassWithNullableStructProperty { Value = new StructWithProperties { Value = 42 } };
+
+            subject.Should().NotBeEquivalentTo(unexpected, o => o
+                .Using<StructWithProperties?, StructWithPropertiesComparer>()
+            );
+        }
+
+        [Fact]
+        public void Can_compare_not_null_against_null_with_custom_nullable_comparer_for_nullable_property()
+        {
+            var subject = new ClassWithNullableStructProperty { Value = new StructWithProperties { Value = 42 } };
+
+            subject.Should().NotBeEquivalentTo(new ClassWithNullableStructProperty(), o => o
+                .Using<StructWithProperties?, StructWithPropertiesComparer>()
+            );
+        }
+
+        [Fact]
+        public void Can_compare_not_null_against_not_null_with_custom_nullable_comparer_for_nullable_property()
+        {
+            var subject = new ClassWithNullableStructProperty { Value = new StructWithProperties { Value = 42 } };
+            var expected = new ClassWithNullableStructProperty { Value = new StructWithProperties { Value = 42 } };
+
+            subject.Should().BeEquivalentTo(expected, o => o
+                .Using<StructWithProperties?, StructWithPropertiesComparer>());
+        }
+
+        private class ClassWithNullableStructProperty
+        {
+            [UsedImplicitly]
+            public StructWithProperties? Value { get; set; }
+        }
+
+        private struct StructWithProperties
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public int Value { get; set; }
+        }
+
+        private class StructWithPropertiesComparer
+            : IEqualityComparer<StructWithProperties>, IEqualityComparer<StructWithProperties?>
+        {
+            public bool Equals(StructWithProperties x, StructWithProperties y) => Equals(x.Value, y.Value);
+
+            public int GetHashCode(StructWithProperties obj) => obj.Value;
+
+            public bool Equals(StructWithProperties? x, StructWithProperties? y) => Equals(x?.Value, y?.Value);
+
+            public int GetHashCode(StructWithProperties? obj) => obj?.Value ?? 0;
+        }
+
+        [Fact]
+        public void Can_compare_null_against_null_with_custom_comparer_for_property()
+        {
+            var subject = new ClassWithClassProperty();
+
+            subject.Should().BeEquivalentTo(new ClassWithClassProperty(), o => o
+                .Using<ClassProperty, ClassPropertyComparer>());
+        }
+
+        [Fact]
+        public void Can_compare_null_against_not_null_with_custom_comparer_for_property()
+        {
+            var subject = new ClassWithClassProperty();
+            var unexpected = new ClassWithClassProperty { Value = new ClassProperty { Value = 42 } };
+
+            subject.Should().NotBeEquivalentTo(unexpected, o => o
+                .Using<ClassProperty, ClassPropertyComparer>());
+        }
+
+        [Fact]
+        public void Can_compare_not_null_against_null_with_custom_comparer_for_property()
+        {
+            var subject = new ClassWithClassProperty { Value = new ClassProperty { Value = 42 } };
+
+            subject.Should().NotBeEquivalentTo(new ClassWithClassProperty(), o => o
+                .Using<ClassProperty, ClassPropertyComparer>());
+        }
+
+        [Fact]
+        public void Can_compare_not_null_against_not_null_with_custom_comparer_for_property()
+        {
+            var subject = new ClassWithClassProperty { Value = new ClassProperty { Value = 42 } };
+            var expected = new ClassWithClassProperty { Value = new ClassProperty { Value = 42 } };
+
+            subject.Should().BeEquivalentTo(expected, o => o
+                .Using<ClassProperty, ClassPropertyComparer>());
+        }
+
+        private class ClassWithClassProperty
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public ClassProperty Value { get; set; }
+        }
+
+        private class ClassProperty
+        {
+            public int Value { get; set; }
+        }
+
+        private class ClassPropertyComparer : IEqualityComparer<ClassProperty>
+        {
+            public bool Equals(ClassProperty x, ClassProperty y) => Equals(x?.Value, y?.Value);
+
+            public int GetHashCode(ClassProperty obj) => obj.Value;
         }
     }
-
-    [Fact]
-    public void Can_compare_null_against_null_with_custom_comparer_for_nullable_property()
-    {
-        // Arrange
-        var subject = new ClassWithNullableStructProperty();
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(new ClassWithNullableStructProperty(), o => o
-            .Using<StructWithProperties, StructWithPropertiesComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_null_against_not_null_with_custom_comparer_for_nullable_property()
-    {
-        // Arrange
-        var subject = new ClassWithNullableStructProperty();
-        var unexpected = new ClassWithNullableStructProperty
-        {
-            Value = new StructWithProperties
-            {
-                Value = 42
-            },
-        };
-
-        // Act / Assert
-        subject.Should().NotBeEquivalentTo(unexpected, o => o
-            .Using<StructWithProperties, StructWithPropertiesComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_not_null_against_null_with_custom_comparer_for_nullable_property()
-    {
-        // Arrange
-        var subject = new ClassWithNullableStructProperty
-        {
-            Value = new StructWithProperties
-            {
-                Value = 42
-            },
-        };
-
-        // Act / Assert
-        subject.Should().NotBeEquivalentTo(new ClassWithNullableStructProperty(), o => o
-            .Using<StructWithProperties, StructWithPropertiesComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_not_null_against_not_null_with_custom_comparer_for_nullable_property()
-    {
-        // Arrange
-        var subject = new ClassWithNullableStructProperty
-        {
-            Value = new StructWithProperties
-            {
-                Value = 42
-            },
-        };
-        var expected = new ClassWithNullableStructProperty
-        {
-            Value = new StructWithProperties
-            {
-                Value = 42
-            },
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expected, o => o
-            .Using<StructWithProperties, StructWithPropertiesComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_null_against_null_with_custom_nullable_comparer_for_nullable_property()
-    {
-        // Arrange
-        var subject = new ClassWithNullableStructProperty();
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(new ClassWithNullableStructProperty(), o => o
-            .Using<StructWithProperties?, StructWithPropertiesComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_null_against_not_null_with_custom_nullable_comparer_for_nullable_property()
-    {
-        // Arrange
-        var subject = new ClassWithNullableStructProperty();
-        var unexpected = new ClassWithNullableStructProperty
-        {
-            Value = new StructWithProperties
-            {
-                Value = 42
-            },
-        };
-
-        // Act / Assert
-        subject.Should().NotBeEquivalentTo(unexpected, o => o
-            .Using<StructWithProperties?, StructWithPropertiesComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_not_null_against_null_with_custom_nullable_comparer_for_nullable_property()
-    {
-        // Arrange
-        var subject = new ClassWithNullableStructProperty
-        {
-            Value = new StructWithProperties
-            {
-                Value = 42
-            },
-        };
-
-        // Act / Assert
-        subject.Should().NotBeEquivalentTo(new ClassWithNullableStructProperty(), o => o
-            .Using<StructWithProperties?, StructWithPropertiesComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_not_null_against_not_null_with_custom_nullable_comparer_for_nullable_property()
-    {
-        // Arrange
-        var subject = new ClassWithNullableStructProperty
-        {
-            Value = new StructWithProperties
-            {
-                Value = 42
-            },
-        };
-        var expected = new ClassWithNullableStructProperty
-        {
-            Value = new StructWithProperties
-            {
-                Value = 42
-            },
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expected, o => o
-            .Using<StructWithProperties?, StructWithPropertiesComparer>()
-        );
-    }
-
-    private class ClassWithNullableStructProperty
-    {
-        [UsedImplicitly]
-        public StructWithProperties? Value { get; set; }
-    }
-
-    private struct StructWithProperties
-    {
-        // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public int Value { get; set; }
-    }
-
-    private class StructWithPropertiesComparer : IEqualityComparer<StructWithProperties>, IEqualityComparer<StructWithProperties?>
-    {
-        public bool Equals(StructWithProperties x, StructWithProperties y) => Equals(x.Value, y.Value);
-
-        public int GetHashCode(StructWithProperties obj) => obj.Value;
-
-        public bool Equals(StructWithProperties? x, StructWithProperties? y) => Equals(x?.Value, y?.Value);
-
-        public int GetHashCode(StructWithProperties? obj) => obj?.Value ?? 0;
-    }
-
-    [Fact]
-    public void Can_compare_null_against_null_with_custom_comparer_for_property()
-    {
-        // Arrange
-        var subject = new ClassWithClassProperty();
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(new ClassWithClassProperty(), o => o
-            .Using<ClassProperty, ClassPropertyComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_null_against_not_null_with_custom_comparer_for_property()
-    {
-        // Arrange
-        var subject = new ClassWithClassProperty();
-        var unexpected = new ClassWithClassProperty
-        {
-            Value = new ClassProperty
-            {
-                Value = 42
-            },
-        };
-
-        // Act / Assert
-        subject.Should().NotBeEquivalentTo(unexpected, o => o
-            .Using<ClassProperty, ClassPropertyComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_not_null_against_null_with_custom_comparer_for_property()
-    {
-        // Arrange
-        var subject = new ClassWithClassProperty
-        {
-            Value = new ClassProperty
-            {
-                Value = 42
-            },
-        };
-
-        // Act / Assert
-        subject.Should().NotBeEquivalentTo(new ClassWithClassProperty(), o => o
-            .Using<ClassProperty, ClassPropertyComparer>()
-        );
-    }
-
-    [Fact]
-    public void Can_compare_not_null_against_not_null_with_custom_comparer_for_property()
-    {
-        // Arrange
-        var subject = new ClassWithClassProperty
-        {
-            Value = new ClassProperty
-            {
-                Value = 42
-            },
-        };
-        var expected = new ClassWithClassProperty
-        {
-            Value = new ClassProperty
-            {
-                Value = 42
-            },
-        };
-
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expected, o => o
-            .Using<ClassProperty, ClassPropertyComparer>()
-        );
-    }
-
-    private class ClassWithClassProperty
-    {
-        // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public ClassProperty Value { get; set; }
-    }
-
-    public class ClassProperty
-    {
-        public int Value { get; set; }
-    }
-
-    private class ClassPropertyComparer : IEqualityComparer<ClassProperty>
-    {
-        public bool Equals(ClassProperty x, ClassProperty y) => Equals(x?.Value, y?.Value);
-
-        public int GetHashCode(ClassProperty obj) => obj.Value;
-    }
-
-    #endregion
 }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/MemberConversionSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/MemberConversionSpecs.cs
@@ -9,69 +9,54 @@ public class MemberConversionSpecs
     [Fact]
     public void When_two_objects_have_the_same_properties_with_convertable_values_it_should_succeed()
     {
-        // Arrange
         var subject = new { Age = "37", Birthdate = "1973-09-20" };
-
         var other = new { Age = 37, Birthdate = new DateTime(1973, 9, 20) };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(other, o => o.WithAutoConversion());
     }
 
     [Fact]
     public void When_a_string_is_declared_equivalent_to_an_int_representing_the_numerals_it_should_pass()
     {
-        // Arrange
         var actual = new { Property = "32" };
-
         var expectation = new { Property = 32 };
 
-        // Act / Assert
-        actual.Should().BeEquivalentTo(expectation,
-            options => options.WithAutoConversion());
+        actual.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
     }
 
     [Fact]
     public void When_an_int_is_compared_equivalent_to_a_string_representing_the_number_it_should_pass()
     {
-        // Arrange
         var subject = new { Property = 32 };
         var expectation = new { Property = "32" };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
     }
 
     [Fact]
     public void Numbers_can_be_converted_to_enums()
     {
-        // Arrange
         var expectation = new { Property = EnumFour.Three };
         var subject = new { Property = 3UL };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
     }
 
     [Fact]
     public void Enums_are_not_converted_to_enums_of_different_type()
     {
-        // Arrange
         var expectation = new { Property = EnumTwo.Two };
         var subject = new { Property = EnumThree.Two };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
     }
 
     [Fact]
     public void Strings_are_not_converted_to_enums()
     {
-        // Arrange
         var expectation = new { Property = EnumTwo.Two };
         var subject = new { Property = "Two" };
 
-        // Act / Assert
         var act = () => subject.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
 
         act.Should().Throw<XunitException>();
@@ -80,60 +65,44 @@ public class MemberConversionSpecs
     [Fact]
     public void Numbers_that_are_out_of_range_cannot_be_converted_to_enums()
     {
-        // Arrange
         var expectation = new { Property = EnumFour.Three };
         var subject = new { Property = 4 };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*subject*Property*EnumFour*");
+        act.Should().Throw<XunitException>().WithMessage("*subject*Property*EnumFour*");
     }
 
     [Fact]
     public void When_injecting_a_null_predicate_into_WithAutoConversionFor_it_should_throw()
     {
-        // Arrange
         var subject = new object();
-
         var expectation = new object();
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation,
             options => options.WithAutoConversionFor(predicate: null));
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("predicate");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("predicate");
     }
 
     [Fact]
     public void When_only_a_single_property_is_and_can_be_converted_but_the_other_one_doesnt_match_it_should_throw()
     {
-        // Arrange
         var subject = new { Age = 32, Birthdate = "1973-09-20" };
-
         var expectation = new { Age = "32", Birthdate = new DateTime(1973, 9, 20) };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation,
             options => options.WithAutoConversionFor(x => x.Path.Contains("Birthdate")));
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage("*Age*String*int*");
     }
 
     [Fact]
     public void When_only_a_single_property_is_converted_and_the_other_matches_it_should_succeed()
     {
-        // Arrange
         var subject = new { Age = 32, Birthdate = "1973-09-20" };
-
         var expectation = new { Age = 32, Birthdate = new DateTime(1973, 9, 20) };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, options => options
             .WithAutoConversionFor(x => x.Path.Contains("Birthdate")));
     }
@@ -141,34 +110,25 @@ public class MemberConversionSpecs
     [Fact]
     public void When_injecting_a_null_predicate_into_WithoutAutoConversionFor_it_should_throw()
     {
-        // Arrange
         var subject = new object();
-
         var expectation = new object();
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation,
             options => options.WithoutAutoConversionFor(predicate: null));
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("predicate");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("predicate");
     }
 
     [Fact]
     public void When_a_specific_mismatching_property_is_excluded_from_conversion_it_should_throw()
     {
-        // Arrange
         var subject = new { Age = 32, Birthdate = "1973-09-20" };
-
         var expectation = new { Age = 32, Birthdate = new DateTime(1973, 9, 20) };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation, options => options
             .WithAutoConversion()
             .WithoutAutoConversionFor(x => x.Path.Contains("Birthdate")));
 
-        // Assert
         act.Should().Throw<XunitException>().Which.Message
             .Should().Match("Expected*<1973-09-20>*\"1973-09-20\"*", "{0} field is of mismatched type",
                 nameof(expectation.Birthdate))
@@ -180,11 +140,9 @@ public class MemberConversionSpecs
     [Fact]
     public void When_declaring_equivalent_a_convertable_object_that_is_equivalent_once_converted_it_should_pass()
     {
-        // Arrange
-        string str = "This is a test";
+        const string str = "This is a test";
         CustomConvertible obj = new(str);
 
-        // Act / Assert
         obj.Should().BeEquivalentTo(str, options => options.WithAutoConversion());
     }
 }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/MemberLessObjectsSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/MemberLessObjectsSpecs.cs
@@ -9,44 +9,35 @@ public class MemberLessObjectsSpecs
     [Fact]
     public void When_asserting_instances_of_an_anonymous_type_having_no_members_are_equivalent_it_should_fail()
     {
-        // Arrange / Act
         Action act = () => new { }.Should().BeEquivalentTo(new { });
 
-        // Assert
         act.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
     public void When_asserting_instances_of_a_class_having_no_members_are_equivalent_it_should_fail()
     {
-        // Arrange / Act
         Action act = () => new ClassWithNoMembers().Should().BeEquivalentTo(new ClassWithNoMembers());
 
-        // Assert
         act.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
     public void When_asserting_instances_of_Object_are_equivalent_it_should_fail()
     {
-        // Arrange / Act
         Action act = () => new object().Should().BeEquivalentTo(new object());
 
-        // Assert
         act.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
     public void When_asserting_instance_of_object_is_equivalent_to_null_it_should_fail_with_a_descriptive_message()
     {
-        // Arrange
         object actual = new();
         object expected = null;
 
-        // Act
-        Action act = () => actual.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+        Action act = () => actual.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("*Expected*to be <null>*we want to test the failure message*, but found System.Object*");
     }
@@ -54,29 +45,22 @@ public class MemberLessObjectsSpecs
     [Fact]
     public void When_asserting_null_is_equivalent_to_instance_of_object_it_should_fail()
     {
-        // Arrange
         object actual = null;
         object expected = new();
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*Expected*to be System.Object*but found <null>*");
+        act.Should().Throw<XunitException>().WithMessage("*Expected*to be System.Object*but found <null>*");
     }
 
     [Fact]
     public void When_an_type_only_exposes_fields_but_fields_are_ignored_in_the_equivalence_comparision_it_should_fail()
     {
-        // Arrange
         var object1 = new ClassWithOnlyAField { Value = 1 };
         var object2 = new ClassWithOnlyAField { Value = 101 };
 
-        // Act
         Action act = () => object1.Should().BeEquivalentTo(object2, opts => opts.IncludingAllDeclaredProperties());
 
-        // Assert
         act.Should().Throw<InvalidOperationException>("the objects have no members to compare.");
     }
 
@@ -84,68 +68,50 @@ public class MemberLessObjectsSpecs
     public void
         When_an_type_only_exposes_properties_but_properties_are_ignored_in_the_equivalence_comparision_it_should_fail()
     {
-        // Arrange
         var object1 = new ClassWithOnlyAProperty { Value = 1 };
         var object2 = new ClassWithOnlyAProperty { Value = 101 };
 
-        // Act
         Action act = () => object1.Should().BeEquivalentTo(object2, opts => opts.ExcludingProperties());
 
-        // Assert
         act.Should().Throw<InvalidOperationException>("the objects have no members to compare.");
     }
 
     [Fact]
     public void When_asserting_instances_of_arrays_of_types_in_System_are_equivalent_it_should_respect_the_runtime_type()
     {
-        // Arrange
-        object actual = new int[0];
-        object expectation = new int[0];
+        object actual = Array.Empty<int>();
+        object expectation = Array.Empty<int>();
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_throwing_on_missing_members_and_there_are_no_missing_members_should_not_throw()
     {
-        // Arrange
         var subject = new { Version = 2, Age = 36, };
-
         var expectation = new { Version = 2, Age = 36 };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expectation,
-            options => options.ThrowingOnMissingMembers());
+        subject.Should().BeEquivalentTo(expectation, options => options.ThrowingOnMissingMembers());
     }
 
     [Fact]
     public void When_throwing_on_missing_members_and_there_is_a_missing_member_should_throw()
     {
-        // Arrange
         var subject = new { Version = 2 };
-
         var expectation = new { Version = 2, Age = 36 };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expectation,
             options => options.ThrowingOnMissingMembers());
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expectation has property Age that the other object does not have*");
+        act.Should().Throw<XunitException>().WithMessage("Expectation has property Age that the other object does not have*");
     }
 
     [Fact]
     public void When_throwing_on_missing_members_and_there_is_an_additional_property_on_subject_should_not_throw()
     {
-        // Arrange
         var subject = new { Version = 2, Age = 36, Additional = 13 };
-
         var expectation = new { Version = 2, Age = 36 };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expectation,
-            options => options.ThrowingOnMissingMembers());
+        subject.Should().BeEquivalentTo(expectation, options => options.ThrowingOnMissingMembers());
     }
 }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -12,7 +12,6 @@ public class MemberMatchingSpecs
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
     public void When_excluding_missing_members_both_fields_and_properties_should_be_ignored()
     {
-        // Arrange
         var class1 = new ClassWithSomeFieldsAndProperties
         {
             Field1 = "Lorem",
@@ -22,40 +21,28 @@ public class MemberMatchingSpecs
             Property2 = "amet",
             Property3 = "consectetur"
         };
-
         var class2 = new { Field1 = "Lorem" };
 
-        // Act / Assert
         class1.Should().BeEquivalentTo(class2, opts => opts.ExcludingMissingMembers());
     }
 
     [Fact]
     public void When_a_property_shared_by_anonymous_types_doesnt_match_it_should_throw()
     {
-        // Arrange
         var subject = new { Age = 36 };
-
         var other = new { Age = 37 };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(other, options => options.ExcludingMissingMembers());
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
     [Fact]
     public void Nested_properties_can_be_mapped_using_a_nested_expression()
     {
-        // Arrange
         var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
+        var expectation = new ParentOfExpectationWithProperty2([new ExpectationWithProperty2 { Property2 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(
-        [
-            new ExpectationWithProperty2 { Property2 = "Hello" }
-        ]);
-
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ParentOfSubjectWithProperty1>(
@@ -66,15 +53,9 @@ public class MemberMatchingSpecs
     [Fact]
     public void Nested_properties_can_be_mapped_using_a_nested_type_and_property_names()
     {
-        // Arrange
         var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
+        var expectation = new ParentOfExpectationWithProperty2([new ExpectationWithProperty2 { Property2 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(
-        [
-            new ExpectationWithProperty2 { Property2 = "Hello" }
-        ]);
-
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Property2", "Property1"));
@@ -83,18 +64,10 @@ public class MemberMatchingSpecs
     [Fact]
     public void Nested_explicitly_implemented_properties_can_be_mapped_using_a_nested_type_and_property_names()
     {
-        // Arrange
-        var subject =
-            new ParentOfSubjectWithExplicitlyImplementedProperty(new[] { new SubjectWithExplicitImplementedProperty() });
-
+        var subject = new ParentOfSubjectWithExplicitlyImplementedProperty([new SubjectWithExplicitImplementedProperty()]);
         ((IProperty)subject.Children[0]).Property = "Hello";
+        var expectation = new ParentOfExpectationWithProperty2([new ExpectationWithProperty2 { Property2 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(
-        [
-            new ExpectationWithProperty2 { Property2 = "Hello" }
-        ]);
-
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ExpectationWithProperty2, SubjectWithExplicitImplementedProperty>("Property2", "Property"));
@@ -103,12 +76,9 @@ public class MemberMatchingSpecs
     [Fact]
     public void Nested_fields_can_be_mapped_using_a_nested_type_and_field_names()
     {
-        // Arrange
         var subject = new ClassWithSomeFieldsAndProperties { Field1 = "John", Field2 = "Mary" };
-
         var expectation = new ClassWithSomeFieldsAndProperties { Field1 = "Mary", Field2 = "John" };
 
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ClassWithSomeFieldsAndProperties, ClassWithSomeFieldsAndProperties>("Field1", "Field2")
@@ -118,15 +88,9 @@ public class MemberMatchingSpecs
     [Fact]
     public void Nested_properties_can_be_mapped_using_a_nested_type_and_a_property_expression()
     {
-        // Arrange
         var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
+        var expectation = new ParentOfExpectationWithProperty2([new ExpectationWithProperty2 { Property2 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(
-        [
-            new ExpectationWithProperty2 { Property2 = "Hello" }
-        ]);
-
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>(
@@ -136,12 +100,9 @@ public class MemberMatchingSpecs
     [Fact]
     public void Nested_properties_on_a_collection_can_be_mapped_using_a_dotted_path()
     {
-        // Arrange
         var subject = new { Parent = new[] { new SubjectWithProperty1 { Property1 = "Hello" } } };
-
         var expectation = new { Parent = new[] { new ExpectationWithProperty2 { Property2 = "Hello" } } };
 
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Parent[].Property2", "Parent[].Property1"));
@@ -150,12 +111,9 @@ public class MemberMatchingSpecs
     [Fact]
     public void Properties_can_be_mapped_by_name()
     {
-        // Arrange
         var subject = new SubjectWithProperty1 { Property1 = "Hello" };
-
         var expectation = new ExpectationWithProperty2 { Property2 = "Hello" };
 
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Property2", "Property1"));
@@ -164,17 +122,10 @@ public class MemberMatchingSpecs
     [Fact]
     public void Properties_can_be_mapped_by_name_to_an_explicitly_implemented_property()
     {
-        // Arrange
         var subject = new SubjectWithExplicitImplementedProperty();
-
         ((IProperty)subject).Property = "Hello";
+        var expectation = new ExpectationWithProperty2 { Property2 = "Hello" };
 
-        var expectation = new ExpectationWithProperty2
-        {
-            Property2 = "Hello"
-        };
-
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Property2", "Property"));
@@ -183,12 +134,9 @@ public class MemberMatchingSpecs
     [Fact]
     public void Fields_can_be_mapped_by_name()
     {
-        // Arrange
         var subject = new ClassWithSomeFieldsAndProperties { Field1 = "Hello", Field2 = "John" };
-
         var expectation = new ClassWithSomeFieldsAndProperties { Field1 = "John", Field2 = "Hello" };
 
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Field2", "Field1")
@@ -198,12 +146,9 @@ public class MemberMatchingSpecs
     [Fact]
     public void Fields_can_be_mapped_to_a_property_by_name()
     {
-        // Arrange
         var subject = new ClassWithSomeFieldsAndProperties { Property1 = "John" };
-
         var expectation = new ClassWithSomeFieldsAndProperties { Field1 = "John", };
 
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Field1", "Property1")
@@ -213,12 +158,9 @@ public class MemberMatchingSpecs
     [Fact]
     public void Properties_can_be_mapped_to_a_field_by_expression()
     {
-        // Arrange
         var subject = new ClassWithSomeFieldsAndProperties { Field1 = "John", };
-
         var expectation = new ClassWithSomeFieldsAndProperties { Property1 = "John" };
 
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ClassWithSomeFieldsAndProperties>(e => e.Property1, s => s.Field1)
@@ -228,12 +170,9 @@ public class MemberMatchingSpecs
     [Fact]
     public void Properties_can_be_mapped_to_inherited_properties()
     {
-        // Arrange
         var subject = new Derived { BaseProperty = "Hello World" };
-
         var expectation = new { AnotherProperty = "Hello World" };
 
-        // Act / Assert
         subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<Derived>(e => e.AnotherProperty, s => s.BaseProperty));
@@ -242,17 +181,13 @@ public class MemberMatchingSpecs
     [Fact]
     public void A_failed_assertion_reports_the_subjects_mapped_property()
     {
-        // Arrange
         var subject = new SubjectWithProperty1 { Property1 = "Hello" };
-
         var expectation = new ExpectationWithProperty2 { Property2 = "Hello2" };
 
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<SubjectWithProperty1>(e => e.Property2, e => e.Property1));
 
-        // Assert
         act.Should()
             .Throw<XunitException>()
             .WithMessage("Expected property subject.Property1 to be*Hello*");
@@ -264,15 +199,11 @@ public class MemberMatchingSpecs
         var subject = new SubjectWithProperty1();
         var expectation = new ExpectationWithProperty2();
 
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("", "Parent[0].Property1"));
 
-        // Assert
-        act.Should()
-            .Throw<ArgumentException>()
-            .WithMessage("*member path*");
+        act.Should().Throw<ArgumentException>().WithMessage("*member path*");
     }
 
     [Fact]
@@ -281,15 +212,11 @@ public class MemberMatchingSpecs
         var subject = new SubjectWithProperty1();
         var expectation = new ExpectationWithProperty2();
 
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Parent[0].Property1", ""));
 
-        // Assert
-        act.Should()
-            .Throw<ArgumentException>()
-            .WithMessage("*member path*");
+        act.Should().Throw<ArgumentException>().WithMessage("*member path*");
     }
 
     [Fact]
@@ -298,15 +225,11 @@ public class MemberMatchingSpecs
         var subject = new SubjectWithProperty1();
         var expectation = new ExpectationWithProperty2();
 
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping(null, "Parent[0].Property1"));
 
-        // Assert
-        act.Should()
-            .Throw<ArgumentException>()
-            .WithMessage("*member path*");
+        act.Should().Throw<ArgumentException>().WithMessage("*member path*");
     }
 
     [Fact]
@@ -315,15 +238,11 @@ public class MemberMatchingSpecs
         var subject = new SubjectWithProperty1();
         var expectation = new ExpectationWithProperty2();
 
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Parent[0].Property1", null));
 
-        // Assert
-        act.Should()
-            .Throw<ArgumentException>()
-            .WithMessage("*member path*");
+        act.Should().Throw<ArgumentException>().WithMessage("*member path*");
     }
 
     [Fact]
@@ -332,205 +251,123 @@ public class MemberMatchingSpecs
         var subject = new SubjectWithProperty1();
         var expectation = new ExpectationWithProperty2();
 
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Parent[].Property1", "OtherParent[].Property2"));
 
-        // Assert
-        act.Should()
-            .Throw<ArgumentException>()
-            .WithMessage("*parent*");
+        act.Should().Throw<ArgumentException>().WithMessage("*parent*");
     }
 
     [Fact]
     public void Numeric_indexes_in_the_path_are_not_allowed()
     {
         var subject = new { Parent = new[] { new SubjectWithProperty1 { Property1 = "Hello" } } };
-
         var expectation = new { Parent = new[] { new ExpectationWithProperty2 { Property2 = "Hello" } } };
 
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Parent[0].Property2", "Parent[0].Property1"));
 
-        // Assert
-        act.Should()
-            .Throw<ArgumentException>()
-            .WithMessage("*without specific index*");
+        act.Should().Throw<ArgumentException>().WithMessage("*without specific index*");
     }
 
     [Fact]
     public void Mapping_to_a_non_existing_subject_member_is_not_allowed()
     {
-        // Arrange
         var subject = new SubjectWithProperty1 { Property1 = "Hello" };
-
         var expectation = new ExpectationWithProperty2 { Property2 = "Hello" };
 
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Property2", "NonExistingProperty"));
 
-        // Assert
-        act.Should()
-            .Throw<MissingMemberException>()
-            .WithMessage("*not have member NonExistingProperty*");
+        act.Should().Throw<MissingMemberException>().WithMessage("*not have member NonExistingProperty*");
     }
 
     [Fact]
     public void A_null_subject_should_result_in_a_normal_assertion_failure()
     {
-        // Arrange
         SubjectWithProperty1 subject = null;
-
         ExpectationWithProperty2 expectation = new() { Property2 = "Hello" };
 
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping("Property2", "Property1"));
 
-        // Assert
-        act.Should()
-            .Throw<XunitException>()
-            .WithMessage("*Expected*ExpectationWithProperty2*found <null>*");
+        act.Should().Throw<XunitException>().WithMessage("*Expected*ExpectationWithProperty2*found <null>*");
     }
 
     [Fact]
     public void Nested_types_and_dotted_expectation_member_paths_cannot_be_combined()
     {
-        // Arrange
         var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
+        var expectation = new ParentOfExpectationWithProperty2([new ExpectationWithProperty2 { Property2 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(
-        [
-            new ExpectationWithProperty2 { Property2 = "Hello" }
-        ]);
-
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Parent.Property2", "Property1"));
 
-        // Assert
-        act.Should()
-            .Throw<ArgumentException>()
-            .WithMessage("*cannot be a nested path*");
+        act.Should().Throw<ArgumentException>().WithMessage("*cannot be a nested path*");
     }
 
     [Fact]
     public void Nested_types_and_dotted_subject_member_paths_cannot_be_combined()
     {
-        // Arrange
         var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
+        var expectation = new ParentOfExpectationWithProperty2([new ExpectationWithProperty2 { Property2 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(
-        [
-            new ExpectationWithProperty2 { Property2 = "Hello" }
-        ]);
-
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Property2", "Parent.Property1"));
 
-        // Assert
-        act.Should()
-            .Throw<ArgumentException>()
-            .WithMessage("*cannot be a nested path*");
+        act.Should().Throw<ArgumentException>().WithMessage("*cannot be a nested path*");
     }
 
     [Fact]
     public void The_member_name_on_a_nested_type_mapping_must_be_a_valid_member()
     {
-        // Arrange
         var subject = new ParentOfSubjectWithProperty1([new SubjectWithProperty1 { Property1 = "Hello" }]);
+        var expectation = new ParentOfExpectationWithProperty2([new ExpectationWithProperty2 { Property2 = "Hello" }]);
 
-        var expectation = new ParentOfExpectationWithProperty2(
-        [
-            new ExpectationWithProperty2 { Property2 = "Hello" }
-        ]);
-
-        // Act
         Action act = () => subject.Should()
             .BeEquivalentTo(expectation, opt => opt
                 .WithMapping<ExpectationWithProperty2, SubjectWithProperty1>("Property2", "NonExistingProperty"));
 
-        // Assert
-        act.Should()
-            .Throw<MissingMemberException>()
-            .WithMessage("*does not have member NonExistingProperty*");
+        act.Should().Throw<MissingMemberException>().WithMessage("*does not have member NonExistingProperty*");
     }
 
     [Fact]
     public void Exclusion_of_missing_members_works_with_mapping()
     {
-        // Arrange
-        var subject = new
-        {
-            Property1 = 1
-        };
+        var subject = new { Property1 = 1 };
+        var expectation = new { Property2 = 2, Ignore = 3 };
 
-        var expectation = new
-        {
-            Property2 = 2,
-            Ignore = 3
-        };
-
-        // Act / Assert
         subject.Should()
             .NotBeEquivalentTo(expectation, opt => opt
                 .WithMapping("Property2", "Property1")
-                .ExcludingMissingMembers()
-            );
+                .ExcludingMissingMembers());
     }
 
     [Fact]
     public void Mapping_works_with_exclusion_of_missing_members()
     {
-        // Arrange
-        var subject = new
-        {
-            Property1 = 1
-        };
+        var subject = new { Property1 = 1 };
+        var expectation = new { Property2 = 2, Ignore = 3 };
 
-        var expectation = new
-        {
-            Property2 = 2,
-            Ignore = 3
-        };
-
-        // Act / Assert
         subject.Should()
             .NotBeEquivalentTo(expectation, opt => opt
                 .ExcludingMissingMembers()
-                .WithMapping("Property2", "Property1")
-            );
+                .WithMapping("Property2", "Property1"));
     }
 
     [Fact]
     public void Can_map_members_of_a_root_collection()
     {
-        // Arrange
-        var entity = new Entity
-        {
-            EntityId = 1,
-            Name = "Test"
-        };
-
-        var dto = new EntityDto
-        {
-            Id = 1,
-            Name = "Test"
-        };
-
+        var entity = new Entity { EntityId = 1, Name = "Test" };
+        var dto = new EntityDto { Id = 1, Name = "Test" };
         Entity[] entityCol = [entity];
         EntityDto[] dtoCol = [dto];
 
-        // Act / Assert
         dtoCol.Should().BeEquivalentTo(entityCol, c =>
             c.WithMapping<EntityDto>(s => s.EntityId, d => d.Id));
     }
@@ -538,25 +375,22 @@ public class MemberMatchingSpecs
     [Fact]
     public void Can_explicitly_include_a_property_on_a_mapped_type()
     {
-        // Arrange
         var expectation = new CustomerWithPropertiesDto
         {
             AddressInformation = new CustomerWithPropertiesDto.ResidenceDto
             {
                 Address = "123 Main St",
-                IsValidated = true,
-            },
+                IsValidated = true
+            }
         };
-
         var subject = new CustomerWithProperty
         {
             Address = new CustomerWithProperty.Residence
             {
-                Address = "123 Main St",
-            },
+                Address = "123 Main St"
+            }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, o => o
             .Including(r => r.AddressInformation.Address)
             .WithMapping<CustomerWithPropertiesDto, CustomerWithProperty>(s => s.AddressInformation, d => d.Address));
@@ -565,25 +399,22 @@ public class MemberMatchingSpecs
     [Fact]
     public void Can_exclude_a_property_on_a_mapped_type()
     {
-        // Arrange
         var expectation = new CustomerWithPropertiesDto
         {
             AddressInformation = new CustomerWithPropertiesDto.ResidenceDto
             {
                 Address = "123 Main St",
-                IsValidated = true,
-            },
+                IsValidated = true
+            }
         };
-
         var subject = new CustomerWithProperty
         {
             Address = new CustomerWithProperty.Residence
             {
-                Address = "123 Main St",
-            },
+                Address = "123 Main St"
+            }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, o => o
             .Excluding(r => r.AddressInformation.IsValidated)
             .WithMapping<CustomerWithPropertiesDto, CustomerWithProperty>(s => s.AddressInformation, d => d.Address));
@@ -592,25 +423,22 @@ public class MemberMatchingSpecs
     [Fact]
     public void Can_explicitly_include_a_field_on_a_mapped_type()
     {
-        // Arrange
         var expectation = new CustomerWithFieldDto
         {
             AddressInformation = new CustomerWithFieldDto.ResidenceDto
             {
                 Address = "123 Main St",
-                IsValidated = true,
-            },
+                IsValidated = true
+            }
         };
-
         var subject = new CustomerWithField
         {
             Address = new CustomerWithField.Residence
             {
-                Address = "123 Main St",
-            },
+                Address = "123 Main St"
+            }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, o => o
             .Including(r => r.AddressInformation.Address)
             .WithMapping<CustomerWithFieldDto, CustomerWithField>(s => s.AddressInformation, d => d.Address));
@@ -619,25 +447,22 @@ public class MemberMatchingSpecs
     [Fact]
     public void Can_exclude_a_field_on_a_mapped_type()
     {
-        // Arrange
         var expectation = new CustomerWithFieldDto
         {
             AddressInformation = new CustomerWithFieldDto.ResidenceDto
             {
                 Address = "123 Main St",
-                IsValidated = true,
-            },
+                IsValidated = true
+            }
         };
-
         var subject = new CustomerWithField
         {
             Address = new CustomerWithField.Residence
             {
-                Address = "123 Main St",
-            },
+                Address = "123 Main St"
+            }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation, o => o
             .Excluding(r => r.AddressInformation.IsValidated)
             .WithMapping<CustomerWithFieldDto, CustomerWithField>(s => s.AddressInformation, d => d.Address));

--- a/Tests/AwesomeAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/NestedPropertiesSpecs.cs
@@ -10,44 +10,35 @@ public class NestedPropertiesSpecs
     [Fact]
     public void When_all_the_properties_of_the_nested_objects_are_equal_it_should_succeed()
     {
-        // Arrange
         var subject = new Root
         {
             Text = "Root",
             Level = new Level1 { Text = "Level1", Level = new Level2 { Text = "Level2" } }
         };
-
         var expected = new RootDto
         {
             Text = "Root",
             Level = new Level1Dto { Text = "Level1", Level = new Level2Dto { Text = "Level2" } }
         };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public void When_the_expectation_contains_a_nested_null_it_should_properly_report_the_difference()
     {
-        // Arrange
         var subject = new Root { Text = "Root", Level = new Level1 { Text = "Level1", Level = new Level2() } };
-
         var expected = new RootDto { Text = "Root", Level = new Level1Dto { Text = "Level1", Level = null } };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("*Expected*Level.Level*to be <null>, but found*Level2*Without automatic conversion*");
     }
 
     [Fact]
-    public void
-        When_not_all_the_properties_of_the_nested_objects_are_equal_but_nested_objects_are_excluded_it_should_succeed()
+    public void When_not_all_the_properties_of_the_nested_objects_are_equal_but_nested_objects_are_excluded_it_should_succeed()
     {
-        // Arrange
         var subject = new
         {
             Property = new ClassWithValueSemanticsOnSingleProperty
@@ -56,7 +47,6 @@ public class NestedPropertiesSpecs
                 NestedProperty = "Should be ignored"
             }
         };
-
         var expected = new
         {
             Property = new ClassWithValueSemanticsOnSingleProperty
@@ -66,23 +56,17 @@ public class NestedPropertiesSpecs
             }
         };
 
-        // Act / Assert
-        subject.Should().BeEquivalentTo(expected,
-            options => options.WithoutRecursing());
+        subject.Should().BeEquivalentTo(expected, options => options.WithoutRecursing());
     }
 
     [Fact]
     public void When_nested_objects_should_be_excluded_it_should_do_a_simple_equality_check_instead()
     {
-        // Arrange
         var item = new Item { Child = new Item() };
 
-        // Act
         Action act = () => item.Should().BeEquivalentTo(new Item(), options => options.WithoutRecursing());
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected*Item*null*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Item*null*");
     }
 
     public class Item
@@ -93,22 +77,17 @@ public class NestedPropertiesSpecs
     [Fact]
     public void When_not_all_the_properties_of_the_nested_objects_are_equal_it_should_throw()
     {
-        // Arrange
         var subject = new Root { Text = "Root", Level = new Level1 { Text = "Level1" } };
-
         var expected = new RootDto { Text = "Root", Level = new Level1Dto { Text = "Level2" } };
 
-        // Act
         Action act = () =>
             subject.Should().BeEquivalentTo(expected);
 
-        // Assert
+        // Checking exception message exactly is against general guidelines,
+        // but in that case it was done on purpose, so that we have at least a single
+        // test confirming that whole mechanism of gathering description from
+        // equivalency steps works.
         act.Should().Throw<XunitException>().Which.Message
-
-            // Checking exception message exactly is against general guidelines
-            // but in that case it was done on purpose, so that we have at least have a single
-            // test confirming that whole mechanism of gathering description from
-            // equivalency steps works.
             .Should().Be("""
                 Expected property subject.Level.Text to be the same string, but they differ at index 5:
                         ↓ (actual)
@@ -133,18 +112,12 @@ public class NestedPropertiesSpecs
     [Fact]
     public void When_the_actual_nested_object_is_null_it_should_throw()
     {
-        // Arrange
         var subject = new Root { Text = "Root", Level = new Level1 { Text = "Level2" } };
-
         var expected = new RootDto { Text = "Root", Level = null };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act
-            .Should().Throw<XunitException>()
-            .WithMessage("Expected*Level*to be <null>*, but found*Level1*Level2*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Level*to be <null>*, but found*Level1*Level2*");
     }
 
     public class StringSubContainer
@@ -175,13 +148,11 @@ public class NestedPropertiesSpecs
     [Fact]
     public void When_deeply_nested_strings_dont_match_it_should_properly_report_the_mismatches()
     {
-        // Arrange
         MyClass2[] expected =
         [
             new MyClass2 { One = new StringContainer("EXPECTED", "EXPECTED"), Two = new StringContainer("CORRECT") },
             new MyClass2()
         ];
-
         MyClass2[] actual =
         [
             new MyClass2
@@ -191,123 +162,89 @@ public class NestedPropertiesSpecs
             new MyClass2()
         ];
 
-        // Act
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*EXPECTED*INCORRECT*EXPECTED*INCORRECT*");
+        act.Should().Throw<XunitException>().WithMessage("*EXPECTED*INCORRECT*EXPECTED*INCORRECT*");
     }
 
     [Fact]
     public void When_the_nested_object_property_is_null_it_should_throw()
     {
-        // Arrange
         var subject = new Root { Text = "Root", Level = null };
-
         var expected = new RootDto { Text = "Root", Level = new Level1Dto { Text = "Level2" } };
 
-        // Act
-        Action act = () =>
-            subject.Should().BeEquivalentTo(expected);
+        Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act
-            .Should().Throw<XunitException>()
+        act.Should().Throw<XunitException>()
             .WithMessage("Expected property subject.Level*to be*Level1Dto*Level2*, but found <null>*");
     }
 
     [Fact]
     public void When_not_all_the_properties_of_the_nested_object_exist_on_the_expected_object_it_should_throw()
     {
-        // Arrange
         var subject = new { Level = new { Text = "Level1", } };
-
         var expected = new { Level = new { Text = "Level1", OtherProperty = "OtherProperty" } };
 
-        // Act
         Action act = () => subject.Should().BeEquivalentTo(expected);
 
-        // Assert
-        act
-            .Should().Throw<XunitException>()
+        act.Should().Throw<XunitException>()
             .WithMessage("Expectation has property Level.OtherProperty that the other object does not have*");
     }
 
     [Fact]
     public void When_all_the_shared_properties_of_the_nested_objects_are_equal_it_should_succeed()
     {
-        // Arrange
         var subject = new { Level = new { Text = "Level1", Property = "Property" } };
-
         var expected = new { Level = new { Text = "Level1", OtherProperty = "OtherProperty" } };
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expected, options => options.ExcludingMissingMembers());
     }
 
     [Fact]
     public void When_deeply_nested_properties_do_not_have_all_equal_values_it_should_throw()
     {
-        // Arrange
         var root = new Root
         {
             Text = "Root",
             Level = new Level1 { Text = "Level1", Level = new Level2 { Text = "Level2" } }
         };
-
         var rootDto = new RootDto
         {
             Text = "Root",
             Level = new Level1Dto { Text = "Level1", Level = new Level2Dto { Text = "A wrong text value" } }
         };
 
-        // Act
         Action act = () => root.Should().BeEquivalentTo(rootDto);
 
-        // Assert
-        act
-            .Should().Throw<XunitException>()
-            .WithMessage(
-                "Expected*Level.Level.Text*to be *\"Level2\"*A wrong text value*");
+        act.Should().Throw<XunitException>().WithMessage("Expected*Level.Level.Text*to be *\"Level2\"*A wrong text value*");
     }
 
     [Fact]
     public void When_two_objects_have_the_same_nested_objects_it_should_not_throw()
     {
-        // Arrange
         var c1 = new ClassOne();
         var c2 = new ClassOne();
 
-        // Act / Assert
         c1.Should().BeEquivalentTo(c2);
     }
 
     [Fact]
     public void When_a_property_of_a_nested_object_doesnt_match_it_should_clearly_indicate_the_path()
     {
-        // Arrange
         var c1 = new ClassOne();
-        var c2 = new ClassOne();
-        c2.RefOne.ValTwo = 2;
+        var c2 = new ClassOne { RefOne = { ValTwo = 2 } };
 
-        // Act
         Action act = () => c1.Should().BeEquivalentTo(c2);
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("Expected property c1.RefOne.ValTwo to be 2, but found 3*");
+        act.Should().Throw<XunitException>().WithMessage("Expected property c1.RefOne.ValTwo to be 2, but found 3*");
     }
 
     [Fact]
     public void Should_support_nested_collections_containing_empty_objects()
     {
-        // Arrange
         OuterWithObject[] orig = [new OuterWithObject { MyProperty = [new Inner()] }];
-
         OuterWithObject[] expectation = [new OuterWithObject { MyProperty = [new Inner()] }];
 
-        // Act / Assert
         orig.Should().BeEquivalentTo(expectation);
     }
 

--- a/Tests/AwesomeAssertions.Equivalency.Specs/NonEquivalencySpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/NonEquivalencySpecs.cs
@@ -9,76 +9,60 @@ public class NonEquivalencySpecs
     [Fact]
     public void When_asserting_inequivalence_of_equal_ints_as_object_it_should_fail()
     {
-        // Arrange
         object i1 = 1;
         object i2 = 1;
 
-        // Act
         Action act = () => i1.Should().NotBeEquivalentTo(i2);
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
     [Fact]
     public void When_asserting_inequivalence_of_unequal_ints_as_object_it_should_succeed()
     {
-        // Arrange
         object i1 = 1;
         object i2 = 2;
 
-        // Act / Assert
         i1.Should().NotBeEquivalentTo(i2);
     }
 
     [Fact]
     public void When_asserting_inequivalence_of_equal_strings_as_object_it_should_fail()
     {
-        // Arrange
         object s1 = "A";
         object s2 = "A";
 
-        // Act
         Action act = () => s1.Should().NotBeEquivalentTo(s2);
 
-        // Assert
         act.Should().Throw<XunitException>();
     }
 
     [Fact]
     public void When_asserting_inequivalence_of_unequal_strings_as_object_it_should_succeed()
     {
-        // Arrange
         object s1 = "A";
         object s2 = "B";
 
-        // Act / Assert
         s1.Should().NotBeEquivalentTo(s2);
     }
 
     [Fact]
     public void When_asserting_inequivalence_of_equal_classes_it_should_fail()
     {
-        // Arrange
         var o1 = new { Name = "A" };
         var o2 = new { Name = "A" };
 
-        // Act
         Action act = () => o1.Should().NotBeEquivalentTo(o2, "some {0}", "reason");
 
-        // Assert
-        act.Should().Throw<XunitException>()
-            .WithMessage("*some reason*");
+        act.Should().Throw<XunitException>().WithMessage("*some reason*");
     }
 
     [Fact]
     public void When_asserting_inequivalence_of_unequal_classes_it_should_succeed()
     {
-        // Arrange
         var o1 = new { Name = "A" };
         var o2 = new { Name = "B" };
 
-        // Act / Assert
         o1.Should().NotBeEquivalentTo(o2);
     }
 }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/ObjectReferenceSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/ObjectReferenceSpecs.cs
@@ -28,7 +28,6 @@ public class ObjectReferenceSpecs
 
         // Arrange
         var obj = new object();
-
         var x = new ObjectReference(obj, xPath);
         var y = new ObjectReference(obj, yPath);
 

--- a/Tests/AwesomeAssertions.Equivalency.Specs/RecordSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/RecordSpecs.cs
@@ -10,7 +10,6 @@ public class RecordSpecs
     public void When_the_subject_is_a_record_it_should_compare_it_by_its_members()
     {
         var actual = new MyRecord { StringField = "foo", CollectionProperty = ["bar", "zip", "foo"] };
-
         var expected = new MyRecord { StringField = "foo", CollectionProperty = ["foo", "bar", "zip"] };
 
         actual.Should().BeEquivalentTo(expected);
@@ -20,7 +19,6 @@ public class RecordSpecs
     public void When_the_subject_is_a_record_struct_it_should_compare_it_by_its_members()
     {
         var actual = new MyRecordStruct("foo", ["bar", "zip", "foo"]);
-
         var expected = new MyRecordStruct("foo", ["bar", "zip", "foo"]);
 
         actual.Should().BeEquivalentTo(expected);
@@ -30,24 +28,20 @@ public class RecordSpecs
     public void When_the_subject_is_a_record_it_should_mention_that_in_the_configuration_output()
     {
         var actual = new MyRecord { StringField = "foo", };
-
         var expected = new MyRecord { StringField = "bar", };
 
         Action act = () => actual.Should().BeEquivalentTo(expected);
 
-        act.Should().Throw<XunitException>()
-            .WithMessage("*Compare records by their members*");
+        act.Should().Throw<XunitException>().WithMessage("*Compare records by their members*");
     }
 
     [Fact]
     public void When_a_record_should_be_treated_as_a_value_type_it_should_use_its_equality_for_comparing()
     {
         var actual = new MyRecord { StringField = "foo", CollectionProperty = ["bar", "zip", "foo"] };
-
         var expected = new MyRecord { StringField = "foo", CollectionProperty = ["foo", "bar", "zip"] };
 
-        Action act = () => actual.Should().BeEquivalentTo(expected, o => o
-            .ComparingByValue<MyRecord>());
+        Action act = () => actual.Should().BeEquivalentTo(expected, o => o.ComparingByValue<MyRecord>());
 
         act.Should().Throw<XunitException>()
             .WithMessage("*Expected*MyRecord*but found*MyRecord*")
@@ -58,7 +52,6 @@ public class RecordSpecs
     public void When_all_records_should_be_treated_as_value_types_it_should_use_equality_for_comparing()
     {
         var actual = new MyRecord { StringField = "foo", CollectionProperty = ["bar", "zip", "foo"] };
-
         var expected = new MyRecord { StringField = "foo", CollectionProperty = ["foo", "bar", "zip"] };
 
         Action act = () => actual.Should().BeEquivalentTo(expected, o => o
@@ -74,7 +67,6 @@ public class RecordSpecs
         When_all_records_except_a_specific_type_should_be_treated_as_value_types_it_should_compare_that_specific_type_by_its_members()
     {
         var actual = new MyRecord { StringField = "foo", CollectionProperty = ["bar", "zip", "foo"] };
-
         var expected = new MyRecord { StringField = "foo", CollectionProperty = ["foo", "bar", "zip"] };
 
         actual.Should().BeEquivalentTo(expected, o => o
@@ -86,7 +78,6 @@ public class RecordSpecs
     public void When_global_record_comparing_options_are_chained_it_should_ensure_the_last_one_wins()
     {
         var actual = new MyRecord { CollectionProperty = ["bar", "zip", "foo"] };
-
         var expected = new MyRecord { CollectionProperty = ["foo", "bar", "zip"] };
 
         actual.Should().BeEquivalentTo(expected, o => o

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Accessibility.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Accessibility.cs
@@ -13,110 +13,55 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_a_property_is_write_only_it_should_be_ignored()
         {
-            // Arrange
-            var expected = new ClassWithWriteOnlyProperty
-            {
-                WriteOnlyProperty = 123,
-                SomeOtherProperty = "whatever"
-            };
+            var expected = new ClassWithWriteOnlyProperty { WriteOnlyProperty = 123, SomeOtherProperty = "whatever" };
+            var subject = new { SomeOtherProperty = "whatever" };
 
-            var subject = new
-            {
-                SomeOtherProperty = "whatever"
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
         public void When_a_property_is_private_it_should_be_ignored()
         {
-            // Arrange
-            var subject = new Customer("MyPassword")
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
+            var subject = new Customer("MyPassword") { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
+            var other = new Customer("SomeOtherPassword") { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
 
-            var other = new Customer("SomeOtherPassword")
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(other);
         }
 
         [Fact]
         public void When_a_field_is_private_it_should_be_ignored()
         {
-            // Arrange
-            var subject = new ClassWithAPrivateField(1234)
-            {
-                Value = 1
-            };
+            var subject = new ClassWithAPrivateField(1234) { Value = 1 };
+            var other = new ClassWithAPrivateField(54321) { Value = 1 };
 
-            var other = new ClassWithAPrivateField(54321)
-            {
-                Value = 1
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(other);
         }
 
         [Fact]
         public void When_a_property_is_protected_it_should_be_ignored()
         {
-            // Arrange
-            var subject = new Customer
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
-
+            var subject = new Customer { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
             subject.SetProtected("ActualValue");
-
-            var expected = new Customer
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
-
+            var expected = new Customer { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
             expected.SetProtected("ExpectedValue");
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
         public void When_a_property_is_internal_and_it_should_be_included_it_should_fail_the_assertion()
         {
-            // Arrange
             var actual = new ClassWithInternalProperty
             {
-                PublicProperty = "public",
-                InternalProperty = "internal",
-                ProtectedInternalProperty = "internal"
+                PublicProperty = "public", InternalProperty = "internal", ProtectedInternalProperty = "internal"
             };
-
             var expected = new ClassWithInternalProperty
             {
-                PublicProperty = "public",
-                InternalProperty = "also internal",
-                ProtectedInternalProperty = "also internal"
+                PublicProperty = "public", InternalProperty = "also internal", ProtectedInternalProperty = "also internal"
             };
 
-            // Act
             Action act = () => actual.Should().BeEquivalentTo(expected, options => options.IncludingInternalProperties());
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("*InternalProperty*internal*also internal*ProtectedInternalProperty*");
         }
@@ -136,47 +81,32 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_a_field_is_internal_it_should_be_excluded_from_the_comparison()
         {
-            // Arrange
             var actual = new ClassWithInternalField
             {
-                PublicField = "public",
-                InternalField = "internal",
-                ProtectedInternalField = "internal"
+                PublicField = "public", InternalField = "internal", ProtectedInternalField = "internal"
             };
-
             var expected = new ClassWithInternalField
             {
-                PublicField = "public",
-                InternalField = "also internal",
-                ProtectedInternalField = "also internal"
+                PublicField = "public", InternalField = "also internal", ProtectedInternalField = "also internal"
             };
 
-            // Act / Assert
             actual.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
         public void When_a_field_is_internal_and_it_should_be_included_it_should_fail_the_assertion()
         {
-            // Arrange
             var actual = new ClassWithInternalField
             {
-                PublicField = "public",
-                InternalField = "internal",
-                ProtectedInternalField = "internal"
+                PublicField = "public", InternalField = "internal", ProtectedInternalField = "internal"
             };
-
             var expected = new ClassWithInternalField
             {
-                PublicField = "public",
-                InternalField = "also internal",
-                ProtectedInternalField = "also internal"
+                PublicField = "public", InternalField = "also internal", ProtectedInternalField = "also internal"
             };
 
-            // Act
             Action act = () => actual.Should().BeEquivalentTo(expected, options => options.IncludingInternalFields());
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("*InternalField*internal*also internal*ProtectedInternalField*");
         }
 
@@ -198,30 +128,22 @@ public partial class SelectionRulesSpecs
             // Arrange
             var actual = new ClassWithInternalProperty
             {
-                PublicProperty = "public",
-                InternalProperty = "internal",
-                ProtectedInternalProperty = "internal"
+                PublicProperty = "public", InternalProperty = "internal", ProtectedInternalProperty = "internal"
             };
-
             var expected = new ClassWithInternalProperty
             {
-                PublicProperty = "public",
-                InternalProperty = "also internal",
-                ProtectedInternalProperty = "also internal"
+                PublicProperty = "public", InternalProperty = "also internal", ProtectedInternalProperty = "also internal"
             };
 
-            // Act / Assert
             actual.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
         public void Private_protected_properties_are_ignored()
         {
-            // Arrange
             var subject = new ClassWithPrivateProtectedProperty("Name", 13);
             var other = new ClassWithPrivateProtectedProperty("Name", 37);
 
-            // Act/Assert
             subject.Should().BeEquivalentTo(other);
         }
 
@@ -243,11 +165,9 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Private_protected_fields_are_ignored()
         {
-            // Arrange
             var subject = new ClassWithPrivateProtectedField("Name", 13);
             var other = new ClassWithPrivateProtectedField("Name", 37);
 
-            // Act/Assert
             subject.Should().BeEquivalentTo(other);
         }
 
@@ -269,25 +189,15 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Normal_properties_have_priority_over_explicitly_implemented_properties()
         {
-            // Arrange
-            var instance = new MyClass
-            {
-                Message = "instance string message",
-            };
+            var instance = new MyClass { Message = "instance string message" };
             ((IMyInterface)instance).Message = 42;
             instance.Items.AddRange([1, 2, 3]);
-
-            var other = new MyClass
-            {
-                Message = "other string message",
-            };
+            var other = new MyClass { Message = "other string message" };
             ((IMyInterface)other).Message = 42;
             other.Items.AddRange([1, 2, 27]);
 
-            // Act
             Action act = () => instance.Should().BeEquivalentTo(other);
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "*Expected property *.Message to be the same string*" +

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Basic.cs
@@ -15,45 +15,23 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Property_names_are_case_sensitive()
         {
-            // Arrange
-            var subject = new
-            {
-                Name = "John"
-            };
+            var subject = new { Name = "John" };
+            var other = new { name = "John" };
 
-            var other = new
-            {
-                name = "John"
-            };
-
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(other);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expectation*name**other*not have*");
+            act.Should().Throw<XunitException>().WithMessage("Expectation*name**other*not have*");
         }
 
         [Fact]
         public void Field_names_are_case_sensitive()
         {
-            // Arrange
-            var subject = new ClassWithFieldInUpperCase
-            {
-                Name = "John"
-            };
+            var subject = new ClassWithFieldInUpperCase { Name = "John" };
+            var other = new ClassWithFieldInLowerCase { name = "John" };
 
-            var other = new ClassWithFieldInLowerCase
-            {
-                name = "John"
-            };
-
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(other);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expectation*name**other*not have*");
+            act.Should().Throw<XunitException>().WithMessage("Expectation*name**other*not have*");
         }
 
         private class ClassWithFieldInLowerCase
@@ -73,18 +51,9 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_a_property_is_an_indexer_it_should_be_ignored()
         {
-            // Arrange
-            var expected = new ClassWithIndexer
-            {
-                Foo = "test"
-            };
+            var expected = new ClassWithIndexer { Foo = "test" };
+            var result = new ClassWithIndexer { Foo = "test" };
 
-            var result = new ClassWithIndexer
-            {
-                Foo = "test"
-            };
-
-            // Act / Assert
             result.Should().BeEquivalentTo(expected);
         }
 
@@ -93,86 +62,54 @@ public partial class SelectionRulesSpecs
             [UsedImplicitly]
             public object Foo { get; set; }
 
-            public string this[int n] =>
-                n.ToString(
-                    CultureInfo.InvariantCulture);
+            public string this[int n] => n.ToString(CultureInfo.InvariantCulture);
         }
 
         [Fact]
         public void When_the_expected_object_has_a_property_not_available_on_the_subject_it_should_throw()
         {
-            // Arrange
-            var subject = new
-            {
-            };
-
+            var subject = new { };
             var other = new
             {
                 // ReSharper disable once StringLiteralTypo
                 City = "Rijswijk"
             };
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(other);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expectation has property City that the other object does not have*");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expectation has property City that the other object does not have*");
         }
 
         [Fact]
         public void When_equally_named_properties_are_type_incompatible_it_should_throw()
         {
-            // Arrange
-            var subject = new
-            {
-                Type = "A"
-            };
+            var subject = new { Type = "A" };
+            var other = new { Type = 36 };
 
-            var other = new
-            {
-                Type = 36
-            };
-
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(other);
 
-            // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected property subject.Type to be 36, but found*\"A\"*");
+            act.Should().Throw<XunitException>().WithMessage("Expected property subject.Type to be 36, but found*\"A\"*");
         }
 
         [Fact]
         public void When_multiple_properties_mismatch_it_should_report_all_of_them()
         {
-            // Arrange
             var subject = new
             {
                 Property1 = "A",
                 Property2 = "B",
-                SubType1 = new
-                {
-                    SubProperty1 = "C",
-                    SubProperty2 = "D"
-                }
+                SubType1 = new { SubProperty1 = "C", SubProperty2 = "D" }
             };
-
             var other = new
             {
                 Property1 = "1",
                 Property2 = "2",
-                SubType1 = new
-                {
-                    SubProperty1 = "3",
-                    SubProperty2 = "D"
-                }
+                SubType1 = new { SubProperty1 = "3", SubProperty2 = "D" }
             };
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(other);
 
-            // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage("""
@@ -186,26 +123,17 @@ public partial class SelectionRulesSpecs
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public void Including_all_declared_properties_excludes_all_fields()
         {
-            // Arrange
             var class1 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor",
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
-
             var class2 = new ClassWithSomeFieldsAndProperties
             {
                 Field1 = "foo",
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
 
-            // Act / Assert
             class1.Should().BeEquivalentTo(class2, opts => opts.IncludingAllDeclaredProperties());
         }
 
@@ -213,25 +141,16 @@ public partial class SelectionRulesSpecs
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public void Including_all_runtime_properties_excludes_all_fields()
         {
-            // Arrange
             object class1 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor",
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
-
             object class2 = new ClassWithSomeFieldsAndProperties
             {
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
 
-            // Act / Assert
             class1.Should().BeEquivalentTo(class2, opts => opts.IncludingAllRuntimeProperties());
         }
 
@@ -239,60 +158,31 @@ public partial class SelectionRulesSpecs
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public void Respecting_the_runtime_type_includes_both_properties_and_fields_included()
         {
-            // Arrange
-            object class1 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "Lorem",
-                Property1 = "sit"
-            };
-
+            object class1 = new ClassWithSomeFieldsAndProperties { Field1 = "Lorem", Property1 = "sit" };
             object class2 = new ClassWithSomeFieldsAndProperties();
 
-            // Act
             Action act =
                 () => class1.Should().BeEquivalentTo(class2, opts => opts.PreferringRuntimeMemberTypes());
 
-            // Assert
             act.Should().Throw<XunitException>().Which.Message.Should().Contain("Field1").And.Contain("Property1");
         }
 
         [Fact]
         public void A_nested_class_without_properties_inside_a_collection_is_fine()
         {
-            // Arrange
-            var sut = new List<BaseClassPointingToClassWithoutProperties>
-            {
-                new()
-                {
-                    Name = "theName"
-                }
-            };
+            var sut = new List<BaseClassPointingToClassWithoutProperties> { new() { Name = "theName" } };
 
-            // Act / Assert
-            sut.Should().BeEquivalentTo(
-            [
-                new BaseClassPointingToClassWithoutProperties
-                {
-                    Name = "theName"
-                }
-            ]);
+            sut.Should().BeEquivalentTo([new BaseClassPointingToClassWithoutProperties { Name = "theName" }]);
         }
 
 #if NETCOREAPP3_0_OR_GREATER
         [Fact]
         public void Will_include_default_interface_properties_in_the_comparison()
         {
-            var lista = new List<ITest>
-            {
-                new Test { Name = "Test" }
-            };
+            var listA = new List<ITest> { new Test { Name = "Test" } };
+            List<ITest> listB = [new Test { Name = "Test" }];
 
-            List<ITest> listb = new()
-            {
-                new Test { Name = "Test" }
-            };
-
-            lista.Should().BeEquivalentTo(listb);
+            listA.Should().BeEquivalentTo(listB);
         }
 
         private class Test : ITest

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Browsability.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Browsability.cs
@@ -13,192 +13,102 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_browsable_field_differs_excluding_non_browsable_members_should_not_affect_result()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                BrowsableField = 0
-            };
+            var subject = new ClassWithNonBrowsableMembers { BrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers { BrowsableField = 1 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                BrowsableField = 1
-            };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_browsable_property_differs_excluding_non_browsable_members_should_not_affect_result()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                BrowsableProperty = 0
-            };
+            var subject = new ClassWithNonBrowsableMembers { BrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers { BrowsableProperty = 1 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                BrowsableProperty = 1
-            };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_advanced_browsable_field_differs_excluding_non_browsable_members_should_not_affect_result()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                AdvancedBrowsableField = 0
-            };
+            var subject = new ClassWithNonBrowsableMembers { AdvancedBrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers { AdvancedBrowsableField = 1 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                AdvancedBrowsableField = 1
-            };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_advanced_browsable_property_differs_excluding_non_browsable_members_should_not_affect_result()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                AdvancedBrowsableProperty = 0
-            };
+            var subject = new ClassWithNonBrowsableMembers { AdvancedBrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers { AdvancedBrowsableProperty = 1 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                AdvancedBrowsableProperty = 1
-            };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_explicitly_browsable_field_differs_excluding_non_browsable_members_should_not_affect_result()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                ExplicitlyBrowsableField = 0
-            };
+            var subject = new ClassWithNonBrowsableMembers { ExplicitlyBrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers { ExplicitlyBrowsableField = 1 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                ExplicitlyBrowsableField = 1
-            };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_explicitly_browsable_property_differs_excluding_non_browsable_members_should_not_affect_result()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                ExplicitlyBrowsableProperty = 0
-            };
+            var subject = new ClassWithNonBrowsableMembers { ExplicitlyBrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers { ExplicitlyBrowsableProperty = 1 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                ExplicitlyBrowsableProperty = 1
-            };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_non_browsable_field_differs_excluding_non_browsable_members_should_make_it_succeed()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                NonBrowsableField = 0
-            };
+            var subject = new ClassWithNonBrowsableMembers { NonBrowsableField = 0 };
+            var expectation = new ClassWithNonBrowsableMembers { NonBrowsableField = 1 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                NonBrowsableField = 1
-            };
-
-            // Act & Assert
             subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
         }
 
         [Fact]
         public void When_non_browsable_property_differs_excluding_non_browsable_members_should_make_it_succeed()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                NonBrowsableProperty = 0
-            };
+            var subject = new ClassWithNonBrowsableMembers { NonBrowsableProperty = 0 };
+            var expectation = new ClassWithNonBrowsableMembers { NonBrowsableProperty = 1 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                NonBrowsableProperty = 1
-            };
-
-            // Act & Assert
             subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
         }
 
         [Fact]
         public void When_property_is_non_browsable_only_in_subject_excluding_non_browsable_members_should_not_make_it_succeed()
         {
-            // Arrange
-            var subject =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
-                {
-                    PropertyThatMightBeNonBrowsable = 0
-                };
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable { PropertyThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable { PropertyThatMightBeNonBrowsable = 1 };
 
-            var expectation =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
-                {
-                    PropertyThatMightBeNonBrowsable = 1
-                };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
 
-            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected property subject.PropertyThatMightBeNonBrowsable to be 1, but found 0.*");
         }
@@ -207,20 +117,9 @@ public partial class SelectionRulesSpecs
         public void
             When_property_is_non_browsable_only_in_subject_ignoring_non_browsable_members_on_subject_should_make_it_succeed()
         {
-            // Arrange
-            var subject =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
-                {
-                    PropertyThatMightBeNonBrowsable = 0
-                };
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable { PropertyThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable { PropertyThatMightBeNonBrowsable = 1 };
 
-            var expectation =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
-                {
-                    PropertyThatMightBeNonBrowsable = 1
-                };
-
-            // Act & Assert
             subject.Should().BeEquivalentTo(
                 expectation,
                 config => config.IgnoringNonBrowsableMembersOnSubject().ExcludingMissingMembers());
@@ -229,24 +128,12 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_non_browsable_property_on_subject_is_ignored_but_is_present_on_expectation_it_should_fail()
         {
-            // Arrange
-            var subject =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
-                {
-                    PropertyThatMightBeNonBrowsable = 0
-                };
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable { PropertyThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable { PropertyThatMightBeNonBrowsable = 1 };
 
-            var expectation =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
-                {
-                    PropertyThatMightBeNonBrowsable = 1
-                };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(expectation, config => config.IgnoringNonBrowsableMembersOnSubject());
 
-            // Assert
             action.Should().Throw<XunitException>().WithMessage(
                 "Expectation has*ThatMightBeNonBrowsable that is non-browsable in the other object, and non-browsable " +
                 "members on the subject are ignored with the current configuration*");
@@ -255,64 +142,33 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Only_ignore_non_browsable_matching_members()
         {
-            // Arrange
-            var subject = new
-            {
-                NonExisting = 0
-            };
+            var subject = new { NonExisting = 0 };
+            var expectation = new { Existing = 1 };
 
-            var expectation = new
-            {
-                Existing = 1
-            };
+            Action action = () =>
+                subject.Should().BeEquivalentTo(expectation, config => config.IgnoringNonBrowsableMembersOnSubject());
 
-            // Act
-            Action action = () => subject.Should().BeEquivalentTo(expectation, config => config.IgnoringNonBrowsableMembersOnSubject());
-
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_property_is_non_browsable_only_in_expectation_excluding_non_browsable_members_should_make_it_succeed()
         {
-            // Arrange
-            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
-            {
-                PropertyThatMightBeNonBrowsable = 0
-            };
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable { PropertyThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable { PropertyThatMightBeNonBrowsable = 1 };
 
-            var expectation =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
-                {
-                    PropertyThatMightBeNonBrowsable = 1
-                };
-
-            // Act & Assert
             subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
         }
 
         [Fact]
         public void When_field_is_non_browsable_only_in_subject_excluding_non_browsable_members_should_not_make_it_succeed()
         {
-            // Arrange
-            var subject =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
-                {
-                    FieldThatMightBeNonBrowsable = 0
-                };
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable { FieldThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable { FieldThatMightBeNonBrowsable = 1 };
 
-            var expectation =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
-                {
-                    FieldThatMightBeNonBrowsable = 1
-                };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
 
-            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected field subject.FieldThatMightBeNonBrowsable to be 1, but found 0.*");
         }
@@ -320,20 +176,9 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_field_is_non_browsable_only_in_subject_ignoring_non_browsable_members_on_subject_should_make_it_succeed()
         {
-            // Arrange
-            var subject =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
-                {
-                    FieldThatMightBeNonBrowsable = 0
-                };
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable { FieldThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable { FieldThatMightBeNonBrowsable = 1 };
 
-            var expectation =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
-                {
-                    FieldThatMightBeNonBrowsable = 1
-                };
-
-            // Act & Assert
             subject.Should().BeEquivalentTo(
                 expectation,
                 config => config.IgnoringNonBrowsableMembersOnSubject().ExcludingMissingMembers());
@@ -342,151 +187,97 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_field_is_non_browsable_only_in_expectation_excluding_non_browsable_members_should_make_it_succeed()
         {
-            // Arrange
-            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable
-            {
-                FieldThatMightBeNonBrowsable = 0
-            };
+            var subject = new ClassWhereMemberThatCouldBeNonBrowsableIsBrowsable { FieldThatMightBeNonBrowsable = 0 };
+            var expectation = new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable { FieldThatMightBeNonBrowsable = 1 };
 
-            var expectation =
-                new ClassWhereMemberThatCouldBeNonBrowsableIsNonBrowsable
-                {
-                    FieldThatMightBeNonBrowsable = 1
-                };
-
-            // Act & Assert
             subject.Should().BeEquivalentTo(expectation, config => config.ExcludingNonBrowsableMembers());
         }
 
         [Fact]
         public void When_property_is_missing_from_subject_excluding_non_browsable_members_should_make_it_succeed()
         {
-            // Arrange
-            var subject =
-                new
-                {
-                    BrowsableField = 1,
-                    BrowsableProperty = 1,
-                    ExplicitlyBrowsableField = 1,
-                    ExplicitlyBrowsableProperty = 1,
-                    AdvancedBrowsableField = 1,
-                    AdvancedBrowsableProperty = 1,
-                    NonBrowsableField = 2
-                    /* NonBrowsableProperty missing */
-                };
-
+            var subject = new
+            {
+                BrowsableField = 1, BrowsableProperty = 1,
+                ExplicitlyBrowsableField = 1, ExplicitlyBrowsableProperty = 1,
+                AdvancedBrowsableField = 1, AdvancedBrowsableProperty = 1,
+                NonBrowsableField = 2
+                /* NonBrowsableProperty missing */
+            };
             var expected = new ClassWithNonBrowsableMembers
             {
-                BrowsableField = 1,
-                BrowsableProperty = 1,
-                ExplicitlyBrowsableField = 1,
-                ExplicitlyBrowsableProperty = 1,
-                AdvancedBrowsableField = 1,
-                AdvancedBrowsableProperty = 1,
-                NonBrowsableField = 2,
-                NonBrowsableProperty = 2
+                BrowsableField = 1, BrowsableProperty = 1,
+                ExplicitlyBrowsableField = 1, ExplicitlyBrowsableProperty = 1,
+                AdvancedBrowsableField = 1, AdvancedBrowsableProperty = 1,
+                NonBrowsableField = 2, NonBrowsableProperty = 2
             };
 
-            // Act & Assert
             subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNonBrowsableMembers());
         }
 
         [Fact]
         public void When_field_is_missing_from_subject_excluding_non_browsable_members_should_make_it_succeed()
         {
-            // Arrange
-            var subject =
-                new
-                {
-                    BrowsableField = 1,
-                    BrowsableProperty = 1,
-                    ExplicitlyBrowsableField = 1,
-                    ExplicitlyBrowsableProperty = 1,
-                    AdvancedBrowsableField = 1,
-                    AdvancedBrowsableProperty = 1,
-                    /* NonBrowsableField missing */
-                    NonBrowsableProperty = 2
-                };
-
-            var expected = new ClassWithNonBrowsableMembers
+            var subject = new
             {
-                BrowsableField = 1,
-                BrowsableProperty = 1,
-                ExplicitlyBrowsableField = 1,
-                ExplicitlyBrowsableProperty = 1,
-                AdvancedBrowsableField = 1,
-                AdvancedBrowsableProperty = 1,
-                NonBrowsableField = 2,
+                BrowsableField = 1, BrowsableProperty = 1,
+                ExplicitlyBrowsableField = 1, ExplicitlyBrowsableProperty = 1,
+                AdvancedBrowsableField = 1, AdvancedBrowsableProperty = 1,
+                /* NonBrowsableField missing */
                 NonBrowsableProperty = 2
             };
+            var expected = new ClassWithNonBrowsableMembers
+            {
+                BrowsableField = 1, BrowsableProperty = 1,
+                ExplicitlyBrowsableField = 1, ExplicitlyBrowsableProperty = 1,
+                AdvancedBrowsableField = 1, AdvancedBrowsableProperty = 1,
+                NonBrowsableField = 2, NonBrowsableProperty = 2
+            };
 
-            // Act & Assert
             subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNonBrowsableMembers());
         }
 
         [Fact]
         public void When_property_is_missing_from_expectation_excluding_non_browsable_members_should_make_it_succeed()
         {
-            // Arrange
             var subject = new ClassWithNonBrowsableMembers
             {
-                BrowsableField = 1,
-                BrowsableProperty = 1,
-                ExplicitlyBrowsableField = 1,
-                ExplicitlyBrowsableProperty = 1,
-                AdvancedBrowsableField = 1,
-                AdvancedBrowsableProperty = 1,
-                NonBrowsableField = 2,
-                NonBrowsableProperty = 2
+                BrowsableField = 1, BrowsableProperty = 1,
+                ExplicitlyBrowsableField = 1, ExplicitlyBrowsableProperty = 1,
+                AdvancedBrowsableField = 1, AdvancedBrowsableProperty = 1,
+                NonBrowsableField = 2, NonBrowsableProperty = 2
+            };
+            var expected = new
+            {
+                BrowsableField = 1, BrowsableProperty = 1,
+                ExplicitlyBrowsableField = 1, ExplicitlyBrowsableProperty = 1,
+                AdvancedBrowsableField = 1, AdvancedBrowsableProperty = 1,
+                NonBrowsableField = 2
+                /* NonBrowsableProperty missing */
             };
 
-            var expected =
-                new
-                {
-                    BrowsableField = 1,
-                    BrowsableProperty = 1,
-                    ExplicitlyBrowsableField = 1,
-                    ExplicitlyBrowsableProperty = 1,
-                    AdvancedBrowsableField = 1,
-                    AdvancedBrowsableProperty = 1,
-                    NonBrowsableField = 2
-                    /* NonBrowsableProperty missing */
-                };
-
-            // Act & Assert
             subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNonBrowsableMembers());
         }
 
         [Fact]
         public void When_field_is_missing_from_expectation_excluding_non_browsable_members_should_make_it_succeed()
         {
-            // Arrange
             var subject = new ClassWithNonBrowsableMembers
             {
-                BrowsableField = 1,
-                BrowsableProperty = 1,
-                ExplicitlyBrowsableField = 1,
-                ExplicitlyBrowsableProperty = 1,
-                AdvancedBrowsableField = 1,
-                AdvancedBrowsableProperty = 1,
-                NonBrowsableField = 2,
+                BrowsableField = 1, BrowsableProperty = 1,
+                ExplicitlyBrowsableField = 1, ExplicitlyBrowsableProperty = 1,
+                AdvancedBrowsableField = 1, AdvancedBrowsableProperty = 1,
+                NonBrowsableField = 2, NonBrowsableProperty = 2
+            };
+            var expected = new
+            {
+                BrowsableField = 1, BrowsableProperty = 1,
+                ExplicitlyBrowsableField = 1, ExplicitlyBrowsableProperty = 1,
+                AdvancedBrowsableField = 1, AdvancedBrowsableProperty = 1,
+                /* NonBrowsableField missing */
                 NonBrowsableProperty = 2
             };
 
-            var expected =
-                new
-                {
-                    BrowsableField = 1,
-                    BrowsableProperty = 1,
-                    ExplicitlyBrowsableField = 1,
-                    ExplicitlyBrowsableProperty = 1,
-                    AdvancedBrowsableField = 1,
-                    AdvancedBrowsableProperty = 1,
-                    /* NonBrowsableField missing */
-                    NonBrowsableProperty = 2
-                };
-
-            // Act & Assert
             subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingNonBrowsableMembers());
         }
 
@@ -494,24 +285,14 @@ public partial class SelectionRulesSpecs
         public void
             When_non_browsable_members_are_excluded_it_should_still_be_possible_to_explicitly_include_non_browsable_field()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                NonBrowsableField = 1
-            };
+            var subject = new ClassWithNonBrowsableMembers { NonBrowsableField = 1 };
+            var expectation = new ClassWithNonBrowsableMembers { NonBrowsableField = 2 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                NonBrowsableField = 2
-            };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(
                     expectation,
                     opt => opt.IncludingFields().ExcludingNonBrowsableMembers().Including(e => e.NonBrowsableField));
 
-            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected field subject.NonBrowsableField to be 2, but found 1.*");
         }
@@ -520,24 +301,14 @@ public partial class SelectionRulesSpecs
         public void
             When_non_browsable_members_are_excluded_it_should_still_be_possible_to_explicitly_include_non_browsable_property()
         {
-            // Arrange
-            var subject = new ClassWithNonBrowsableMembers
-            {
-                NonBrowsableProperty = 1
-            };
+            var subject = new ClassWithNonBrowsableMembers { NonBrowsableProperty = 1 };
+            var expectation = new ClassWithNonBrowsableMembers { NonBrowsableProperty = 2 };
 
-            var expectation = new ClassWithNonBrowsableMembers
-            {
-                NonBrowsableProperty = 2
-            };
-
-            // Act
             Action action =
                 () => subject.Should().BeEquivalentTo(
                     expectation,
                     opt => opt.IncludingProperties().ExcludingNonBrowsableMembers().Including(e => e.NonBrowsableProperty));
 
-            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected property subject.NonBrowsableProperty to be 2, but found 1.*");
         }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Covariance.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Covariance.cs
@@ -13,59 +13,25 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Excluding_a_covariant_property_should_work()
         {
-            // Arrange
             var actual = new DerivedWithCovariantOverride(new DerivedWithProperty
-            {
-                DerivedProperty = "a",
-                BaseProperty = "a_base"
-            })
-            {
-                OtherProp = "other"
-            };
-
+                { DerivedProperty = "a", BaseProperty = "a_base" }) { OtherProp = "other" };
             var expectation = new DerivedWithCovariantOverride(new DerivedWithProperty
-            {
-                DerivedProperty = "b",
-                BaseProperty =
-                    "b_base"
-            })
-            {
-                OtherProp = "other"
-            };
+                { DerivedProperty = "b", BaseProperty = "b_base" }) { OtherProp = "other" };
 
-            // Act / Assert
-            actual.Should().BeEquivalentTo(expectation, opts => opts
-                .Excluding(d => d.Property));
+            actual.Should().BeEquivalentTo(expectation, opts => opts.Excluding(d => d.Property));
         }
 
         [Fact]
         public void Excluding_a_covariant_property_through_the_base_class_excludes_the_base_class_property()
         {
-            // Arrange
             var actual = new DerivedWithCovariantOverride(new DerivedWithProperty
-            {
-                DerivedProperty = "a",
-                BaseProperty = "a_base"
-            })
-            {
-                OtherProp = "other"
-            };
-
+                { DerivedProperty = "a", BaseProperty = "a_base" }) { OtherProp = "other" };
             BaseWithAbstractProperty expectation = new DerivedWithCovariantOverride(new DerivedWithProperty
-            {
-                DerivedProperty =
-                    "b",
-                BaseProperty = "b_base"
-            })
-            {
-                OtherProp = "other"
-            };
+                { DerivedProperty = "b", BaseProperty = "b_base" }) { OtherProp = "other" };
 
-            // Act
             Action act = () => actual.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(d => d.Property));
 
-            // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage("No members*");
         }
 

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Excluding.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Excluding.cs
@@ -15,122 +15,53 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void A_member_excluded_by_path_is_described_in_the_failure_message()
         {
-            // Arrange
-            var subject = new
-            {
-                Name = "John",
-                Age = 13
-            };
+            var subject = new { Name = "John", Age = 13 };
+            var customer = new { Name = "Jack", Age = 37 };
 
-            var customer = new
-            {
-                Name = "Jack",
-                Age = 37
-            };
+            Action act = () => subject.Should().BeEquivalentTo(customer, options => options.Excluding(d => d.Age));
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(customer, options => options
-                .Excluding(d => d.Age));
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Exclude*Age*");
+            act.Should().Throw<XunitException>().WithMessage("*Exclude*Age*");
         }
 
         [Fact]
         public void A_member_excluded_by_predicate_is_described_in_the_failure_message()
         {
-            // Arrange
-            var subject = new
-            {
-                Name = "John",
-                Age = 13
-            };
+            var subject = new { Name = "John", Age = 13 };
+            var customer = new { Name = "Jack", Age = 37 };
 
-            var customer = new
-            {
-                Name = "Jack",
-                Age = 37
-            };
+            Action act = () => subject.Should().BeEquivalentTo(customer, options => options.Excluding(ctx => ctx.Path == "Age"));
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(customer, options => options
-                .Excluding(ctx => ctx.Path == "Age"));
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Exclude member when*Age*");
+            act.Should().Throw<XunitException>().WithMessage("*Exclude member when*Age*");
         }
 
         [Fact]
         public void A_member_excluded_by_name_is_described_in_the_failure_message()
         {
-            // Arrange
-            var subject = new
-            {
-                Id = 1,
-                Name = "John",
-                Age = 13,
-            };
+            var subject = new { Id = 1, Name = "John", Age = 13 };
+            var customer = new { Id = 2, Name = "Jack", Age = 37 };
 
-            var customer = new
-            {
-                Id = 2,
-                Name = "Jack",
-                Age = 37,
-            };
+            Action act = () => subject.Should().BeEquivalentTo(customer, options => options.ExcludingMembersNamed("Name", "Age"));
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(customer, options => options
-                .ExcludingMembersNamed("Name", "Age"));
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Exclude members named: Name, Age*");
+            act.Should().Throw<XunitException>().WithMessage("*Exclude members named: Name, Age*");
         }
 
         [Fact]
         public void Excluding_member_by_name_should_succeed()
         {
-            // Arrange
-            var subject = new
-            {
-                Id = 1,
-                Name = "John",
-                Age = 13,
-            };
+            var subject = new { Id = 1, Name = "John", Age = 13 };
+            var customer = new { Id = 1, Name = "Jack", Age = 13 };
 
-            var customer = new
-            {
-                Id = 1,
-                Name = "Jack",
-                Age = 13,
-            };
-
-            // Act / Assert
-            subject.Should().BeEquivalentTo(customer, options => options
-                .ExcludingMembersNamed("Name"));
+            subject.Should().BeEquivalentTo(customer, options => options.ExcludingMembersNamed("Name"));
         }
 
         [Fact]
         public void Excluding_member_by_name_respects_casing()
         {
-            // Arrange
-            var subject = new
-            {
-                Name = "John",
-            };
+            var subject = new { Name = "John" };
+            var customer = new { Name = "Jack" };
 
-            var customer = new
-            {
-                Name = "Jack",
-            };
+            Action act = () => subject.Should().BeEquivalentTo(customer, options => options.ExcludingMembersNamed("name"));
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(customer, options => options
-                .ExcludingMembersNamed("name"));
-
-            // Assert
             act.Should().Throw<XunitException>()
                 .Which.Message.Should().Match("Expected property subject.Name*- Exclude members named: name*");
         }
@@ -138,63 +69,29 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Excluding_member_by_name_should_pass_in_nested_types()
         {
-            // Arrange
-            var subject = new
-            {
-                Id = 1,
-                Nested = new
-                {
-                    Name = "John",
-                    Age = 13,
-                },
-            };
+            var subject = new { Id = 1, Nested = new { Name = "John", Age = 13 } };
+            var customer = new { Id = 1, Nested = new { Age = 13 } };
 
-            var customer = new
-            {
-                Id = 1,
-                Nested = new
-                {
-                    Age = 13,
-                },
-            };
-
-            // Act / Assert
-            subject.Should().BeEquivalentTo(customer, options => options
-                .ExcludingMembersNamed("Name"));
+            subject.Should().BeEquivalentTo(customer, options => options.ExcludingMembersNamed("Name"));
         }
 
         [Fact]
         public void Passing_a_null_parameter_as_member_names_should_throw()
         {
-            // Arrange
-            var subject = new
-            {
-                Age = 10,
-            };
+            var subject = new { Age = 10 };
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(subject, options => options
-                .ExcludingMembersNamed(null!));
+            Action act = () => subject.Should().BeEquivalentTo(subject, options => options.ExcludingMembersNamed(null!));
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("memberNames");
+            act.Should().Throw<ArgumentNullException>().WithParameterName("memberNames");
         }
 
         [Fact]
         public void Passing_an_empty_collection_parameter_as_member_names_should_throw()
         {
-            // Arrange
-            var subject = new
-            {
-                Age = 10,
-            };
+            var subject = new { Age = 10 };
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(subject, options => options
-                .ExcludingMembersNamed([]));
+            Action act = () => subject.Should().BeEquivalentTo(subject, options => options.ExcludingMembersNamed([]));
 
-            // Assert
             act.Should().Throw<ArgumentException>()
                 .WithParameterName("memberNames")
                 .WithMessage("At least one member name must be specified*memberNames*");
@@ -203,22 +100,9 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_only_the_excluded_property_doesnt_match_it_should_not_throw()
         {
-            // Arrange
-            var dto = new CustomerDto
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
+            var dto = new CustomerDto { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
+            var customer = new Customer { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "Dennis" };
 
-            var customer = new Customer
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "Dennis"
-            };
-
-            // Act / Assert
             dto.Should().BeEquivalentTo(customer, options => options
                 .Excluding(d => d.Name)
                 .Excluding(d => d.Id));
@@ -227,47 +111,21 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_only_the_excluded_property_doesnt_match_it_should_not_throw_if_root_is_a_collection()
         {
-            // Arrange
-            var dto = new Customer
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
+            var dto = new Customer { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
+            var customer = new Customer { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "Dennis" };
 
-            var customer = new Customer
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "Dennis"
-            };
-
-            // Act / Assert
-            new[] { dto }.Should().BeEquivalentTo(new[] { customer }, options => options
-                .Excluding(d => d.Name)
-                .Excluding(d => d.Id));
+            new[] { dto }.Should().BeEquivalentTo([customer], options => options.Excluding(d => d.Name).Excluding(d => d.Id));
         }
 
         [Fact]
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public void When_excluding_members_it_should_pass_if_only_the_excluded_members_are_different()
         {
-            // Arrange
             var class1 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit"
-            };
-
+                { Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor", Property1 = "sit" };
             var class2 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "Lorem",
-                Field2 = "ipsum"
-            };
+                { Field1 = "Lorem", Field2 = "ipsum" };
 
-            // Act / Assert
             class1.Should().BeEquivalentTo(class2,
                 opts => opts.Excluding(o => o.Field3).Excluding(o => o.Property1));
         }
@@ -276,49 +134,25 @@ public partial class SelectionRulesSpecs
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public void When_excluding_members_it_should_fail_if_any_non_excluded_members_are_different()
         {
-            // Arrange
             var class1 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit"
-            };
-
+                { Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor", Property1 = "sit" };
             var class2 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "Lorem",
-                Field2 = "ipsum"
-            };
+                { Field1 = "Lorem", Field2 = "ipsum" };
 
-            // Act
             Action act =
                 () => class1.Should().BeEquivalentTo(class2, opts => opts.Excluding(o => o.Property1));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*Field3*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*Field3*");
         }
 
         [Fact]
         public void When_excluding_member_names_it_should_pass_if_only_the_excluded_members_are_different()
         {
-            // Arrange
             var class1 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "First",
-                Field2 = "Second",
-                Field3 = "Rhird",
-                Property1 = "FirstProperty",
-            };
-
+                { Field1 = "First", Field2 = "Second", Field3 = "Third", Property1 = "FirstProperty" };
             var class2 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "First",
-                Field2 = "Second",
-            };
+                { Field1 = "First", Field2 = "Second" };
 
-            // Act / Assert
             class1.Should().BeEquivalentTo(class2,
                 opts => opts.ExcludingMembersNamed("Field3", "Property1"));
         }
@@ -328,152 +162,73 @@ public partial class SelectionRulesSpecs
         {
             // Arrange
             var class1 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "First",
-                Field2 = "Second",
-                Field3 = "Rhird",
-                Property1 = "FirstProperty",
-            };
-
+                { Field1 = "First", Field2 = "Second", Field3 = "Third", Property1 = "FirstProperty" };
             var class2 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "First",
-                Field2 = "Second",
-            };
+                { Field1 = "First", Field2 = "Second" };
 
-            // Act
             Action act =
                 () => class1.Should().BeEquivalentTo(class2, opts => opts.ExcludingMembersNamed("Property1"));
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*Field3*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*Field3*");
         }
 
         [Fact]
         public void When_all_shared_properties_match_it_should_not_throw()
         {
-            // Arrange
-            var dto = new CustomerDto
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
+            var dto = new CustomerDto { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
+            var customer = new Customer { Id = 1, Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
 
-            var customer = new Customer
-            {
-                Id = 1,
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
-
-            // Act / Assert
             dto.Should().BeEquivalentTo(customer, options => options.ExcludingMissingMembers());
         }
 
         [Fact]
         public void When_a_deeply_nested_property_with_a_value_mismatch_is_excluded_it_should_not_throw()
         {
-            // Arrange
             var subject = new Root
             {
                 Text = "Root",
-                Level = new Level1
-                {
-                    Text = "Level1",
-                    Level = new Level2
-                    {
-                        Text = "Mismatch"
-                    }
-                }
+                Level = new Level1 { Text = "Level1", Level = new Level2 { Text = "Mismatch" } }
             };
-
             var expected = new RootDto
             {
                 Text = "Root",
-                Level = new Level1Dto
-                {
-                    Text = "Level1",
-                    Level = new Level2Dto
-                    {
-                        Text = "Level2"
-                    }
-                }
+                Level = new Level1Dto { Text = "Level1", Level = new Level2Dto { Text = "Level2" } }
             };
 
-            // Act / Assert
-            subject.Should().BeEquivalentTo(expected,
-                options => options.Excluding(r => r.Level.Level.Text));
+            subject.Should().BeEquivalentTo(expected, options => options.Excluding(r => r.Level.Level.Text));
         }
 
         [Fact]
         public void When_a_deeply_nested_property_with_a_value_mismatch_is_excluded_it_should_not_throw_if_root_is_a_collection()
         {
-            // Arrange
             var subject = new Root
             {
                 Text = "Root",
-                Level = new Level1
-                {
-                    Text = "Level1",
-                    Level = new Level2
-                    {
-                        Text = "Mismatch"
-                    }
-                }
+                Level = new Level1 { Text = "Level1", Level = new Level2 { Text = "Mismatch" } }
             };
-
             var expected = new RootDto
             {
                 Text = "Root",
-                Level = new Level1Dto
-                {
-                    Text = "Level1",
-                    Level = new Level2Dto
-                    {
-                        Text = "Level2"
-                    }
-                }
+                Level = new Level1Dto { Text = "Level1", Level = new Level2Dto { Text = "Level2" } }
             };
 
-            // Act / Assert
-            new[] { subject }.Should().BeEquivalentTo(new[] { expected },
-                options => options.Excluding(r => r.Level.Level.Text));
+            new[] { subject }.Should().BeEquivalentTo([expected], options => options.Excluding(r => r.Level.Level.Text));
         }
 
         [Fact]
         public void When_a_property_with_a_value_mismatch_is_excluded_using_a_predicate_it_should_not_throw()
         {
-            // Arrange
             var subject = new Root
             {
                 Text = "Root",
-                Level = new Level1
-                {
-                    Text = "Level1",
-                    Level = new Level2
-                    {
-                        Text = "Mismatch"
-                    }
-                }
+                Level = new Level1 { Text = "Level1", Level = new Level2 { Text = "Mismatch" } }
             };
-
             var expected = new RootDto
             {
                 Text = "Root",
-                Level = new Level1Dto
-                {
-                    Text = "Level1",
-                    Level = new Level2Dto
-                    {
-                        Text = "Level2"
-                    }
-                }
+                Level = new Level1Dto { Text = "Level1", Level = new Level2Dto { Text = "Level2" } }
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected, config =>
                 config.Excluding(ctx => ctx.Path == "Level.Level.Text"));
         }
@@ -481,14 +236,11 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_members_are_excluded_by_the_access_modifier_of_the_getter_using_a_predicate_they_should_be_ignored()
         {
-            // Arrange
             var subject = new ClassWithAllAccessModifiersForMembers("public", "protected",
                 "internal", "protected-internal", "private", "private-protected");
-
             var expected = new ClassWithAllAccessModifiersForMembers("public", "protected",
                 "ignored-internal", "ignored-protected-internal", "private", "private-protected");
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected, config => config
                 .IncludingInternalFields()
                 .Excluding(ctx =>
@@ -499,14 +251,11 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_members_are_excluded_by_the_access_modifier_of_the_setter_using_a_predicate_they_should_be_ignored()
         {
-            // Arrange
             var subject = new ClassWithAllAccessModifiersForMembers("public", "protected",
                 "internal", "protected-internal", "private", "private-protected");
-
             var expected = new ClassWithAllAccessModifiersForMembers("public", "protected",
                 "ignored-internal", "ignored-protected-internal", "ignored-private", "private-protected");
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected, config => config
                 .IncludingInternalFields()
                 .Excluding(ctx =>
@@ -519,124 +268,61 @@ public partial class SelectionRulesSpecs
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public void When_excluding_properties_it_should_still_compare_fields()
         {
-            // Arrange
             var class1 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor",
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
-
             var class2 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "color"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "color"
             };
 
-            // Act
-            Action act =
-                () => class1.Should().BeEquivalentTo(class2, opts => opts.ExcludingProperties());
+            Action act = () => class1.Should().BeEquivalentTo(class2, opts => opts.ExcludingProperties());
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*dolor*color*");
+            act.Should().Throw<XunitException>().WithMessage("*dolor*color*");
         }
 
         [Fact]
         public void When_excluding_fields_it_should_still_compare_properties()
         {
-            // Arrange
             var class1 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor",
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
-
             var class2 = new ClassWithSomeFieldsAndProperties
             {
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "different"
+                Property1 = "sit", Property2 = "amet", Property3 = "different"
             };
 
-            // Act
-            Action act =
-                () => class1.Should().BeEquivalentTo(class2, opts => opts.ExcludingFields());
+            Action act = () => class1.Should().BeEquivalentTo(class2, opts => opts.ExcludingFields());
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Property3*consectetur*");
+            act.Should().Throw<XunitException>().WithMessage("*Property3*consectetur*");
         }
 
         [Fact]
         public void When_excluding_properties_via_non_array_indexers_it_should_exclude_the_specified_paths()
         {
-            // Arrange
             var subject = new
             {
-                List = new[]
-                {
-                    new
-                    {
-                        Foo = 1,
-                        Bar = 2
-                    },
-                    new
-                    {
-                        Foo = 3,
-                        Bar = 4
-                    }
-                }.ToList(),
+                List = new[] { new { Foo = 1, Bar = 2 }, new { Foo = 3, Bar = 4 } }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new()
-                    {
-                        Value = 1
-                    },
-                    ["Bar"] = new()
-                    {
-                        Value = 2
-                    }
+                    ["Foo"] = new() { Value = 1 },
+                    ["Bar"] = new() { Value = 2 }
                 }
             };
-
             var expected = new
             {
-                List = new[]
-                {
-                    new
-                    {
-                        Foo = 1,
-                        Bar = 2
-                    },
-                    new
-                    {
-                        Foo = 2,
-                        Bar = 4
-                    }
-                }.ToList(),
+                List = new[] { new { Foo = 1, Bar = 2 }, new { Foo = 2, Bar = 4 } }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new()
-                    {
-                        Value = 1
-                    },
-                    ["Bar"] = new()
-                    {
-                        Value = 3
-                    }
+                    ["Foo"] = new() { Value = 1 },
+                    ["Bar"] = new() { Value = 3 }
                 }
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected,
                 options => options
                     .Excluding(x => x.List[1].Foo)
@@ -647,65 +333,26 @@ public partial class SelectionRulesSpecs
         public void
             When_excluding_properties_via_non_array_indexers_it_should_exclude_the_specified_paths_if_root_is_a_collection()
         {
-            // Arrange
             var subject = new
             {
-                List = new[]
-                {
-                    new
-                    {
-                        Foo = 1,
-                        Bar = 2
-                    },
-                    new
-                    {
-                        Foo = 3,
-                        Bar = 4
-                    }
-                }.ToList(),
+                List = new[] { new { Foo = 1, Bar = 2 }, new { Foo = 3, Bar = 4 } }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new()
-                    {
-                        Value = 1
-                    },
-                    ["Bar"] = new()
-                    {
-                        Value = 2
-                    }
+                    ["Foo"] = new() { Value = 1 },
+                    ["Bar"] = new() { Value = 2 }
                 }
             };
-
             var expected = new
             {
-                List = new[]
-                {
-                    new
-                    {
-                        Foo = 1,
-                        Bar = 2
-                    },
-                    new
-                    {
-                        Foo = 2,
-                        Bar = 4
-                    }
-                }.ToList(),
+                List = new[] { new { Foo = 1, Bar = 2 }, new { Foo = 2, Bar = 4 } }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new()
-                    {
-                        Value = 1
-                    },
-                    ["Bar"] = new()
-                    {
-                        Value = 3
-                    }
+                    ["Foo"] = new() { Value = 1 },
+                    ["Bar"] = new() { Value = 3 }
                 }
             };
 
-            // Act / Assert
-            new[] { subject }.Should().BeEquivalentTo(new[] { expected },
+            new[] { subject }.Should().BeEquivalentTo([expected],
                 options => options
                     .Excluding(x => x.List[1].Foo)
                     .Excluding(x => x.Dictionary["Bar"].Value));
@@ -714,71 +361,31 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_excluding_properties_via_non_array_indexers_it_should_not_exclude_paths_with_different_indexes()
         {
-            // Arrange
             var subject = new
             {
-                List = new[]
-                {
-                    new
-                    {
-                        Foo = 1,
-                        Bar = 2
-                    },
-                    new
-                    {
-                        Foo = 3,
-                        Bar = 4
-                    }
-                }.ToList(),
+                List = new[] { new { Foo = 1, Bar = 2 }, new { Foo = 3, Bar = 4 } }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new()
-                    {
-                        Value = 1
-                    },
-                    ["Bar"] = new()
-                    {
-                        Value = 2
-                    }
+                    ["Foo"] = new() { Value = 1 },
+                    ["Bar"] = new() { Value = 2 }
                 }
             };
-
             var expected = new
             {
-                List = new[]
-                {
-                    new
-                    {
-                        Foo = 5,
-                        Bar = 2
-                    },
-                    new
-                    {
-                        Foo = 2,
-                        Bar = 4
-                    }
-                }.ToList(),
+                List = new[] { new { Foo = 5, Bar = 2 }, new { Foo = 2, Bar = 4 } }.ToList(),
                 Dictionary = new Dictionary<string, ClassWithOnlyAProperty>
                 {
-                    ["Foo"] = new()
-                    {
-                        Value = 6
-                    },
-                    ["Bar"] = new()
-                    {
-                        Value = 3
-                    }
+                    ["Foo"] = new() { Value = 6 },
+                    ["Bar"] = new() { Value = 3 }
                 }
             };
 
-            // Act
             Action act = () =>
                 subject.Should().BeEquivalentTo(expected,
                     options => options
                         .Excluding(x => x.List[1].Foo)
                         .Excluding(x => x.Dictionary["Bar"].Value));
 
-            // Assert
             act.Should().Throw<XunitException>();
         }
 
@@ -787,42 +394,24 @@ public partial class SelectionRulesSpecs
         public void
             When_configured_for_runtime_typing_and_properties_are_excluded_the_runtime_type_should_be_used_and_properties_should_be_ignored()
         {
-            // Arrange
             object class1 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor",
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
-
             object class2 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor"
             };
 
-            // Act / Assert
             class1.Should().BeEquivalentTo(class2, opts => opts.ExcludingProperties().PreferringRuntimeMemberTypes());
         }
 
         [Fact]
         public void When_excluding_virtual_or_abstract_property_exclusion_works_properly()
         {
-            var obj1 = new Derived
-            {
-                DerivedProperty1 = "Something",
-                DerivedProperty2 = "A"
-            };
-
-            var obj2 = new Derived
-            {
-                DerivedProperty1 = "Something",
-                DerivedProperty2 = "B"
-            };
+            var obj1 = new Derived { DerivedProperty1 = "Something", DerivedProperty2 = "A" };
+            var obj2 = new Derived { DerivedProperty1 = "Something", DerivedProperty2 = "B" };
 
             obj1.Should().BeEquivalentTo(obj2, opt => opt
                 .Excluding(o => o.AbstractProperty)
@@ -833,17 +422,8 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Abstract_properties_cannot_be_excluded()
         {
-            var obj1 = new Derived
-            {
-                DerivedProperty1 = "Something",
-                DerivedProperty2 = "A"
-            };
-
-            var obj2 = new Derived
-            {
-                DerivedProperty1 = "Something",
-                DerivedProperty2 = "B"
-            };
+            var obj1 = new Derived { DerivedProperty1 = "Something", DerivedProperty2 = "A" };
+            var obj2 = new Derived { DerivedProperty1 = "Something", DerivedProperty2 = "B" };
 
             Action act = () => obj1.Should().BeEquivalentTo(obj2, opt => opt
                 .Excluding(o => o.AbstractProperty + "B"));
@@ -856,44 +436,24 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Can_exclude_a_default_interface_property_using_an_expression()
         {
-            // Arrange
-            IHaveDefaultProperty subject = new ClassReceivedDefaultInterfaceProperty
-            {
-                NormalProperty = "Value"
-            };
+            IHaveDefaultProperty subject = new ClassReceivedDefaultInterfaceProperty { NormalProperty = "Value" };
+            IHaveDefaultProperty expectation = new ClassReceivedDefaultInterfaceProperty { NormalProperty = "Another Value" };
 
-            IHaveDefaultProperty expectation = new ClassReceivedDefaultInterfaceProperty
-            {
-                NormalProperty = "Another Value"
-            };
-
-            // Act
             var act = () => subject.Should().BeEquivalentTo(expectation,
                 x => x.Excluding(p => p.DefaultProperty));
 
-            // Assert
             act.Should().Throw<XunitException>().Which.Message.Should().NotContain("subject.DefaultProperty");
         }
 
         [Fact]
         public void Can_exclude_a_default_interface_property_using_a_name()
         {
-            // Arrange
-            IHaveDefaultProperty subject = new ClassReceivedDefaultInterfaceProperty
-            {
-                NormalProperty = "Value"
-            };
+            IHaveDefaultProperty subject = new ClassReceivedDefaultInterfaceProperty { NormalProperty = "Value" };
+            IHaveDefaultProperty expectation = new ClassReceivedDefaultInterfaceProperty { NormalProperty = "Another Value" };
 
-            IHaveDefaultProperty expectation = new ClassReceivedDefaultInterfaceProperty
-            {
-                NormalProperty = "Another Value"
-            };
-
-            // Act
             var act = () => subject.Should().BeEquivalentTo(expectation,
                 x => x.Excluding(info => info.Name.Contains("DefaultProperty")));
 
-            // Assert
             act.Should().Throw<XunitException>().Which.Message.Should().NotContain("subject.DefaultProperty");
         }
 
@@ -913,24 +473,9 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void An_anonymous_object_with_multiple_fields_excludes_correctly()
         {
-            // Arrange
-            var subject = new
-            {
-                FirstName = "John",
-                MiddleName = "X",
-                LastName = "Doe",
-                Age = 34
-            };
+            var subject = new { FirstName = "John", MiddleName = "X", LastName = "Doe", Age = 34 };
+            var expectation = new { FirstName = "John", MiddleName = "W.", LastName = "Smith", Age = 29 };
 
-            var expectation = new
-            {
-                FirstName = "John",
-                MiddleName = "W.",
-                LastName = "Smith",
-                Age = 29
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(p => new { p.MiddleName, p.LastName, p.Age }));
         }
@@ -938,58 +483,21 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void An_empty_anonymous_object_excludes_nothing()
         {
-            // Arrange
-            var subject = new
-            {
-                FirstName = "John",
-                MiddleName = "X",
-                LastName = "Doe",
-                Age = 34
-            };
+            var subject = new { FirstName = "John", MiddleName = "X", LastName = "Doe", Age = 34 };
+            var expectation = new { FirstName = "John", MiddleName = "W.", LastName = "Smith", Age = 29 };
 
-            var expectation = new
-            {
-                FirstName = "John",
-                MiddleName = "W.",
-                LastName = "Smith",
-                Age = 29
-            };
-
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(p => new { }));
 
-            // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void An_anonymous_object_can_exclude_collections()
         {
-            // Arrange
-            var subject = new
-            {
-                Names = new[]
-                {
-                    "John",
-                    "X.",
-                    "Doe"
-                },
-                Age = 34
-            };
+            var subject = new { Names = new[] { "John", "X.", "Doe" }, Age = 34 };
+            var expectation = new { Names = new[] { "John", "W.", "Smith" }, Age = 34 };
 
-            var expectation = new
-            {
-                Names = new[]
-                {
-                    "John",
-                    "W.",
-                    "Smith"
-                },
-                Age = 34
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(p => new { p.Names }));
         }
@@ -997,30 +505,9 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void An_anonymous_object_can_exclude_nested_objects()
         {
-            // Arrange
-            var subject = new
-            {
-                Names = new
-                {
-                    FirstName = "John",
-                    MiddleName = "X",
-                    LastName = "Doe",
-                },
-                Age = 34
-            };
+            var subject = new { Names = new { FirstName = "John", MiddleName = "X", LastName = "Doe" }, Age = 34 };
+            var expectation = new { Names = new { FirstName = "John", MiddleName = "W.", LastName = "Smith" }, Age = 34 };
 
-            var expectation = new
-            {
-                Names = new
-                {
-                    FirstName = "John",
-                    MiddleName = "W.",
-                    LastName = "Smith",
-                },
-                Age = 34
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(p => new { p.Names.MiddleName, p.Names.LastName }));
         }
@@ -1028,76 +515,32 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void An_anonymous_object_can_exclude_nested_objects_inside_collections()
         {
-            // Arrange
             var subject = new
             {
-                Names = new
-                {
-                    FirstName = "John",
-                    MiddleName = "X",
-                    LastName = "Doe",
-                },
+                Names = new { FirstName = "John", MiddleName = "X", LastName = "Doe" },
                 Pets = new[]
                 {
-                    new
-                    {
-                        Name = "Dog",
-                        Age = 1,
-                        Color = "Black"
-                    },
-                    new
-                    {
-                        Name = "Cat",
-                        Age = 1,
-                        Color = "Black"
-                    },
-                    new
-                    {
-                        Name = "Bird",
-                        Age = 1,
-                        Color = "Black"
-                    },
+                    new { Name = "Dog", Age = 1, Color = "Black" },
+                    new { Name = "Cat", Age = 1, Color = "Black" },
+                    new { Name = "Bird", Age = 1, Color = "Black" }
                 }
             };
-
             var expectation = new
             {
-                Names = new
-                {
-                    FirstName = "John",
-                    MiddleName = "W.",
-                    LastName = "Smith",
-                },
+                Names = new { FirstName = "John", MiddleName = "W.", LastName = "Smith" },
                 Pets = new[]
                 {
-                    new
-                    {
-                        Name = "Dog",
-                        Age = 1,
-                        Color = "Black"
-                    },
-                    new
-                    {
-                        Name = "Dog",
-                        Age = 2,
-                        Color = "Gray"
-                    },
-                    new
-                    {
-                        Name = "Bird",
-                        Age = 3,
-                        Color = "Black"
-                    },
+                    new { Name = "Dog", Age = 1, Color = "Black" },
+                    new { Name = "Dog", Age = 2, Color = "Gray" },
+                    new { Name = "Bird", Age = 3, Color = "Black" }
                 }
             };
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(p => new { p.Names.MiddleName, p.Names.LastName })
                 .For(p => p.Pets)
                 .Exclude(p => new { p.Age, p.Name }));
 
-            // Assert
             act.Should().Throw<XunitException>().Which.Message.Should()
                 .NotMatch("*Pets[1].Age*").And
                 .NotMatch("*Pets[1].Name*").And
@@ -1107,143 +550,57 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void An_anonymous_object_can_exclude_nested_objects_inside_nested_collections()
         {
-            // Arrange
             var subject = new
             {
-                Names = new
-                {
-                    FirstName = "John",
-                    MiddleName = "W.",
-                    LastName = "Smith",
-                },
+                Names = new { FirstName = "John", MiddleName = "W.", LastName = "Smith" },
                 Pets = new[]
                 {
                     new
                     {
                         Name = "Dog",
-                        Fleas = new[]
-                        {
-                            new
-                            {
-                                Name = "Flea 1",
-                                Age = 1,
-                            },
-                            new
-                            {
-                                Name = "Flea 2",
-                                Age = 2,
-                            },
-                        },
+                        Fleas = new[] { new { Name = "Flea 1", Age = 1 }, new { Name = "Flea 2", Age = 2 } }
                     },
                     new
                     {
                         Name = "Dog",
-                        Fleas = new[]
-                        {
-                            new
-                            {
-                                Name = "Flea 10",
-                                Age = 1,
-                            },
-                            new
-                            {
-                                Name = "Flea 21",
-                                Age = 3,
-                            },
-                        },
+                        Fleas = new[] { new { Name = "Flea 10", Age = 1 }, new { Name = "Flea 21", Age = 3 } }
                     },
                     new
                     {
                         Name = "Dog",
-                        Fleas = new[]
-                        {
-                            new
-                            {
-                                Name = "Flea 1",
-                                Age = 1,
-                            },
-                            new
-                            {
-                                Name = "Flea 2",
-                                Age = 2,
-                            },
-                        },
-                    },
-                },
+                        Fleas = new[] { new { Name = "Flea 1", Age = 1 }, new { Name = "Flea 2", Age = 2 } }
+                    }
+                }
             };
-
             var expectation = new
             {
-                Names = new
-                {
-                    FirstName = "John",
-                    MiddleName = "W.",
-                    LastName = "Smith",
-                },
+                Names = new { FirstName = "John", MiddleName = "W.", LastName = "Smith" },
                 Pets = new[]
                 {
                     new
                     {
                         Name = "Dog",
-                        Fleas = new[]
-                        {
-                            new
-                            {
-                                Name = "Flea 1",
-                                Age = 1,
-                            },
-                            new
-                            {
-                                Name = "Flea 2",
-                                Age = 2,
-                            },
-                        },
+                        Fleas = new[] { new { Name = "Flea 1", Age = 1 }, new { Name = "Flea 2", Age = 2 } }
                     },
                     new
                     {
                         Name = "Dog",
-                        Fleas = new[]
-                        {
-                            new
-                            {
-                                Name = "Flea 1",
-                                Age = 1,
-                            },
-                            new
-                            {
-                                Name = "Flea 2",
-                                Age = 1,
-                            },
-                        },
+                        Fleas = new[] { new { Name = "Flea 1", Age = 1 }, new { Name = "Flea 2", Age = 1 } }
                     },
                     new
                     {
                         Name = "Bird",
-                        Fleas = new[]
-                        {
-                            new
-                            {
-                                Name = "Flea 1",
-                                Age = 1,
-                            },
-                            new
-                            {
-                                Name = "Flea 2",
-                                Age = 2,
-                            },
-                        },
-                    },
-                },
+                        Fleas = new[] { new { Name = "Flea 1", Age = 1 }, new { Name = "Flea 2", Age = 2 } }
+                    }
+                }
             };
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(p => new { p.Names.MiddleName, p.Names.LastName })
                 .For(person => person.Pets)
                 .For(pet => pet.Fleas)
                 .Exclude(flea => new { flea.Name, flea.Age }));
 
-            // Assert
             act.Should().Throw<XunitException>().Which.Message.Should()
                 .NotMatch("*Pets[*].Fleas[*].Age*").And
                 .NotMatch("*Pets[*].Fleas[*].Name*").And
@@ -1254,70 +611,32 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void An_empty_anonymous_object_excludes_nothing_inside_collections()
         {
-            // Arrange
             var subject = new
             {
-                Names = new
-                {
-                    FirstName = "John",
-                    MiddleName = "X",
-                    LastName = "Doe",
-                },
+                Names = new { FirstName = "John", MiddleName = "X", LastName = "Doe" },
                 Pets = new[]
                 {
-                    new
-                    {
-                        Name = "Dog",
-                        Age = 1
-                    },
-                    new
-                    {
-                        Name = "Cat",
-                        Age = 1
-                    },
-                    new
-                    {
-                        Name = "Bird",
-                        Age = 1
-                    },
+                    new { Name = "Dog", Age = 1 },
+                    new { Name = "Cat", Age = 1 },
+                    new { Name = "Bird", Age = 1 }
                 }
             };
-
             var expectation = new
             {
-                Names = new
-                {
-                    FirstName = "John",
-                    MiddleName = "W.",
-                    LastName = "Smith",
-                },
+                Names = new { FirstName = "John", MiddleName = "W.", LastName = "Smith" },
                 Pets = new[]
                 {
-                    new
-                    {
-                        Name = "Dog",
-                        Age = 1
-                    },
-                    new
-                    {
-                        Name = "Dog",
-                        Age = 2
-                    },
-                    new
-                    {
-                        Name = "Bird",
-                        Age = 1
-                    },
+                    new { Name = "Dog", Age = 1 },
+                    new { Name = "Dog", Age = 2 },
+                    new { Name = "Bird", Age = 1 }
                 }
             };
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(p => new { p.Names.MiddleName, p.Names.LastName })
                 .For(p => p.Pets)
                 .Exclude(p => new { }));
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("*Pets[1].Name*Pets[1].Age*");
         }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Including.cs
@@ -14,22 +14,9 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_specific_properties_have_been_specified_it_should_ignore_the_other_properties()
         {
-            // Arrange
-            var subject = new
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
+            var subject = new { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
+            var customer = new { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "Dennis" };
 
-            var customer = new
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "Dennis"
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(customer, options => options
                 .Including(d => d.Age)
                 .Including(d => d.Birthdate));
@@ -38,68 +25,31 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void A_member_included_by_path_is_described_in_the_failure_message()
         {
-            // Arrange
-            var subject = new
-            {
-                Name = "John"
-            };
+            var subject = new { Name = "John" };
+            var customer = new { Name = "Jack" };
 
-            var customer = new
-            {
-                Name = "Jack"
-            };
+            Action act = () => subject.Should().BeEquivalentTo(customer, options => options.Including(d => d.Name));
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(customer, options => options
-                .Including(d => d.Name));
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Include*Name*");
+            act.Should().Throw<XunitException>().WithMessage("*Include*Name*");
         }
 
         [Fact]
         public void A_member_included_by_predicate_is_described_in_the_failure_message()
         {
-            // Arrange
-            var subject = new
-            {
-                Name = "John"
-            };
+            var subject = new { Name = "John" };
+            var customer = new { Name = "Jack" };
 
-            var customer = new
-            {
-                Name = "Jack"
-            };
+            Action act = () => subject.Should().BeEquivalentTo(customer, options => options.Including(ctx => ctx.Path == "Name"));
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(customer, options => options
-                .Including(ctx => ctx.Path == "Name"));
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Include member when*Name*");
+            act.Should().Throw<XunitException>().WithMessage("*Include member when*Name*");
         }
 
         [Fact]
         public void When_a_predicate_for_properties_to_include_has_been_specified_it_should_ignore_the_other_properties()
         {
-            // Arrange
-            var subject = new
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "John"
-            };
+            var subject = new { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "John" };
+            var customer = new { Age = 36, Birthdate = new DateTime(1973, 9, 20), Name = "Dennis" };
 
-            var customer = new
-            {
-                Age = 36,
-                Birthdate = new DateTime(1973, 9, 20),
-                Name = "Dennis"
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(customer, options => options
                 .Including(info => info.Path.EndsWith("Age", StringComparison.Ordinal))
                 .Including(info => info.Path.EndsWith("Birthdate", StringComparison.Ordinal)));
@@ -108,13 +58,10 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_a_non_property_expression_is_provided_it_should_throw()
         {
-            // Arrange
             var dto = new CustomerDto();
 
-            // Act
             Action act = () => dto.Should().BeEquivalentTo(dto, options => options.Including(d => d.GetType()));
 
-            // Assert
             act.Should().Throw<ArgumentException>()
                 .WithMessage("Expression <d.GetType()> cannot be used to select a member.*")
                 .WithParameterName("expression");
@@ -123,21 +70,10 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_including_a_property_it_should_exactly_match_the_property()
         {
-            // Arrange
-            var actual = new
-            {
-                DeclaredType = LocalOtherType.NonDefault,
-                Type = LocalType.NonDefault
-            };
+            var actual = new { DeclaredType = LocalOtherType.NonDefault, Type = LocalType.NonDefault };
+            var expectation = new { DeclaredType = LocalOtherType.NonDefault };
 
-            var expectation = new
-            {
-                DeclaredType = LocalOtherType.NonDefault
-            };
-
-            // Act / Assert
-            actual.Should().BeEquivalentTo(expectation,
-                config => config.Including(o => o.DeclaredType));
+            actual.Should().BeEquivalentTo(expectation, config => config.Including(o => o.DeclaredType));
         }
 
         private enum LocalOtherType : byte
@@ -161,45 +97,14 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_including_a_property_using_an_expression_it_should_evaluate_it_from_the_root()
         {
-            // Arrange
-            var list1 = new List<CustomType>
-            {
-                new()
-                {
-                    Name = "A"
-                },
-                new()
-                {
-                    Name = "B"
-                }
-            };
+            var list1 = new List<CustomType> { new() { Name = "A" }, new() { Name = "B" } };
+            var subject = new ClassA { ListOfCustomTypes = list1 };
+            var list2 = new List<CustomType> { new() { Name = "C" }, new() { Name = "D" } };
+            var expectation = new ClassA { ListOfCustomTypes = list2 };
 
-            var list2 = new List<CustomType>
-            {
-                new()
-                {
-                    Name = "C"
-                },
-                new()
-                {
-                    Name = "D"
-                }
-            };
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expectation, options => options.Including(x => x.ListOfCustomTypes));
 
-            var objectA = new ClassA
-            {
-                ListOfCustomTypes = list1
-            };
-
-            var objectB = new ClassA
-            {
-                ListOfCustomTypes = list2
-            };
-
-            // Act
-            Action act = () => objectA.Should().BeEquivalentTo(objectB, options => options.Including(x => x.ListOfCustomTypes));
-
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("*C*but*A*D*but*B*");
         }
 
@@ -211,45 +116,30 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_null_is_provided_as_property_expression_it_should_throw()
         {
-            // Arrange
             var dto = new CustomerDto();
 
-            // Act
-            Action act =
-                () => dto.Should().BeEquivalentTo(dto, options => options.Including(null));
+            Action act = () => dto.Should().BeEquivalentTo(dto, options => options.Including(null));
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Expected an expression, but found <null>.*");
+            act.Should().Throw<ArgumentNullException>().WithMessage("Expected an expression, but found <null>.*");
         }
 
         [Fact]
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public void When_including_fields_it_should_succeed_if_just_the_included_field_match()
         {
-            // Arrange
             var class1 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor",
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
-
             var class2 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum"
+                Field1 = "Lorem", Field2 = "ipsum"
             };
 
-            // Act
-            Action act =
-                () =>
-                    class1.Should().BeEquivalentTo(class2, opts => opts.Including(o => o.Field1).Including(o => o.Field2));
+            Action act = () =>
+                class1.Should().BeEquivalentTo(class2, opts => opts.Including(o => o.Field1).Including(o => o.Field2));
 
-            // Assert
             act.Should().NotThrow("the only selected fields have the same value");
         }
 
@@ -257,30 +147,19 @@ public partial class SelectionRulesSpecs
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public void When_including_fields_it_should_fail_if_any_included_field_do_not_match()
         {
-            // Arrange
             var class1 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor",
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
-
             var class2 = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum"
+                Field1 = "Lorem", Field2 = "ipsum"
             };
 
-            // Act
-            Action act =
-                () =>
-                    class1.Should().BeEquivalentTo(class2,
-                        opts => opts.Including(o => o.Field1).Including(o => o.Field2).Including(o => o.Field3));
+            Action act = () => class1.Should().BeEquivalentTo(class2,
+                opts => opts.Including(o => o.Field1).Including(o => o.Field2).Including(o => o.Field3));
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected field class1.Field3*");
         }
 
@@ -288,58 +167,32 @@ public partial class SelectionRulesSpecs
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
         public void When_both_field_and_properties_are_configured_for_inclusion_both_should_be_included()
         {
-            // Arrange
-            var class1 = new ClassWithSomeFieldsAndProperties
-            {
-                Field1 = "Lorem",
-                Property1 = "sit"
-            };
-
+            var class1 = new ClassWithSomeFieldsAndProperties { Field1 = "Lorem", Property1 = "sit" };
             var class2 = new ClassWithSomeFieldsAndProperties();
 
-            // Act
             Action act =
                 () => class1.Should().BeEquivalentTo(class2, opts => opts.IncludingFields().IncludingProperties());
 
-            // Assert
             act.Should().Throw<XunitException>().Which.Message.Should().Contain("Field1").And.Contain("Property1");
         }
 
         [Fact]
         public void Including_nested_objects_restores_the_default_behavior()
         {
-            // Arrange
             var subject = new Root
             {
                 Text = "Root",
-                Level = new Level1
-                {
-                    Text = "Level1",
-                    Level = new Level2
-                    {
-                        Text = "Mismatch"
-                    }
-                }
+                Level = new Level1 { Text = "Level1", Level = new Level2 { Text = "Mismatch" } }
             };
-
             var expected = new RootDto
             {
                 Text = "Root",
-                Level = new Level1Dto
-                {
-                    Text = "Level1",
-                    Level = new Level2Dto
-                    {
-                        Text = "Level2"
-                    }
-                }
+                Level = new Level1Dto { Text = "Level1", Level = new Level2Dto { Text = "Level2" } }
             };
 
-            // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected,
-                options => options.WithoutRecursing().IncludingNestedObjects());
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, options => options.WithoutRecursing().IncludingNestedObjects());
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("*Level.Level.Text*Mismatch*Level2*");
         }
 
@@ -347,43 +200,23 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Can_include_a_default_interface_property_using_an_expression()
         {
-            // Arrange
-            IHaveDefaultProperty subject = new ClassReceivedDefaultInterfaceProperty
-            {
-                NormalProperty = "Value"
-            };
+            IHaveDefaultProperty subject = new ClassReceivedDefaultInterfaceProperty { NormalProperty = "Value" };
+            IHaveDefaultProperty expectation = new ClassReceivedDefaultInterfaceProperty { NormalProperty = "Another Value" };
 
-            IHaveDefaultProperty expectation = new ClassReceivedDefaultInterfaceProperty
-            {
-                NormalProperty = "Another Value"
-            };
-
-            // Act
             var act = () => subject.Should().BeEquivalentTo(expectation, x => x.Including(p => p.DefaultProperty));
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected property subject.DefaultProperty to be 13, but found 5.*");
         }
 
         [Fact]
         public void Can_include_a_default_interface_property_using_a_name()
         {
-            // Arrange
-            IHaveDefaultProperty subject = new ClassReceivedDefaultInterfaceProperty
-            {
-                NormalProperty = "Value"
-            };
+            IHaveDefaultProperty subject = new ClassReceivedDefaultInterfaceProperty { NormalProperty = "Value" };
+            IHaveDefaultProperty expectation = new ClassReceivedDefaultInterfaceProperty { NormalProperty = "Another Value" };
 
-            IHaveDefaultProperty expectation = new ClassReceivedDefaultInterfaceProperty
-            {
-                NormalProperty = "Another Value"
-            };
-
-            // Act
             var act = () => subject.Should().BeEquivalentTo(expectation,
                 x => x.Including(p => p.Name.Contains("DefaultProperty")));
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected property subject.DefaultProperty to be 13, but found 5.*");
         }
 
@@ -403,95 +236,52 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void An_anonymous_object_selects_correctly()
         {
-            // Arrange
             var subject = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum",
-                Field3 = "dolor",
-                Property1 = "sit",
-                Property2 = "amet",
-                Property3 = "consectetur"
+                Field1 = "Lorem", Field2 = "ipsum", Field3 = "dolor",
+                Property1 = "sit", Property2 = "amet", Property3 = "consectetur"
             };
-
             var expectation = new ClassWithSomeFieldsAndProperties
             {
-                Field1 = "Lorem",
-                Field2 = "ipsum"
+                Field1 = "Lorem", Field2 = "ipsum"
             };
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation,
-                        opts => opts.Including(o => new { o.Field1, o.Field2, o.Field3 }));
+                opts => opts.Including(o => new { o.Field1, o.Field2, o.Field3 }));
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected field subject.Field3*");
         }
 
         [Fact]
         public void An_anonymous_object_selects_nested_fields_correctly()
         {
-            // Arrange
-            var subject = new
-            {
-                Field = "Lorem",
-                NestedField = new
-                {
-                    FieldB = "ipsum"
-                }
-            };
+            var subject = new { Field = "Lorem", NestedField = new { FieldB = "ipsum" } };
+            var expectation = new { FieldA = "Lorem", NestedField = new { FieldB = "no ipsum" } };
 
-            var expectation = new
-            {
-                FieldA = "Lorem",
-                NestedField = new
-                {
-                    FieldB = "no ipsum"
-                }
-            };
-
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation,
-                        opts => opts.Including(o => new { o.NestedField.FieldB }));
+                opts => opts.Including(o => new { o.NestedField.FieldB }));
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected*subject.NestedField.FieldB*");
         }
 
         [Fact]
         public void An_anonymous_object_in_combination_with_exclude_selects_nested_fields_correctly()
         {
-            // Arrange
             var subject = new
             {
                 FieldA = "Lorem",
-                NestedField = new
-                {
-                    FieldB = "ipsum",
-                    FieldC = "ipsum2",
-                    FieldD = "ipsum3",
-                    FieldE = "ipsum4",
-                }
+                NestedField = new { FieldB = "ipsum", FieldC = "ipsum2", FieldD = "ipsum3", FieldE = "ipsum4" }
             };
-
             var expectation = new
             {
                 FieldA = "Lorem",
-                NestedField = new
-                {
-                    FieldB = "no ipsum",
-                    FieldC = "no ipsum2",
-                    FieldD = "no ipsum3",
-                    FieldE = "no ipsum4",
-                }
+                NestedField = new { FieldB = "no ipsum", FieldC = "no ipsum2", FieldD = "no ipsum3", FieldE = "no ipsum4" }
             };
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(o => new { o.NestedField })
                 .Including(o => new { o.NestedField.FieldB }));
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .Which.Message.Should()
                 .Match("*Expected*subject.NestedField.FieldB*").And

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Interfaces.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Interfaces.cs
@@ -12,148 +12,93 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_an_interface_hierarchy_is_used_it_should_include_all_inherited_properties()
         {
-            // Arrange
-            ICar subject = new Car
-            {
-                VehicleId = 1,
-                Wheels = 4
-            };
+            ICar subject = new Car { VehicleId = 1, Wheels = 4 };
+            ICar expected = new Car { VehicleId = 99999, Wheels = 4 };
 
-            ICar expected = new Car
-            {
-                VehicleId = 99999,
-                Wheels = 4
-            };
-
-            // Act
             Action action = () => subject.Should().BeEquivalentTo(expected);
 
-            // Assert
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected*VehicleId*99999*but*1*");
+            action.Should().Throw<XunitException>().WithMessage("Expected*VehicleId*99999*but*1*");
         }
 
         [Fact]
         public void When_a_reference_to_an_interface_is_provided_it_should_only_include_those_properties()
         {
-            // Arrange
-            IVehicle expected = new Car
-            {
-                VehicleId = 1,
-                Wheels = 4
-            };
+            IVehicle expected = new Car { VehicleId = 1, Wheels = 4 };
+            IVehicle subject = new Car { VehicleId = 1, Wheels = 99999 };
 
-            IVehicle subject = new Car
-            {
-                VehicleId = 1,
-                Wheels = 99999
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
         public void When_a_reference_to_an_explicit_interface_impl_is_provided_it_should_only_include_those_properties()
         {
-            // Arrange
-            IVehicle expected = new ExplicitCar
-            {
-                Wheels = 4
-            };
+            IVehicle expected = new ExplicitCar { Wheels = 4 };
+            IVehicle subject = new ExplicitCar { Wheels = 99999 };
 
-            IVehicle subject = new ExplicitCar
-            {
-                Wheels = 99999
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected);
         }
 
         [Fact]
         public void Explicitly_implemented_subject_properties_are_ignored_if_a_normal_property_exists_with_the_same_name()
         {
-            // Arrange
-            IVehicle expected = new Vehicle
-            {
-                VehicleId = 1
-            };
-
+            IVehicle expected = new Vehicle { VehicleId = 1 };
             IVehicle subject = new ExplicitVehicle
             {
                 VehicleId = 2 // normal property
             };
-
             subject.VehicleId = 1; // explicitly implemented property
 
-            // Act
             Action action = () => subject.Should().BeEquivalentTo(expected);
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void Explicitly_implemented_read_only_subject_properties_are_ignored_if_a_normal_property_exists_with_the_same_name()
+        public void
+            Explicitly_implemented_read_only_subject_properties_are_ignored_if_a_normal_property_exists_with_the_same_name()
         {
-            // Arrange
             IReadOnlyVehicle subject = new ExplicitReadOnlyVehicle(explicitValue: 1)
             {
                 VehicleId = 2 // normal property
             };
+            var expected = new Vehicle { VehicleId = 1 };
 
-            var expected = new Vehicle
-            {
-                VehicleId = 1
-            };
-
-            // Act
             Action action = () => subject.Should().BeEquivalentTo(expected);
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void Explicitly_implemented_subject_properties_are_ignored_if_only_fields_are_included()
         {
-            // Arrange
             var expected = new VehicleWithField
             {
                 VehicleId = 1 // A field named like a property
             };
-
             var subject = new ExplicitVehicle
             {
                 VehicleId = 2 // A real property
             };
 
-            // Act
             Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt
                 .IncludingFields()
                 .ExcludingProperties());
 
-            // Assert
             action.Should().Throw<XunitException>().WithMessage("*field*VehicleId*other*");
         }
 
         [Fact]
         public void Explicitly_implemented_subject_properties_are_ignored_if_only_fields_are_included_and_they_may_be_missing()
         {
-            // Arrange
             var expected = new VehicleWithField
             {
                 VehicleId = 1 // A field named like a property
             };
-
             var subject = new ExplicitVehicle
             {
                 VehicleId = 2 // A real property
             };
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected, opt => opt
                 .IncludingFields()
                 .ExcludingProperties()
@@ -163,145 +108,90 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Excluding_missing_members_does_not_affect_how_explicitly_implemented_subject_properties_are_dealt_with()
         {
-            // Arrange
-            IVehicle expected = new Vehicle
-            {
-                VehicleId = 1
-            };
-
+            IVehicle expected = new Vehicle { VehicleId = 1 };
             IVehicle subject = new ExplicitVehicle
             {
                 VehicleId = 2 // instance member
             };
-
             subject.VehicleId = 1; // interface member
 
-            // Act
             Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.ExcludingMissingMembers());
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_respecting_declared_types_explicit_interface_member_on_interfaced_expectation_should_be_used()
         {
-            // Arrange
             IVehicle expected = new ExplicitVehicle
             {
                 VehicleId = 2 // instance member
             };
-
             expected.VehicleId = 1; // interface member
+            IVehicle subject = new Vehicle { VehicleId = 1 };
 
-            IVehicle subject = new Vehicle
-            {
-                VehicleId = 1
-            };
-
-            // Act / Assert
             subject.Should().BeEquivalentTo(expected, opt => opt.PreferringDeclaredMemberTypes());
         }
 
         [Fact]
         public void When_respecting_runtime_types_explicit_interface_member_on_interfaced_subject_should_not_be_used()
         {
-            // Arrange
-            IVehicle expected = new Vehicle
-            {
-                VehicleId = 1
-            };
-
+            IVehicle expected = new Vehicle { VehicleId = 1 };
             IVehicle subject = new ExplicitVehicle
             {
                 VehicleId = 2 // instance member
             };
-
             subject.VehicleId = 1; // interface member
 
-            // Act
             Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.PreferringRuntimeMemberTypes());
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_respecting_runtime_types_explicit_interface_member_on_interfaced_expectation_should_not_be_used()
         {
-            // Arrange
             IVehicle expected = new ExplicitVehicle
             {
                 VehicleId = 2 // instance member
             };
-
             expected.VehicleId = 1; // interface member
+            IVehicle subject = new Vehicle { VehicleId = 1 };
 
-            IVehicle subject = new Vehicle
-            {
-                VehicleId = 1
-            };
-
-            // Act
             Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.PreferringRuntimeMemberTypes());
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_respecting_declared_types_explicit_interface_member_on_expectation_should_not_be_used()
         {
-            // Arrange
-            var expected = new ExplicitVehicle
-            {
-                VehicleId = 2
-            };
-
+            var expected = new ExplicitVehicle { VehicleId = 2 };
             ((IVehicle)expected).VehicleId = 1;
+            var subject = new Vehicle { VehicleId = 1 };
 
-            var subject = new Vehicle
-            {
-                VehicleId = 1
-            };
-
-            // Act
             Action action = () => subject.Should().BeEquivalentTo(expected);
 
-            // Assert
             action.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void Can_find_explicitly_implemented_property_on_the_subject()
         {
-            // Arrange
             IPerson person = new Person();
             person.Name = "Bob";
 
-            // Act / Assert
             person.Should().BeEquivalentTo(new { Name = "Bob" });
         }
 
         [Fact]
         public void Can_exclude_explicitly_implemented_properties()
         {
-            // Arrange
-            var subject = new Person
-            {
-                NormalProperty = "Normal",
-            };
-
+            var subject = new Person { NormalProperty = "Normal", };
             ((IPerson)subject).Name = "Bob";
-
-            var expectation = new Person
-            {
-                NormalProperty = "Normal",
-            };
-
+            var expectation = new Person { NormalProperty = "Normal", };
             ((IPerson)expectation).Name = "Jim";
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation, options => options.ExcludingExplicitlyImplementedProperties());
         }
 
@@ -321,26 +211,9 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Excluding_an_interface_property_through_inheritance_should_work()
         {
-            // Arrange
-            IInterfaceWithTwoProperties[] actual =
-            [
-                new DerivedClassImplementingInterface
-                {
-                    Value1 = 1,
-                    Value2 = 2
-                }
-            ];
+            IInterfaceWithTwoProperties[] actual = [new DerivedClassImplementingInterface { Value1 = 1, Value2 = 2 }];
+            IInterfaceWithTwoProperties[] expected = [new DerivedClassImplementingInterface { Value1 = 999, Value2 = 2 }];
 
-            IInterfaceWithTwoProperties[] expected =
-            [
-                new DerivedClassImplementingInterface
-                {
-                    Value1 = 999,
-                    Value2 = 2
-                }
-            ];
-
-            // Act / Assert
             actual.Should().BeEquivalentTo(expected, options => options
                 .Excluding(a => a.Value1)
                 .PreferringRuntimeMemberTypes());
@@ -349,26 +222,9 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Including_an_interface_property_through_inheritance_should_work()
         {
-            // Arrange
-            IInterfaceWithTwoProperties[] actual =
-            [
-                new DerivedClassImplementingInterface
-                {
-                    Value1 = 1,
-                    Value2 = 2
-                }
-            ];
+            IInterfaceWithTwoProperties[] actual = [new DerivedClassImplementingInterface { Value1 = 1, Value2 = 2 }];
+            IInterfaceWithTwoProperties[] expected = [new DerivedClassImplementingInterface { Value1 = 999, Value2 = 2 }];
 
-            IInterfaceWithTwoProperties[] expected =
-            [
-                new DerivedClassImplementingInterface
-                {
-                    Value1 = 999,
-                    Value2 = 2
-                }
-            ];
-
-            // Act / Assert
             actual.Should().BeEquivalentTo(expected, options => options
                 .Including(a => a.Value2)
                 .PreferringRuntimeMemberTypes());

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.MemberHiding.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.MemberHiding.cs
@@ -11,44 +11,22 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Ignores_properties_hidden_by_the_derived_class()
         {
-            // Arrange
-            var subject = new SubclassAHidingProperty<string>
-            {
-                Property = "DerivedValue"
-            };
-
+            var subject = new SubclassAHidingProperty<string> { Property = "DerivedValue" };
             ((BaseWithProperty)subject).Property = "ActualBaseValue";
-
-            var expectation = new SubclassBHidingProperty<string>
-            {
-                Property = "DerivedValue"
-            };
-
+            var expectation = new SubclassBHidingProperty<string> { Property = "DerivedValue" };
             ((AnotherBaseWithProperty)expectation).Property = "ExpectedBaseValue";
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation);
         }
 
         [Fact]
         public void Ignores_properties_of_the_same_runtime_types_hidden_by_the_derived_class()
         {
-            // Arrange
-            var subject = new SubclassHidingStringProperty
-            {
-                Property = "DerivedValue"
-            };
-
+            var subject = new SubclassHidingStringProperty { Property = "DerivedValue" };
             ((BaseWithStringProperty)subject).Property = "ActualBaseValue";
-
-            var expectation = new SubclassHidingStringProperty
-            {
-                Property = "DerivedValue"
-            };
-
+            var expectation = new SubclassHidingStringProperty { Property = "DerivedValue" };
             ((BaseWithStringProperty)expectation).Property = "ExpectedBaseValue";
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation);
         }
 
@@ -56,21 +34,13 @@ public partial class SelectionRulesSpecs
         public void Includes_hidden_property_of_the_base_when_using_a_reference_to_the_base()
         {
             // Arrange
-            BaseWithProperty subject = new SubclassAHidingProperty<string>
-            {
-                Property = "ActualDerivedValue"
-            };
+            BaseWithProperty subject = new SubclassAHidingProperty<string> { Property = "ActualDerivedValue" };
 
             // AA doesn't know the compile-time type of the subject, so even though we pass a reference to the base-class,
             // at run-time, it'll start finding the property on the subject starting from the run-time type, and thus ignore the
             // hidden base-class field
             ((SubclassAHidingProperty<string>)subject).Property = "BaseValue";
-
-            AnotherBaseWithProperty expectation = new SubclassBHidingProperty<string>
-            {
-                Property = "ExpectedDerivedValue"
-            };
-
+            AnotherBaseWithProperty expectation = new SubclassBHidingProperty<string> { Property = "ExpectedDerivedValue" };
             expectation.Property = "BaseValue";
 
             // Act / Assert
@@ -80,44 +50,22 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Run_type_typing_ignores_hidden_properties_even_when_using_a_reference_to_the_base_class()
         {
-            // Arrange
-            var subject = new SubclassAHidingProperty<string>
-            {
-                Property = "DerivedValue"
-            };
-
+            var subject = new SubclassAHidingProperty<string> { Property = "DerivedValue" };
             ((BaseWithProperty)subject).Property = "ActualBaseValue";
-
-            AnotherBaseWithProperty expectation = new SubclassBHidingProperty<string>
-            {
-                Property = "DerivedValue"
-            };
-
+            AnotherBaseWithProperty expectation = new SubclassBHidingProperty<string> { Property = "DerivedValue" };
             expectation.Property = "ExpectedBaseValue";
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation, o => o.PreferringRuntimeMemberTypes());
         }
 
         [Fact]
         public void Including_the_derived_property_excludes_the_hidden_property()
         {
-            // Arrange
-            var subject = new SubclassAHidingProperty<string>
-            {
-                Property = "DerivedValue"
-            };
-
+            var subject = new SubclassAHidingProperty<string> { Property = "DerivedValue" };
             ((BaseWithProperty)subject).Property = "ActualBaseValue";
-
-            var expectation = new SubclassBHidingProperty<string>
-            {
-                Property = "DerivedValue"
-            };
-
+            var expectation = new SubclassBHidingProperty<string> { Property = "DerivedValue" };
             ((AnotherBaseWithProperty)expectation).Property = "ExpectedBaseValue";
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation, opt => opt
                 .Including(o => o.Property));
         }
@@ -125,20 +73,14 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Excluding_the_property_hiding_the_base_class_one_does_not_reveal_the_latter()
         {
-            // Arrange
             var subject = new SubclassAHidingProperty<string>();
-
             ((BaseWithProperty)subject).Property = "ActualBaseValue";
-
             var expectation = new SubclassBHidingProperty<string>();
-
             ((AnotherBaseWithProperty)expectation).Property = "ExpectedBaseValue";
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, o => o
                 .Excluding(b => b.Property));
 
-            // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage("*No members were found *");
         }
 
@@ -174,32 +116,17 @@ public partial class SelectionRulesSpecs
 
         private class SubclassBHidingProperty<T> : AnotherBaseWithProperty
         {
-            public new T Property
-            {
-                get;
-                set;
-            }
+            public new T Property { get; set; }
         }
 
         [Fact]
         public void Ignores_fields_hidden_by_the_derived_class()
         {
-            // Arrange
-            var subject = new SubclassAHidingField
-            {
-                Field = "DerivedValue"
-            };
-
+            var subject = new SubclassAHidingField { Field = "DerivedValue" };
             ((BaseWithField)subject).Field = "ActualBaseValue";
-
-            var expectation = new SubclassBHidingField
-            {
-                Field = "DerivedValue"
-            };
-
+            var expectation = new SubclassBHidingField { Field = "DerivedValue" };
             ((AnotherBaseWithField)expectation).Field = "ExpectedBaseValue";
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation, options => options.IncludingFields());
         }
 
@@ -207,21 +134,13 @@ public partial class SelectionRulesSpecs
         public void Includes_hidden_field_of_the_base_when_using_a_reference_to_the_base()
         {
             // Arrange
-            BaseWithField subject = new SubclassAHidingField
-            {
-                Field = "BaseValueFromSubject"
-            };
+            BaseWithField subject = new SubclassAHidingField { Field = "BaseValueFromSubject" };
 
             // AA doesn't know the compile-time type of the subject, so even though we pass a reference to the base-class,
             // at run-time, it'll start finding the field on the subject starting from the run-time type, and thus ignore the
             // hidden base-class field
             ((SubclassAHidingField)subject).Field = "BaseValueFromExpectation";
-
-            AnotherBaseWithField expectation = new SubclassBHidingField
-            {
-                Field = "ExpectedDerivedValue"
-            };
-
+            AnotherBaseWithField expectation = new SubclassBHidingField { Field = "ExpectedDerivedValue" };
             expectation.Field = "BaseValueFromExpectation";
 
             // Act / Assert
@@ -231,44 +150,22 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Run_type_typing_ignores_hidden_fields_even_when_using_a_reference_to_the_base_class()
         {
-            // Arrange
-            var subject = new SubclassAHidingField
-            {
-                Field = "DerivedValue"
-            };
-
+            var subject = new SubclassAHidingField { Field = "DerivedValue" };
             ((BaseWithField)subject).Field = "ActualBaseValue";
-
-            AnotherBaseWithField expectation = new SubclassBHidingField
-            {
-                Field = "DerivedValue"
-            };
-
+            AnotherBaseWithField expectation = new SubclassBHidingField { Field = "DerivedValue" };
             expectation.Field = "ExpectedBaseValue";
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation, options => options.IncludingFields().PreferringRuntimeMemberTypes());
         }
 
         [Fact]
         public void Including_the_derived_field_excludes_the_hidden_field()
         {
-            // Arrange
-            var subject = new SubclassAHidingField
-            {
-                Field = "DerivedValue"
-            };
-
+            var subject = new SubclassAHidingField { Field = "DerivedValue" };
             ((BaseWithField)subject).Field = "ActualBaseValue";
-
-            var expectation = new SubclassBHidingField
-            {
-                Field = "DerivedValue"
-            };
-
+            var expectation = new SubclassBHidingField { Field = "DerivedValue" };
             ((AnotherBaseWithField)expectation).Field = "ExpectedBaseValue";
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(expectation, options => options
                 .IncludingFields()
                 .Including(o => o.Field));
@@ -277,21 +174,15 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void Excluding_the_field_hiding_the_base_class_one_does_not_reveal_the_latter()
         {
-            // Arrange
             var subject = new SubclassAHidingField();
-
             ((BaseWithField)subject).Field = "ActualBaseValue";
-
             var expectation = new SubclassBHidingField();
-
             ((AnotherBaseWithField)expectation).Field = "ExpectedBaseValue";
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, options => options
                 .IncludingFields()
                 .Excluding(b => b.Field));
 
-            // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage("*No members were found *");
         }
 

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -11,11 +11,9 @@ public partial class SelectionRulesSpecs
     [Fact]
     public void Public_methods_follow_fluent_syntax()
     {
-        // Arrange
         var subject = new Root();
         var expected = new RootDto();
 
-        // Act / Assert
         subject.Should().BeEquivalentTo(expected,
             options => options
                 .AllowingInfiniteRecursion()
@@ -46,7 +44,7 @@ public partial class SelectionRulesSpecs
                 .PreferringDeclaredMemberTypes()
                 .PreferringRuntimeMemberTypes()
                 .ThrowingOnMissingMembers()
-                .Using(new ExtensibilitySpecs.DoEquivalencyStep(() => { }))
+                .Using(new DoEquivalencyStep(() => { }))
                 .Using(new MustMatchByNameRule())
                 .Using(new AllFieldsSelectionRule())
                 .Using(new ByteArrayOrderingRule())
@@ -61,6 +59,23 @@ public partial class SelectionRulesSpecs
                 .WithStrictOrdering()
                 .WithStrictOrderingFor(r => r.Level)
                 .WithTracing()
-            );
+        );
+    }
+
+    internal class DoEquivalencyStep : IEquivalencyStep
+    {
+        private readonly Action doAction;
+
+        public DoEquivalencyStep(Action doAction)
+        {
+            this.doAction = doAction;
+        }
+
+        public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
+            IValidateChildNodeEquivalency valueChildNodes)
+        {
+            doAction();
+            return EquivalencyResult.EquivalencyProven;
+        }
     }
 }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/TupleSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/TupleSpecs.cs
@@ -8,23 +8,18 @@ public class TupleSpecs
     [Fact]
     public void When_a_nested_member_is_a_tuple_it_should_compare_its_property_for_equivalence()
     {
-        // Arrange
         var actual = new { Tuple = (new[] { "string1" }, new[] { "string2" }) };
-
         var expected = new { Tuple = (new[] { "string1" }, new[] { "string2" }) };
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public void When_a_tuple_is_compared_it_should_compare_its_components()
     {
-        // Arrange
         var actual = Tuple.Create("Hello", true, new[] { 3, 2, 1 });
         var expected = Tuple.Create("Hello", true, new[] { 1, 2, 3 });
 
-        // Act / Assert
         actual.Should().BeEquivalentTo(expected);
     }
 }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/XmlSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/XmlSpecs.cs
@@ -11,39 +11,20 @@ public class XmlSpecs
     public void
         When_asserting_a_xml_selfclosing_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
     {
-        // Arrange
-        var subject = new
-        {
-            Document = XDocument.Parse("<parent><child /></parent>")
-        };
+        var subject = new { Document = XDocument.Parse("<parent><child /></parent>") };
+        var expectation = new { Document = XDocument.Parse("<parent><child /></parent>") };
 
-        var expectation = new
-        {
-            Document = XDocument.Parse("<parent><child /></parent>")
-        };
-
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_asserting_a_xml_document_is_equivalent_to_a_xml_document_with_elements_missing_it_should_fail()
     {
-        var subject = new
-        {
-            Document = XDocument.Parse("<parent><child /><child2 /></parent>")
-        };
+        var subject = new { Document = XDocument.Parse("<parent><child /><child2 /></parent>") };
+        var expectation = new { Document = XDocument.Parse("<parent><child /></parent>") };
 
-        var expectation = new
-        {
-            Document = XDocument.Parse("<parent><child /></parent>")
-        };
+        Action act = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Act
-        Action act = () =>
-            subject.Should().BeEquivalentTo(expectation);
-
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected EndElement \"parent\" in property subject.Document at \"/parent\", but found Element \"child2\".*");
     }
@@ -51,40 +32,20 @@ public class XmlSpecs
     [Fact]
     public void When_xml_elements_are_equivalent_it_should_not_throw()
     {
-        // Arrange
-        var subject = new
-        {
-            Element = XElement.Parse("<parent><child /></parent>")
-        };
+        var subject = new { Element = XElement.Parse("<parent><child /></parent>") };
+        var expectation = new { Element = XElement.Parse("<parent><child /></parent>") };
 
-        var expectation = new
-        {
-            Element = XElement.Parse("<parent><child /></parent>")
-        };
-
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_an_xml_element_property_is_equivalent_to_an_xml_element_with_elements_missing_it_should_fail()
     {
-        // Arrange
-        var subject = new
-        {
-            Element = XElement.Parse("<parent><child /><child2 /></parent>")
-        };
+        var subject = new { Element = XElement.Parse("<parent><child /><child2 /></parent>") };
+        var expectation = new { Element = XElement.Parse("<parent><child /></parent>") };
 
-        var expectation = new
-        {
-            Element = XElement.Parse("<parent><child /></parent>")
-        };
+        Action act = () => subject.Should().BeEquivalentTo(expectation);
 
-        // Act
-        Action act = () =>
-            subject.Should().BeEquivalentTo(expectation);
-
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected EndElement \"parent\" in property subject.Element at \"/parent\", but found Element \"child2\"*");
     }
@@ -92,39 +53,21 @@ public class XmlSpecs
     [Fact]
     public void When_asserting_an_xml_attribute_is_equal_to_the_same_xml_attribute_it_should_succeed()
     {
-        var subject = new
-        {
-            Attribute = new XAttribute("name", "value")
-        };
+        var subject = new { Attribute = new XAttribute("name", "value") };
+        var expectation = new { Attribute = new XAttribute("name", "value") };
 
-        var expectation = new
-        {
-            Attribute = new XAttribute("name", "value")
-        };
-
-        // Act / Assert
         subject.Should().BeEquivalentTo(expectation);
     }
 
     [Fact]
     public void When_asserting_an_xml_attribute_is_equal_to_a_different_xml_attribute_it_should_fail_with_descriptive_message()
     {
-        // Arrange
-        var subject = new
-        {
-            Attribute = new XAttribute("name", "value")
-        };
+        var subject = new { Attribute = new XAttribute("name", "value") };
+        var expectation = new { Attribute = new XAttribute("name2", "value") };
 
-        var expectation = new
-        {
-            Attribute = new XAttribute("name2", "value")
-        };
-
-        // Act
         Action act = () =>
-            subject.Should().BeEquivalentTo(expectation, "because we want to test the failure {0}", "message");
+            subject.Should().BeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>().WithMessage(
             "Expected property subject.Attribute to be name2=\"value\" because we want to test the failure message, but found name=\"value\"*");
     }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
@@ -47,12 +47,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().AllBeAssignableTo(typeof(object), "we want to test the failure {0}", "message");
+                collection.Should().AllBeAssignableTo(typeof(object), "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be object *failure message*, but found collection is <null>.");
+                .WithMessage("Expected type to be object because*failure message, but found collection is <null>.");
         }
 
         [Fact]
@@ -113,11 +113,11 @@ public partial class CollectionAssertionSpecs
             var collection = new object[] { 1, "2", 3 };
 
             // Act
-            Action act = () => collection.Should().AllBeAssignableTo(typeof(int), "because they are of different type");
+            Action act = () => collection.Should().AllBeAssignableTo(typeof(int), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be int because they are of different type, but found {int, string, int}.");
+                "Expected type to be int because*failure message, but found {int, string, int}.");
         }
 
         [Fact]
@@ -127,11 +127,11 @@ public partial class CollectionAssertionSpecs
             var collection = new object[] { 1, "2", 3 };
 
             // Act
-            Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
+            Action act = () => collection.Should().AllBeAssignableTo<int>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be int because they are of different type, but found {int, string, int}.");
+                "Expected type to be int because*failure message, but found {int, string, int}.");
         }
 
         [Fact]
@@ -141,11 +141,11 @@ public partial class CollectionAssertionSpecs
             var collection = new object[] { 1, null, 3 };
 
             // Act
-            Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
+            Action act = () => collection.Should().AllBeAssignableTo<int>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be int because they are of different type, but found a null element.");
+                "Expected type to be int because*failure message, but found a null element.");
         }
 
         [Fact]
@@ -165,11 +165,11 @@ public partial class CollectionAssertionSpecs
             Type[] collection = [typeof(int), typeof(string), typeof(int)];
 
             // Act
-            Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
+            Action act = () => collection.Should().AllBeAssignableTo<int>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be int because they are of different type, but found {int, string, int}.");
+                "Expected type to be int because*failure message, but found {int, string, int}.");
         }
 
         [Fact]
@@ -202,12 +202,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().AllBeAssignableTo<object>("we want to test the failure {0}", "message");
+                collection.Should().AllBeAssignableTo<object>("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be object *failure message*, but found collection is <null>.");
+                .WithMessage("Expected type to be object because*failure message, but found collection is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
@@ -57,12 +57,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().AllBeOfType(typeof(object), "we want to test the failure {0}", "message");
+                collection.Should().AllBeOfType(typeof(object), "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be object *failure message*, but found collection is <null>.");
+                .WithMessage("Expected type to be object because*failure message, but found collection is <null>.");
         }
 
         [Fact]
@@ -103,11 +103,11 @@ public partial class CollectionAssertionSpecs
             var collection = new object[] { new Exception(), new ArgumentException("foo") };
 
             // Act
-            Action act = () => collection.Should().AllBeOfType(typeof(Exception), "because they are of different type");
+            Action act = () => collection.Should().AllBeOfType(typeof(Exception), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be System.Exception because they are of different type, but found {System.Exception, System.ArgumentException}.");
+                "Expected type to be System.Exception because*failure message, but found {System.Exception, System.ArgumentException}.");
         }
 
         [Fact]
@@ -117,11 +117,11 @@ public partial class CollectionAssertionSpecs
             var collection = new object[] { new Exception(), new ArgumentException("foo") };
 
             // Act
-            Action act = () => collection.Should().AllBeOfType<Exception>("because they are of different type");
+            Action act = () => collection.Should().AllBeOfType<Exception>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be System.Exception because they are of different type, but found {System.Exception, System.ArgumentException}.");
+                "Expected type to be System.Exception because*failure message, but found {System.Exception, System.ArgumentException}.");
         }
 
         [Fact]
@@ -131,11 +131,11 @@ public partial class CollectionAssertionSpecs
             var collection = new object[] { 1, null, 3 };
 
             // Act
-            Action act = () => collection.Should().AllBeOfType<int>("because they are of different type");
+            Action act = () => collection.Should().AllBeOfType<int>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be int because they are of different type, but found a null element.");
+                "Expected type to be int because*failure message, but found a null element.");
         }
 
         [Fact]
@@ -182,12 +182,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().AllBeOfType<object>("we want to test the failure {0}", "message");
+                collection.Should().AllBeOfType<object>("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be object *failure message*, but found collection is <null>.");
+                .WithMessage("Expected type to be object because*failure message, but found collection is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
@@ -38,14 +38,14 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().AllSatisfy(x => x.Should().Be(1), "because we want to test the failure {0}", "message");
+                collection.Should().AllSatisfy(x => x.Should().Be(1), "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain only items satisfying the inspector because we want to test the failure message, but collection is <null>.");
+                    "Expected collection to contain only items satisfying the inspector because*failure message, but collection is <null>.");
         }
 
         [Fact]
@@ -88,14 +88,13 @@ public partial class CollectionAssertionSpecs
                         customer.Items.Should()
                             .AllSatisfy(item => item.Should().Be(3));
                     },
-                    "because we want to test {0}",
-                    "nested assertions");
+                    "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
                 .WithMessage("""
-                    Expected customers to contain only items satisfying the inspector because we want to test nested assertions:
+                    Expected customers to contain only items satisfying the inspector because*failure message:
                     *At index 0:
                     *Expected customer.Age to be less than 21, but found 21
                     *Expected customer.Items to contain only items satisfying the inspector:

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -31,11 +31,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().BeEmpty("that's what we expect");
+            Action act = () => collection.Should().BeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty because that's what we expect, but found at least one item*1*");
+                .WithMessage("*to be empty because*failure message, but found at least one item*1*");
         }
 
         [Fact]
@@ -81,11 +81,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [];
 
             // Act
-            Action act = () => collection.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+            Action act = () => collection.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection not to be empty because we want to test the failure message.");
+                .WithMessage("Expected collection not to be empty because*failure message.");
         }
 
         [Fact]
@@ -98,12 +98,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().BeEmpty("we want to test the failure {0}", "message");
+                collection.Should().BeEmpty("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be empty *failure message*, but found <null>.");
+                .WithMessage("Expected collection to be empty because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -144,12 +144,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotBeEmpty("we want to test the failure {0}", "message");
+                collection.Should().NotBeEmpty("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection not to be empty *failure message*, but found <null>.");
+                .WithMessage("Expected collection not to be empty because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -175,11 +175,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should().NotBeEmpty("because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to be empty because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection not to be empty because*failure message, but found <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -54,11 +54,11 @@ public partial class CollectionAssertionSpecs
             int[] collection2 = [1, 2];
 
             // Act
-            Action act = () => collection1.Should().BeEquivalentTo(collection2, "we treat {0} alike", "all");
+            Action act = () => collection1.Should().BeEquivalentTo(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*collection*2 item(s)*we treat all alike, but *1 item(s) more than*");
+                "Expected*collection*2 item(s) because*failure message, but *1 item(s) more than*");
         }
 
         [Fact]
@@ -114,7 +114,7 @@ public partial class CollectionAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*<null>*failure message*but found {1, 2, 3}*");
+                "Expected*<null> because*failure message*but found {1, 2, 3}*");
         }
 
         [Fact]
@@ -263,12 +263,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                actual.Should().NotBeEquivalentTo(expectation, "because we want to test the behaviour with a null subject");
+                actual.Should().NotBeEquivalentTo(expectation, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*be equivalent because we want to test the behaviour with a null subject, but found <null>*");
+                "*be equivalent because*failure message, but found <null>*");
         }
 
         [Fact]
@@ -306,12 +306,11 @@ public partial class CollectionAssertionSpecs
             var collection1 = collection;
 
             // Act
-            Action act = () => collection.Should().NotBeEquivalentTo(collection1,
-                "because we want to test the behaviour with same objects");
+            Action act = () => collection.Should().NotBeEquivalentTo(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*not to be equivalent*because we want to test the behaviour with same objects*but they both reference the same object.");
+                "*not to be equivalent*because* failure message, but they both reference the same object.");
         }
 
         [Fact]
@@ -325,11 +324,10 @@ public partial class CollectionAssertionSpecs
             Action act = () => collection.Should().NotBeEquivalentTo(collection1, opt => opt
                     .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.5))
                     .WhenTypeIs<double>(),
-                "because we want to test the failure {0}", "message");
+                "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*not to be equivalent*because we want to test the failure message*");
+            act.Should().Throw<XunitException>().WithMessage("*not to be equivalent*because*failure message*");
         }
 
         [Fact]
@@ -343,12 +341,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                actual.Should().NotBeEquivalentTo(expectation, opt => opt, "we want to test the failure {0}", "message");
+                actual.Should().NotBeEquivalentTo(expectation, opt => opt, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected actual not to be equivalent *failure message*, but found <null>.*");
+                .WithMessage("Expected actual not to be equivalent because*failure message*, but found <null>.*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
@@ -60,11 +60,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 6, 12, 15, 12, 17, 26];
 
             // Act
-            Action action = () => collection.Should().BeInAscendingOrder("because numbers are ordered");
+            Action action = () => collection.Should().BeInAscendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be in ascending order because numbers are ordered," +
+                .WithMessage("Expected collection to be in ascending order because*failure message," +
                     " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
         }
 
@@ -76,11 +76,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 6, 12, 15, 12, 17, 26];
 
             // Act
-            Action action = () => collection.Should().BeInAscendingOrder(Comparer<int>.Default, "because numbers are ordered");
+            Action action = () => collection.Should().BeInAscendingOrder(Comparer<int>.Default, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be in ascending order because numbers are ordered," +
+                .WithMessage("Expected collection to be in ascending order because*failure message," +
                     " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
         }
 
@@ -206,11 +206,11 @@ public partial class CollectionAssertionSpecs
             };
 
             // Act
-            Action act = () => collection.Should().BeInAscendingOrder(o => o.Text, "it should be sorted");
+            Action act = () => collection.Should().BeInAscendingOrder(o => o.Text, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*b*c*a*ordered*Text*should be sorted*a*b*c*");
+                .WithMessage("Expected collection*b*c*a*ordered*Text* because*failure message*a*b*c*");
         }
 
         [Fact]
@@ -227,11 +227,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                collection.Should().BeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should be sorted");
+                collection.Should().BeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*b*c*a*ordered*Text*should be sorted*a*b*c*");
+                .WithMessage("Expected collection*b*c*a*ordered*Text* because*failure message*a*b*c*");
         }
 
         [Fact]
@@ -283,12 +283,12 @@ public partial class CollectionAssertionSpecs
             string[] strings = ["theta", "alpha", "beta"];
 
             // Act
-            Action act = () => strings.Should().BeInAscendingOrder("of {0}", "reasons");
+            Action act = () => strings.Should().BeInAscendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected*ascending*of reasons*index 0*");
+                .WithMessage("Expected*ascending*because*failure message*index 0*");
         }
 
         [Fact]
@@ -308,12 +308,12 @@ public partial class CollectionAssertionSpecs
             string[] strings = ["dennis", "roy", "thomas"];
 
             // Act
-            Action act = () => strings.Should().BeInAscendingOrder(new ByLastCharacterComparer(), "of {0}", "reasons");
+            Action act = () => strings.Should().BeInAscendingOrder(new ByLastCharacterComparer(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected*ascending*of reasons*index 1*");
+                .WithMessage("Expected*ascending*because*failure message*index 1*");
         }
 
         [Fact]
@@ -334,12 +334,12 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                strings.Should().BeInAscendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "of {0}", "reasons");
+                strings.Should().BeInAscendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected*ascending*of reasons*index 1*");
+                .WithMessage("Expected*ascending*because*failure message*index 1*");
         }
 
         [Fact]
@@ -474,11 +474,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 2, 3];
 
             // Act
-            Action action = () => collection.Should().NotBeInAscendingOrder("because numbers are not ordered");
+            Action action = () => collection.Should().NotBeInAscendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in ascending order because numbers are not ordered," +
+                .WithMessage("Did not expect collection to be in ascending order because*failure message," +
                     " but found {1, 2, 2, 3}.");
         }
 
@@ -491,11 +491,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action action = () =>
-                collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "because numbers are not ordered");
+                collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in ascending order because numbers are not ordered," +
+                .WithMessage("Did not expect collection to be in ascending order because*failure message," +
                     " but found {1, 2, 2, 3}.");
         }
 
@@ -520,11 +520,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [];
 
             // Act
-            Action act = () => collection.Should().NotBeInAscendingOrder("because I say {0}", "so");
+            Action act = () => collection.Should().NotBeInAscendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in ascending order because I say so, but found {empty}.");
+                .WithMessage("Did not expect collection to be in ascending order because*failure message, but found {empty}.");
         }
 
         [Fact]
@@ -566,11 +566,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "it should not be sorted");
+            Action act = () => collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in ascending order*should not be sorted*1*2*3*");
+                .WithMessage("Did not expect collection to be in ascending order because*failure message*1*2*3*");
         }
 
         [Fact]
@@ -597,11 +597,11 @@ public partial class CollectionAssertionSpecs
             };
 
             // Act
-            Action act = () => collection.Should().NotBeInAscendingOrder(o => o.Text, "it should not be sorted");
+            Action act = () => collection.Should().NotBeInAscendingOrder(o => o.Text, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*a*b*c*not be ordered*Text*should not be sorted*a*b*c*");
+                .WithMessage("Expected collection*a*b*c*not be ordered \"by Text\" because*failure message*a*b*c*");
         }
 
         [Fact]
@@ -619,11 +619,11 @@ public partial class CollectionAssertionSpecs
             // Act
             Action act = () =>
                 collection.Should()
-                    .NotBeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should not be sorted");
+                    .NotBeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*A*b*C*not be ordered*Text*should not be sorted*A*b*C*");
+                .WithMessage("Expected collection*A*b*C*not be ordered* \"by Text\" because*failure message*A*b*C*");
         }
 
         [Fact]
@@ -675,12 +675,12 @@ public partial class CollectionAssertionSpecs
             string[] strings = ["alpha", "beta", "theta"];
 
             // Act
-            Action act = () => strings.Should().NotBeInAscendingOrder("of {0}", "reasons");
+            Action act = () => strings.Should().NotBeInAscendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Did not expect*ascending*of reasons*but found*");
+                .WithMessage("Did not expect*ascending*because*failure message, but found*");
         }
 
         [Fact]
@@ -700,12 +700,12 @@ public partial class CollectionAssertionSpecs
             string[] strings = ["dennis", "thomas", "roy"];
 
             // Act
-            Action act = () => strings.Should().NotBeInAscendingOrder(new ByLastCharacterComparer(), "of {0}", "reasons");
+            Action act = () => strings.Should().NotBeInAscendingOrder(new ByLastCharacterComparer(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Did not expect*ascending*of reasons*but found*");
+                .WithMessage("Did not expect*ascending*because*failure message, but found*");
         }
 
         [Fact]
@@ -726,12 +726,12 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                strings.Should().NotBeInAscendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "of {0}", "reasons");
+                strings.Should().NotBeInAscendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Did not expect*ascending*of reasons*but found*");
+                .WithMessage("Did not expect*ascending*because*failure message, but found*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeInDescendingOrder.cs
@@ -29,11 +29,11 @@ public partial class CollectionAssertionSpecs
             string[] collection = ["z", "x", "y"];
 
             // Act
-            Action action = () => collection.Should().BeInDescendingOrder("because letters are ordered");
+            Action action = () => collection.Should().BeInDescendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be in descending order because letters are ordered," +
+                .WithMessage("Expected collection to be in descending order because*failure message," +
                     " but found {\"z\", \"x\", \"y\"} where item at index 1 is in wrong order.");
         }
 
@@ -89,11 +89,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action action = () =>
-                collection.Should().BeInDescendingOrder(Comparer<object>.Default, "because letters are ordered");
+                collection.Should().BeInDescendingOrder(Comparer<object>.Default, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be in descending order because letters are ordered," +
+                .WithMessage("Expected collection to be in descending order because*failure message," +
                     " but found {\"z\", \"x\", \"y\"} where item at index 1 is in wrong order.");
         }
 
@@ -121,11 +121,11 @@ public partial class CollectionAssertionSpecs
             };
 
             // Act
-            Action act = () => collection.Should().BeInDescendingOrder(o => o.Text, "it should be sorted");
+            Action act = () => collection.Should().BeInDescendingOrder(o => o.Text, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*b*c*a*ordered*Text*should be sorted*c*b*a*");
+                .WithMessage("Expected collection*b*c*a*ordered*Text*because*failure message*c*b*a*");
         }
 
         [Fact]
@@ -142,11 +142,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                collection.Should().BeInDescendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should be sorted");
+                collection.Should().BeInDescendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*b*c*a*ordered*Text*should be sorted*c*b*a*");
+                .WithMessage("Expected collection*b*c*a*ordered*Text*because*failure message*c*b*a*");
         }
 
         [Fact]
@@ -198,12 +198,12 @@ public partial class CollectionAssertionSpecs
             string[] strings = ["theta", "alpha", "beta"];
 
             // Act
-            Action act = () => strings.Should().BeInDescendingOrder("of {0}", "reasons");
+            Action act = () => strings.Should().BeInDescendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected*descending*of reasons*index 1*");
+                .WithMessage("Expected*descending*because*failure message*index 1*");
         }
 
         [Fact]
@@ -223,12 +223,12 @@ public partial class CollectionAssertionSpecs
             string[] strings = ["dennis", "roy", "barbara"];
 
             // Act
-            Action act = () => strings.Should().BeInDescendingOrder(new ByLastCharacterComparer(), "of {0}", "reasons");
+            Action act = () => strings.Should().BeInDescendingOrder(new ByLastCharacterComparer(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected*descending*of reasons*index 0*");
+                .WithMessage("Expected*descending*because*failure message*index 0*");
         }
 
         [Fact]
@@ -249,12 +249,12 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                strings.Should().BeInDescendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "of {0}", "reasons");
+                strings.Should().BeInDescendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected*descending*of reasons*index 0*");
+                .WithMessage("Expected*descending*because*failure message*index 0*");
         }
     }
 
@@ -288,11 +288,11 @@ public partial class CollectionAssertionSpecs
             string[] collection = ["c", "b", "a"];
 
             // Act
-            Action action = () => collection.Should().NotBeInDescendingOrder("because numbers are not ordered");
+            Action action = () => collection.Should().NotBeInDescendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in descending order because numbers are not ordered," +
+                .WithMessage("Did not expect collection to be in descending order because*failure message," +
                     " but found {\"c\", \"b\", \"a\"}.");
         }
 
@@ -305,11 +305,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action action = () =>
-                collection.Should().NotBeInDescendingOrder(Comparer<object>.Default, "because numbers are not ordered");
+                collection.Should().NotBeInDescendingOrder(Comparer<object>.Default, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in descending order because numbers are not ordered," +
+                .WithMessage("Did not expect collection to be in descending order because*failure message," +
                     " but found {\"c\", \"b\", \"a\"}.");
         }
 
@@ -334,11 +334,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [];
 
             // Act
-            Action act = () => collection.Should().NotBeInDescendingOrder("because I say {0}", "so");
+            Action act = () => collection.Should().NotBeInDescendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in descending order because I say so, but found {empty}.");
+                .WithMessage("Did not expect collection to be in descending order because*failure message, but found {empty}.");
         }
 
         [Fact]
@@ -380,11 +380,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [3, 2, 1];
 
             // Act
-            Action act = () => collection.Should().NotBeInDescendingOrder(Comparer<int>.Default, "it should not be sorted");
+            Action act = () => collection.Should().NotBeInDescendingOrder(Comparer<int>.Default, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in descending order*should not be sorted*3*2*1*");
+                .WithMessage("Did not expect collection to be in descending order*because*failure message*3*2*1*");
         }
 
         [Fact]
@@ -411,11 +411,11 @@ public partial class CollectionAssertionSpecs
             };
 
             // Act
-            Action act = () => collection.Should().NotBeInDescendingOrder(o => o.Text, "it should not be sorted");
+            Action act = () => collection.Should().NotBeInDescendingOrder(o => o.Text, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*b*c*a*not be ordered*Text*should not be sorted*c*b*a*");
+                .WithMessage("Expected collection*b*c*a*not be ordered*Text*because*failure message*c*b*a*");
         }
 
         [Fact]
@@ -433,11 +433,11 @@ public partial class CollectionAssertionSpecs
             // Act
             Action act = () =>
                 collection.Should()
-                    .NotBeInDescendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "it should not be sorted");
+                    .NotBeInDescendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*C*b*A*not be ordered*Text*should not be sorted*C*b*A*");
+                .WithMessage("Expected collection*C*b*A*not be ordered*Text*because*failure message*C*b*A*");
         }
 
         [Fact]
@@ -489,12 +489,12 @@ public partial class CollectionAssertionSpecs
             string[] strings = ["theta", "beta", "alpha"];
 
             // Act
-            Action act = () => strings.Should().NotBeInDescendingOrder("of {0}", "reasons");
+            Action act = () => strings.Should().NotBeInDescendingOrder("we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Did not expect*descending*of reasons*but found*");
+                .WithMessage("Did not expect*descending*because*failure message*but found*");
         }
 
         [Fact]
@@ -514,12 +514,12 @@ public partial class CollectionAssertionSpecs
             string[] strings = ["roy", "dennis", "barbara"];
 
             // Act
-            Action act = () => strings.Should().NotBeInDescendingOrder(new ByLastCharacterComparer(), "of {0}", "reasons");
+            Action act = () => strings.Should().NotBeInDescendingOrder(new ByLastCharacterComparer(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Did not expect*descending*of reasons*but found*");
+                .WithMessage("Did not expect*descending*because*failure message*but found*");
         }
 
         [Fact]
@@ -540,12 +540,12 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                strings.Should().NotBeInDescendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "of {0}", "reasons");
+                strings.Should().NotBeInDescendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Did not expect*descending*of reasons*but found*");
+                .WithMessage("Did not expect*descending*because*failure message*but found*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeNull.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeNull.cs
@@ -29,11 +29,11 @@ public partial class CollectionAssertionSpecs
             IEnumerable<string> someCollection = new string[0];
 
             // Act
-            Action act = () => someCollection.Should().BeNull("because {0} is valid", "null");
+            Action act = () => someCollection.Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someCollection to be <null> because null is valid, but found {empty}.");
+                "Expected someCollection to be <null> because*failure message, but found {empty}.");
         }
     }
 
@@ -56,11 +56,11 @@ public partial class CollectionAssertionSpecs
             IEnumerable<string> someCollection = null;
 
             // Act
-            Action act = () => someCollection.Should().NotBeNull("because {0} should not", "someCollection");
+            Action act = () => someCollection.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someCollection not to be <null> because someCollection should not.");
+                "Expected someCollection not to be <null> because*failure message.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeNullOrEmpty.cs
@@ -41,12 +41,12 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().BeNullOrEmpty("because we want to test the failure {0}", "message");
+            Action act = () => collection.Should().BeNullOrEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to be null or empty because we want to test the failure message, but found at least one item {1}.");
+                    "Expected collection to be null or empty because*failure message, but found at least one item {1}.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeSubsetOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeSubsetOf.cs
@@ -31,11 +31,11 @@ public partial class CollectionAssertionSpecs
             int[] superset = [1, 2, 4, 5];
 
             // Act
-            Action act = () => subset.Should().BeSubsetOf(superset, "because we want to test the failure {0}", "message");
+            Action act = () => subset.Should().BeSubsetOf(superset, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subset to be a subset of {1, 2, 4, 5} because we want to test the failure message, " +
+                "Expected subset to be a subset of {1, 2, 4, 5} because*failure message, " +
                 "but items {3, 6} are not part of the superset.");
         }
 
@@ -102,11 +102,11 @@ public partial class CollectionAssertionSpecs
             int[] otherSet = [1, 2, 3];
 
             // Act
-            Action act = () => subject.Should().NotBeSubsetOf(otherSet, "because I'm {0}", "mistaken");
+            Action act = () => subject.Should().NotBeSubsetOf(otherSet, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect subject {1, 2} to be a subset of {1, 2, 3} because I'm mistaken.");
+                "Did not expect subject {1, 2} to be a subset of {1, 2, 3} because*failure message.");
         }
 
         [Fact]
@@ -120,12 +120,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().BeSubsetOf(collection1, "because we want to test the behaviour with a null subject");
+                collection.Should().BeSubsetOf(collection1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to be a subset of {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to be a subset of {1, 2, 3} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -136,12 +136,11 @@ public partial class CollectionAssertionSpecs
             var collection1 = collection;
 
             // Act
-            Action act = () => collection.Should().NotBeSubsetOf(collection1,
-                "because we want to test the behaviour with same objects");
+            Action act = () => collection.Should().NotBeSubsetOf(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect*to be a subset of*because we want to test the behaviour with same objects*but they both reference the same object.");
+                "Did not expect*to be a subset of*because*failure message, but they both reference the same object.");
         }
 
         [Fact]
@@ -154,12 +153,11 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotBeSubsetOf([1, 2, 3], "we want to test the failure {0}", "message");
+                collection.Should().NotBeSubsetOf([1, 2, 3]);
             };
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Cannot assert a <null> collection against a subset.");
+            act.Should().Throw<XunitException>().WithMessage("Cannot assert a <null> collection against a subset.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.Contain.cs
@@ -52,11 +52,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().Contain(4, "because {0}", "we do");
+            Action act = () => collection.Should().Contain(4, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain 4 because we do.");
+                "Expected collection {1, 2, 3} to contain 4 because*failure message.");
         }
 
         [Fact]
@@ -66,11 +66,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 1];
 
             // Act
-            Action act = () => collection.Should().Contain(1, AtMost.Once(), "failure {0}", "message");
+            Action act = () => collection.Should().Contain(1, AtMost.Once(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 1} to contain 1 at most 1 time because failure message, but found it 2 times.");
+                "Expected collection {1, 2, 1} to contain 1 at most 1 time because*failure message, but found it 2 times.");
         }
 
         [Fact]
@@ -83,12 +83,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().Contain(1, "because we want to test the behaviour with a null subject");
+                collection.Should().Contain(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain 1 because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to contain 1 because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -99,11 +99,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                collection.Should().Contain(1, AtLeast.Once(), "failure {0}", "message");
+                collection.Should().Contain(1, AtLeast.Once(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain 1 because failure message, but found <null>.");
+                "Expected collection to contain 1 because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -113,11 +113,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().Contain([3, 4, 5], "because {0}", "we do");
+            Action act = () => collection.Should().Contain([3, 4, 5], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain {3, 4, 5} because we do, but could not find {4, 5}.");
+                "Expected collection {1, 2, 3} to contain {3, 4, 5} because*failure message, but could not find {4, 5}.");
         }
 
         [Fact]
@@ -127,11 +127,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().Contain([4], "because {0}", "we do");
+            Action act = () => collection.Should().Contain([4], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain 4 because we do.");
+                "Expected collection {1, 2, 3} to contain 4 because*failure message.");
         }
 
         [Fact]
@@ -178,12 +178,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().Contain([1, 2], "we want to test the failure {0}", "message");
+                collection.Should().Contain([1, 2], "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain {1, 2} *failure message*, but found <null>.");
+                .WithMessage("Expected collection to contain {1, 2} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -249,11 +249,11 @@ public partial class CollectionAssertionSpecs
             IEnumerable<int> collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().Contain(item => item > 3, "at least {0} item should be larger than 3", 1);
+            Action act = () => collection.Should().Contain(item => item > 3, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().Which.Message.Should().Be(
-                "Expected collection {1, 2, 3} to have an item matching (item > 3) because at least 1 item should be larger than 3.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to have an item matching (item > 3) because*failure message.");
         }
 
         [Fact]
@@ -263,11 +263,11 @@ public partial class CollectionAssertionSpecs
             IEnumerable<int> collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().Contain(item => item >= 2, Exactly.Times(3), "failure {0}", "message");
+            Action act = () => collection.Should().Contain(item => item >= 2, Exactly.Times(3), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().Which.Message.Should().Be(
-                "Expected collection {1, 2, 3} to contain items matching (item >= 2) exactly 3 times because failure message, but found it 2 times.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3} to contain items matching (item >= 2) exactly 3 times because*failure message, but found it 2 times.");
         }
 
         [Fact]
@@ -341,11 +341,11 @@ public partial class CollectionAssertionSpecs
             IEnumerable<string> strings = ["string1", "string2", "string3"];
 
             // Act
-            Action act = () => strings.Should().Contain("string4", "because {0} is required", "4");
+            Action act = () => strings.Should().Contain("string4", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings {\"string1\", \"string2\", \"string3\"} to contain \"string4\" because 4 is required.");
+                "Expected strings {\"string1\", \"string2\", \"string3\"} to contain \"string4\" because*failure message.");
         }
 
         [Fact]
@@ -358,12 +358,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                strings.Should().Contain("string4", "because we're checking how it reacts to a null subject");
+                strings.Should().Contain("string4", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings to contain \"string4\" because we're checking how it reacts to a null subject, but found <null>.");
+                "Expected strings to contain \"string4\" because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -391,12 +391,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                strings.Should().Contain(x => x == "xxx", "because we're checking how it reacts to a null subject");
+                strings.Should().Contain(x => x == "xxx", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings to contain (x == \"xxx\") because we're checking how it reacts to a null subject, but found <null>.");
+                "Expected strings to contain (x == \"xxx\") because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -454,11 +454,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().NotContain(1, "because we {0} like it, but found it anyhow", "don't");
+            Action act = () => collection.Should().NotContain(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to not contain 1 because we don't like it, but found it anyhow.");
+                "Expected collection {1, 2, 3} to not contain 1 because*failure message.");
         }
 
         [Fact]
@@ -482,11 +482,11 @@ public partial class CollectionAssertionSpecs
             IEnumerable<int> collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().NotContain(item => item == 2, "because {0}s are evil", 2);
+            Action act = () => collection.Should().NotContain(item => item == 2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to not have any items matching (item == 2) because 2s are evil,*{2}*");
+                "Expected collection {1, 2, 3} to not have any items matching (item == 2) because*failure message*");
         }
 
         [Fact]
@@ -509,12 +509,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContain(1, "because we want to test the behaviour with a null subject");
+                collection.Should().NotContain(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to not contain 1 because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to not contain 1 because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -524,12 +524,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should()
-                .NotContain([2], "because we {0} like them", "don't");
+            Action act = () => collection.Should().NotContain([2], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to not contain 2 because we don't like them.");
+                "Expected collection {1, 2, 3} to not contain 2 because*failure message.");
         }
 
         [Fact]
@@ -539,12 +538,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should()
-                .NotContain([1, 2, 4], "because we {0} like them", "don't");
+            Action act = () => collection.Should().NotContain([1, 2, 4], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to not contain {1, 2, 4} because we don't like them, but found {1, 2}.");
+                "Expected collection {1, 2, 3} to not contain {1, 2, 4} because*failure message, but found {1, 2}.");
         }
 
         [Fact]
@@ -588,12 +586,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContain(item => item == 4, "we want to test the failure {0}", "message");
+                collection.Should().NotContain(item => item == 4, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection not to contain (item == 4) *failure message*, but found <null>.");
+                .WithMessage("Expected collection not to contain (item == 4) because*failure message*, but found <null>.");
         }
 
         [Fact]
@@ -606,12 +604,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContain([1, 2, 4], "we want to test the failure {0}", "message");
+                collection.Should().NotContain([1, 2, 4], "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to not contain {1, 2, 4} *failure message*, but found <null>.");
+                .WithMessage("Expected collection to not contain {1, 2, 4} because*failure message*, but found <null>.");
         }
 
         [Fact]
@@ -623,11 +621,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act =
-                () => strings.Should().NotContain(x => x == "xxx", "because we're checking how it reacts to a null subject");
+                () => strings.Should().NotContain(x => x == "xxx", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings not to contain (x == \"xxx\") because we're checking how it reacts to a null subject, but found <null>.");
+                "Expected strings not to contain (x == \"xxx\") because*failure message, but found <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainEquivalentOf.cs
@@ -84,11 +84,10 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                collection.Should().ContainEquivalentOf(item, "because we want to test the failure {0}", "message");
+                collection.Should().ContainEquivalentOf(item, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*because we want to test the failure message*");
+            act.Should().Throw<XunitException>().WithMessage("*because*failure message*");
         }
 
         [Fact]
@@ -116,12 +115,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().ContainEquivalentOf(expectation, "because we want to test the behaviour with a null subject");
+                collection.Should().ContainEquivalentOf(expectation, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain equivalent of 1 because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to contain equivalent of 1 because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -279,11 +278,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
+                collection.Should().NotContainEquivalentOf(item, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {0, 1} not to contain*because we want to test the failure message, " +
+                "Expected collection {0, 1} not to contain*because*failure message, " +
                 "but found one at index 1.*With configuration*");
         }
 
@@ -296,11 +295,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                collection.Should().NotContainEquivalentOf(item, "because we want to test the failure {0}", "message");
+                collection.Should().NotContainEquivalentOf(item, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {0, 1, 1} not to contain*because we want to test the failure message, " +
+                "Expected collection {0, 1, 1} not to contain*because*failure message, " +
                 "but found several at indices {1, 2}.*With configuration*");
         }
 
@@ -354,12 +353,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContainEquivalentOf(1, config => config, "we want to test the failure {0}", "message");
+                collection.Should().NotContainEquivalentOf(1, config => config, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection not to contain *failure message*, but collection is <null>.");
+                .WithMessage("Expected collection not to contain*because*failure message*, but collection is <null>*");
         }
 
         [Fact]
@@ -413,14 +412,14 @@ public partial class CollectionAssertionSpecs
                 using var _ = new AssertionScope();
 
                 collection.Should()
-                    .NotContainEquivalentOf(another, "because we want to test {0}", "first message")
+                    .NotContainEquivalentOf(another, "we want to test the {0} message", "first failure")
                     .And
-                    .HaveCount(4, "because we want to test {0}", "second message");
+                    .HaveCount(4, "we want to test the {0} message", "second failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*not to contain*first message*but found one at index 2.*");
+                .WithMessage("Expected collection*not to contain*first failure*but found one at index 2.*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInConsecutiveOrder.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInConsecutiveOrder.cs
@@ -133,22 +133,22 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInConsecutiveOrder([3, 1], "because we said so");
+            Action act = () => new[] { 1, 2, 3 }.Should().ContainInConsecutiveOrder([3, 1], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain items {3, 1} in order because we said so, but 1 (index 1) did not appear (in the right consecutive order).");
+                "Expected collection {1, 2, 3} to contain items {3, 1} in order because*failure message, but 1 (index 1) did not appear (in the right consecutive order).");
         }
 
         [Fact]
         public void When_a_collection_does_not_contain_an_ordered_item_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInConsecutiveOrder([4, 1], "we failed");
+            Action act = () => new[] { 1, 2, 3 }.Should().ContainInConsecutiveOrder([4, 1], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain items {4, 1} in order because we failed, " +
+                "Expected collection {1, 2, 3} to contain items {4, 1} in order because*failure message, " +
                 "but 4 (index 0) did not appear (in the right consecutive order).");
         }
 
@@ -174,13 +174,12 @@ public partial class CollectionAssertionSpecs
             {
                 using var _ = new AssertionScope();
 
-                collection.Should()
-                    .ContainInConsecutiveOrder([4], "because we're checking how it reacts to a null subject");
+                collection.Should().ContainInConsecutiveOrder([4], "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain {4} in order because we're checking how it reacts to a null subject, but found <null>.");
+                "Expected collection to contain {4} in order because*failure message, but found <null>.");
         }
     }
 
@@ -280,7 +279,7 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContainInConsecutiveOrder([1, 2, 3], "we want to test the failure {0}", "message");
+                collection.Should().NotContainInConsecutiveOrder(1, 2, 3);
             };
 
             // Assert

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainInOrder.cs
@@ -70,23 +70,22 @@ public partial class CollectionAssertionSpecs
         public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder([3, 1], "because we said so");
+            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder([3, 1], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain items {3, 1} in order because we said so, but 1 (index 1) did not appear (in the right order).");
+                "Expected collection {1, 2, 3} to contain items {3, 1} in order because*failure message, but 1 (index 1) did not appear (in the right order).");
         }
 
         [Fact]
         public void When_a_collection_does_not_contain_an_ordered_item_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder([4, 1], "we failed");
+            Action act = () => new[] { 1, 2, 3 }.Should().ContainInOrder([4, 1], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to contain items {4, 1} in order because we failed, " +
-                "but 4 (index 0) did not appear (in the right order).");
+                "Expected collection {1, 2, 3} to contain items {4, 1} in order because*failure message, but 4 (index 0) did not appear (in the right order).");
         }
 
         [Fact]
@@ -138,12 +137,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                ints.Should().ContainInOrder([4], "because we're checking how it reacts to a null subject");
+                ints.Should().ContainInOrder([4], "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected ints to contain {4} in order because we're checking how it reacts to a null subject, but found <null>.");
+                "Expected ints to contain {4} in order because*failure message, but found <null>.");
         }
     }
 
@@ -210,11 +209,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 2, 3];
 
             // Act
-            Action act = () => collection.Should().NotContainInOrder([1, 2, 3], "that's what we expect");
+            Action act = () => collection.Should().NotContainInOrder([1, 2, 3], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 2, 3} to not contain items {1, 2, 3} in order because that's what we expect, " +
+                "Expected collection {1, 2, 2, 3} to not contain items {1, 2, 3} in order because*failure message, " +
                 "but items appeared in order ending at index 3.");
         }
 
@@ -228,9 +227,10 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContainInOrder([1, 2, 3], "we want to test the failure {0}", "message");
+                collection.Should().NotContainInOrder([1, 2, 3], "we want to test the {0} message", "failure");
             };
 
+            // TODO should the message contain the because text?
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Cannot verify absence of ordered containment in a <null> collection.");

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainItemsAssignableTo.cs
@@ -47,12 +47,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().ContainItemsAssignableTo<string>("because we want to test the behaviour with a null subject");
+                collection.Should().ContainItemsAssignableTo<string>("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain at least one element assignable to type string because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to contain at least one element assignable to type string because*failure message, but found <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.ContainSingle.cs
@@ -187,12 +187,12 @@ public partial class CollectionAssertionSpecs
         IEnumerable<int> collection = [];
 
         // Act
-        Action act = () => collection.Should().ContainSingle("more is not allowed");
+        Action act = () => collection.Should().ContainSingle("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
             .WithMessage(
-                "Expected collection to contain a single item because more is not allowed, but the collection is empty.");
+                "Expected collection to contain a single item because*failure message, but the collection is empty.");
     }
 
     [Fact]
@@ -205,12 +205,12 @@ public partial class CollectionAssertionSpecs
         Action act = () =>
         {
             using var _ = new AssertionScope();
-            collection.Should().ContainSingle("more is not allowed");
+            collection.Should().ContainSingle("we want to test the {0} message", "failure");
         };
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expected collection to contain a single item because more is not allowed, but found <null>.");
+            .WithMessage("Expected collection to contain a single item because*failure message, but found <null>.");
     }
 
     [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.EndWith.cs
@@ -20,11 +20,11 @@ public partial class CollectionAssertionSpecs
             string[] collection = ["john", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().EndWith("ryan", "of some reason");
+            Action act = () => collection.Should().EndWith("ryan", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*end*ryan*because of some reason*but*mike*");
+                "Expected*end*ryan*because*failure message*but*mike*");
         }
 
         [Fact]
@@ -49,11 +49,11 @@ public partial class CollectionAssertionSpecs
             string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().EndWith(["bill", "ryan", "mike"], "of some reason");
+            Action act = () => collection.Should().EndWith(["bill", "ryan", "mike"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*end*ryan*because of some reason*but*differs at index 2*");
+                "Expected*end*ryan*because*failure message*but*differs at index 2*");
         }
 
         [Fact]
@@ -93,11 +93,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () => collection.Should().EndWith(["bill", "ryan", "mike"],
-                (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
+                (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*end*ryan*because of some reason*but*differs at index 2*");
+                "Expected*end*ryan*because*failure message*but*differs at index 2*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.Equal.cs
@@ -63,11 +63,11 @@ public partial class CollectionAssertionSpecs
             int[] collection2 = [1, 2, 5];
 
             // Act
-            Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
+            Action act = () => collection1.Should().Equal(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {1, 2, 5} because we want to test the failure message, but {1, 2, 3} differs at index 2.");
+                "Expected collection1 to be equal to {1, 2, 5} because*failure message, but {1, 2, 3} differs at index 2.");
         }
 
         [Fact]
@@ -79,11 +79,11 @@ public partial class CollectionAssertionSpecs
             int[] collection2 = [1, 2];
 
             // Act
-            Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
+            Action act = () => collection1.Should().Equal(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {1, 2} because we want to test the failure message, but {1, 2, 3} contains 1 item(s) too many.");
+                "Expected collection1 to be equal to {1, 2} because*failure message, but {1, 2, 3} contains 1 item(s) too many.");
         }
 
         [Fact]
@@ -95,11 +95,11 @@ public partial class CollectionAssertionSpecs
             int[] collection2 = [1, 2, 3, 4];
 
             // Act
-            Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
+            Action act = () => collection1.Should().Equal(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {1, 2, 3, 4} because we want to test the failure message, but {1, 2, 3} contains 1 item(s) less.");
+                "Expected collection1 to be equal to {1, 2, 3, 4} because*failure message, but {1, 2, 3} contains 1 item(s) less.");
         }
 
         [Fact]
@@ -125,12 +125,11 @@ public partial class CollectionAssertionSpecs
             int[] collection1 = [1, 2, 3];
 
             // Act
-            Action act = () =>
-                collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().Equal(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to be equal to {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to be equal to {1, 2, 3} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -142,8 +141,9 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
+                collection.Should().Equal(collection1, "we want to test the {0} message", "failure");
 
+            // TODO should the message contain the because text?
             // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot compare collection with <null>.*")
@@ -353,11 +353,11 @@ public partial class CollectionAssertionSpecs
             int[] collection2 = [1, 2, 3];
 
             // Act
-            Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the failure {0}", "message");
+            Action act = () => collection1.Should().NotEqual(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect collections {1, 2, 3} and {1, 2, 3} to be equal because we want to test the failure message.");
+                "Did not expect collections {1, 2, 3} and {1, 2, 3} to be equal because*failure message.");
         }
 
         [Fact]
@@ -371,12 +371,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
+                collection.Should().NotEqual(collection1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collections not to be equal because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collections not to be equal because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -388,7 +388,7 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act =
-                () => collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
+                () => collection.Should().NotEqual(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -404,11 +404,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () =>
-                collection1.Should().NotEqual(collection2, "because we want to test the behaviour with same objects");
+                collection1.Should().NotEqual(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collections not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
+                "Expected collections not to be equal because*failure message, but they both reference the same object.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCount.cs
@@ -43,12 +43,12 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action action = () => collection.Should().HaveCount(4, "because we want to test the failure {0}", "message");
+            Action action = () => collection.Should().HaveCount(4, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                    "Expected collection to contain 4 item(s) because*failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -85,11 +85,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().HaveCount(c => c >= 4, "a minimum of 4 is required");
+            Action act = () => collection.Should().HaveCount(c => c >= 4, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {1, 2, 3}.");
+                "Expected collection to have a count (c >= 4) because*failure message, but count is 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -116,12 +116,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveCount(1, "we want to test the behaviour with a null subject");
+                collection.Should().HaveCount(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain 1 item(s) because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to contain 1 item(s) because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -134,12 +134,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveCount(c => c < 3, "we want to test the behaviour with a null subject");
+                collection.Should().HaveCount(c => c < 3, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain (c < 3) items because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to contain (c < 3) items because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -225,11 +225,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action action = () => collection.Should().NotHaveCount(3, "because we want to test the failure {0}", "message");
+            Action action = () => collection.Should().NotHaveCount(3, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*not contain*3*because we want to test the failure message*3*");
+                .WithMessage("*not contain*3*because*failure message*3*");
         }
 
         [Fact]
@@ -242,12 +242,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
+                collection.Should().NotHaveCount(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*not contain*1*because*failure message, but found <null>*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThan.cs
@@ -44,12 +44,12 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action action = () =>
-                collection.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
+                collection.Should().HaveCountGreaterThan(3, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain more than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                    "Expected collection to contain more than 3 item(s) because*failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -62,12 +62,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
+                collection.Should().HaveCountGreaterThan(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*more than*1*because*failure message, but found <null>*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
@@ -44,12 +44,12 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action action = () =>
-                collection.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
+                collection.Should().HaveCountGreaterThanOrEqualTo(4, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain at least 4 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                    "Expected collection to contain at least 4 item(s) because*failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -62,12 +62,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
+                collection.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*at least*1*because*failure message, but found <null>*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThan.cs
@@ -42,12 +42,12 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action action = () => collection.Should().HaveCountLessThan(3, "because we want to test the failure {0}", "message");
+            Action action = () => collection.Should().HaveCountLessThan(3, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                    "Expected collection to contain fewer than 3 item(s) because*failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -60,12 +60,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
+                collection.Should().HaveCountLessThan(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*fewer than*1*because*failure message, but found <null>*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
@@ -44,12 +44,12 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action action = () =>
-                collection.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
+                collection.Should().HaveCountLessThanOrEqualTo(2, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain at most 2 item(s) because we want to test the failure message, but found 3: {1, 2, 3}.");
+                    "Expected collection to contain at most 2 item(s) because*failure message, but found 3: {1, 2, 3}.");
         }
 
         [Fact]
@@ -62,12 +62,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
+                collection.Should().HaveCountLessThanOrEqualTo(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*at most*1*because*failure message, but found <null>*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementAt.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementAt.cs
@@ -43,11 +43,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().HaveElementAt(1, 3, "we put it {0}", "there");
+            Action act = () => collection.Should().HaveElementAt(1, 3, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected 3 at index 1 because we put it there, but found 2.");
+                "Expected 3 at index 1 because*failure message, but found 2.");
         }
 
         [Fact]
@@ -57,11 +57,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => collection.Should().HaveElementAt(4, 3, "we put it {0}", "there");
+            Action act = () => collection.Should().HaveElementAt(4, 3, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected 3 at index 4 because we put it there, but found no element.");
+                "Expected 3 at index 4 because*failure message, but found no element.");
         }
 
         [Fact]
@@ -74,12 +74,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveElementAt(1, 1, "because we want to test the behaviour with a null subject");
+                collection.Should().HaveElementAt(1, 1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to have element at index 1 because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to have element at index 1 because*failure message, but found <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementPreceding.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementPreceding.cs
@@ -33,11 +33,11 @@ public partial class CollectionAssertionSpecs
             string[] collection = ["cris", "mick", "john"];
 
             // Act
-            Action act = () => collection.Should().HaveElementPreceding("john", "cris", "because of some reason");
+            Action act = () => collection.Should().HaveElementPreceding("john", "cris", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*cris*precede*john*because*reason*found*mick*");
+                .WithMessage("Expected*cris*precede*john*because*failure message*found*mick*");
         }
 
         [Fact]
@@ -129,13 +129,13 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveElementPreceding("mick", "cris", "we want to test the failure {0}", "message");
+                collection.Should().HaveElementPreceding("mick", "cris", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to have \"cris\" precede \"mick\" *failure message*, but the collection is <null>.");
+                    "Expected collection to have \"cris\" precede \"mick\" because*failure message*, but the collection is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementSucceeding.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveElementSucceeding.cs
@@ -33,11 +33,11 @@ public partial class CollectionAssertionSpecs
             string[] collection = ["cris", "mick", "john"];
 
             // Act
-            Action act = () => collection.Should().HaveElementSucceeding("mick", "cris", "because of some reason");
+            Action act = () => collection.Should().HaveElementSucceeding("mick", "cris", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*cris*succeed*mick*because*reason*found*john*");
+                .WithMessage("Expected*cris*succeed*mick*because*failure message*found*john*");
         }
 
         [Fact]
@@ -127,13 +127,13 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveElementSucceeding("mick", "cris", "we want to test the failure {0}", "message");
+                collection.Should().HaveElementSucceeding("mick", "cris", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to have \"cris\" succeed \"mick\" *failure message*, but the collection is <null>.");
+                    "Expected collection to have \"cris\" succeed \"mick\" because*failure message*, but the collection is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveSameCount.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.HaveSameCount.cs
@@ -46,11 +46,11 @@ public partial class CollectionAssertionSpecs
             int[] secondCollection = [4, 6];
 
             // Act
-            Action act = () => firstCollection.Should().HaveSameCount(secondCollection, "we want to test the {0}", "reason");
+            Action act = () => firstCollection.Should().HaveSameCount(secondCollection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected firstCollection to have 2 item(s) because we want to test the reason, but found 3.");
+                "Expected firstCollection to have 2 item(s) because*failure message, but found 3.");
         }
 
         [Fact]
@@ -64,12 +64,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveSameCount(collection1, "because we want to test the behaviour with a null subject");
+                collection.Should().HaveSameCount(collection1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to have the same count as {1, 2, 3} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -124,11 +124,11 @@ public partial class CollectionAssertionSpecs
             int[] secondCollection = [4, 5, 6];
 
             // Act
-            Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection, "we want to test the {0}", "reason");
+            Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected firstCollection to not have 3 item(s) because we want to test the reason, but found 3.");
+                "Expected firstCollection to not have 3 item(s) because*failure message, but found 3.");
         }
 
         [Fact]
@@ -142,12 +142,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotHaveSameCount(collection1, "because we want to test the behaviour with a null subject");
+                collection.Should().NotHaveSameCount(collection1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to not have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to not have the same count as {1, 2, 3} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -174,12 +174,11 @@ public partial class CollectionAssertionSpecs
             var collection1 = collection;
 
             // Act
-            Action act = () => collection.Should().NotHaveSameCount(collection1,
-                "because we want to test the behaviour with same objects");
+            Action act = () => collection.Should().NotHaveSameCount(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
+                "*not have the same count*because*failure message*but they both reference the same object.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.IntersectWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.IntersectWith.cs
@@ -32,11 +32,11 @@ public partial class CollectionAssertionSpecs
             int[] otherCollection = [4, 5];
 
             // Act
-            Action action = () => collection.Should().IntersectWith(otherCollection, "they should share items");
+            Action action = () => collection.Should().IntersectWith(otherCollection, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to intersect with {4, 5} because they should share items," +
+                .WithMessage("Expected collection to intersect with {4, 5} because*failure message," +
                     " but {1, 2, 3} does not contain any shared items.");
         }
 
@@ -50,12 +50,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().IntersectWith([4, 5], "we want to test the failure {0}", "message");
+                collection.Should().IntersectWith([4, 5], "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to intersect with {4, 5} *failure message*, but found <null>.");
+                .WithMessage("Expected collection to intersect with {4, 5} because*failure message*, but found <null>.");
         }
 
         [Fact]
@@ -92,11 +92,11 @@ public partial class CollectionAssertionSpecs
             int[] otherCollection = [2, 3, 4];
 
             // Act
-            Action action = () => collection.Should().NotIntersectWith(otherCollection, "they should not share items");
+            Action action = () => collection.Should().NotIntersectWith(otherCollection, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to intersect with {2, 3, 4} because they should not share items," +
+                .WithMessage("Did not expect collection to intersect with {2, 3, 4} because*failure message," +
                     " but found the following shared items {2, 3}.");
         }
 
@@ -108,12 +108,11 @@ public partial class CollectionAssertionSpecs
             var otherCollection = collection;
 
             // Act
-            Action act = () => collection.Should().NotIntersectWith(otherCollection,
-                "because we want to test the behaviour with same objects");
+            Action act = () => collection.Should().NotIntersectWith(otherCollection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect*to intersect with*because we want to test the behaviour with same objects*but they both reference the same object.");
+                "Did not expect*to intersect with*because*failure message*but they both reference the same object.");
         }
 
         [Fact]
@@ -126,12 +125,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotIntersectWith([4, 5], "we want to test the failure {0}", "message");
+                collection.Should().NotIntersectWith([4, 5], "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to intersect with {4, 5} *failure message*, but found <null>.");
+                .WithMessage("Did not expect collection to intersect with {4, 5} because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainItemsAssignableTo.cs
@@ -27,16 +27,14 @@ public partial class CollectionAssertionSpecs
             // Act
             var act = () => collection
                 .Should()
-                .NotContainItemsAssignableTo<int>(
-                    "because we want test that collection does not contain object of {0} type", typeof(int));
+                .NotContainItemsAssignableTo<int>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
                 .WithMessage(
                     "Expected collection to not contain any elements assignable to type int " +
-                    "because we want test that collection does not contain object of System.Int32 type, " +
-                    "but found {int, string, string}.");
+                    "because*failure message, but found {int, string, string}.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.NotContainNulls.cs
@@ -30,11 +30,11 @@ public partial class CollectionAssertionSpecs
             object[] collection = [new object(), null];
 
             // Act
-            Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
+            Action act = () => collection.Should().NotContainNulls("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s because they are evil, but found one at index 1.");
+                "Expected collection not to contain <null>s because*failure message, but found one at index 1.");
         }
 
         [Fact]
@@ -62,11 +62,11 @@ public partial class CollectionAssertionSpecs
             object[] collection = [new object(), null, new object(), null];
 
             // Act
-            Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
+            Action act = () => collection.Should().NotContainNulls("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s*because they are evil*{1, 3}*");
+                "Expected collection not to contain <null>s*because*failure message*{1, 3}*");
         }
 
         [Fact]
@@ -94,11 +94,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should().NotContainNulls("because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().NotContainNulls("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
+                "Expected collection not to contain <null>s because*failure message, but collection is <null>.");
         }
 
         [Fact]
@@ -141,11 +141,11 @@ public partial class CollectionAssertionSpecs
             ];
 
             // Act
-            Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");
+            Action act = () => collection.Should().NotContainNulls(e => e.Text, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s*on e.Text*because they are evil*Text = <null>*");
+                "Expected collection not to contain <null>s*on e.Text*because*failure message*Text = <null>*");
         }
 
         [Fact]
@@ -161,11 +161,11 @@ public partial class CollectionAssertionSpecs
             ];
 
             // Act
-            Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");
+            Action act = () => collection.Should().NotContainNulls(e => e.Text, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s*on e.Text*because they are evil*Text = <null>*Text = <null>*");
+                "Expected collection not to contain <null>s*on e.Text*because*failure message*Text = <null>*Text = <null>*");
         }
 
         [Fact]
@@ -178,12 +178,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContainNulls("we want to test the failure {0}", "message");
+                collection.Should().NotContainNulls("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s *failure message*, but collection is <null>.");
+                "Expected collection not to contain <null>s because*failure message*, but collection is <null>.");
         }
 
         [Fact]
@@ -196,12 +196,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContainNulls(e => e.Text, "because we want to test the behaviour with a null subject");
+                collection.Should().NotContainNulls(e => e.Text, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
+                "Expected collection not to contain <null>s because*failure message, but collection is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyContain.cs
@@ -48,11 +48,11 @@ public partial class CollectionAssertionSpecs
             IEnumerable<int> collection = [2, 12, 3, 11, 2];
 
             // Act
-            Action act = () => collection.Should().OnlyContain(i => i <= 10, "10 is the maximum");
+            Action act = () => collection.Should().OnlyContain(i => i <= 10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain only items matching (i <= 10) because 10 is the maximum, but {12, 11} do(es) not match.");
+                "Expected collection to contain only items matching (i <= 10) because*failure message, but {12, 11} do(es) not match.");
         }
 
         [Fact]
@@ -85,13 +85,13 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().OnlyContain(i => i <= 10, "we want to test the failure {0}", "message");
+                collection.Should().OnlyContain(i => i <= 10, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain only items matching (i <= 10) *failure message*," +
+                    "Expected collection to contain only items matching (i <= 10) because*failure message*," +
                     " but the collection is <null>.");
         }
     }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.OnlyHaveUniqueItems.cs
@@ -30,11 +30,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 3, 3];
 
             // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
+            Action act = () => collection.Should().OnlyHaveUniqueItems("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we don't like duplicates, but item 3 is not unique.");
+                "Expected collection to only have unique items because*failure message, but item 3 is not unique.");
         }
 
         [Fact]
@@ -62,11 +62,11 @@ public partial class CollectionAssertionSpecs
             int[] collection = [1, 2, 2, 3, 3];
 
             // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
+            Action act = () => collection.Should().OnlyHaveUniqueItems("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we don't like duplicates, but items {2, 3} are not unique.");
+                "Expected collection to only have unique items because*failure message, but items {2, 3} are not unique.");
         }
 
         [Fact]
@@ -97,12 +97,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().OnlyHaveUniqueItems("because we want to test the behaviour with a null subject");
+                collection.Should().OnlyHaveUniqueItems("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to only have unique items because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -148,11 +148,11 @@ public partial class CollectionAssertionSpecs
             ];
 
             // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
+            Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items*on e.Text*because we don't like duplicates, but item*three*is not unique.");
+                "Expected collection to only have unique items*on e.Text*because*failure message*but item*three*is not unique.");
         }
 
         [Fact]
@@ -169,11 +169,11 @@ public partial class CollectionAssertionSpecs
             ];
 
             // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
+            Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items*on e.Text*because we don't like duplicates, but items*two*two*three*three*are not unique.");
+                "Expected collection to only have unique items*on e.Text*because*failure message*but items*two*two*three*three*are not unique.");
         }
 
         [Fact]
@@ -212,12 +212,12 @@ public partial class CollectionAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().OnlyHaveUniqueItems(e => e.Text, "because we want to test the behaviour with a null subject");
+                collection.Should().OnlyHaveUniqueItems(e => e.Text, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to only have unique items because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.Satisfy.cs
@@ -123,12 +123,11 @@ public partial class CollectionAssertionSpecs
                     element => element.Text == "four" && element.Number == 4,
                     element => element.Text == "two" && element.Number == 2,
                 },
-                because: "we want to test formatting ({0})",
-                becauseArgs: "args");
+                "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("""
-                Expected collection to satisfy all predicates because we want to test formatting (args), but:
+                Expected collection to satisfy all predicates because*failure message, but:
                 *The following predicates did not have matching elements:
                 *(element.Text == "two") AndAlso (element.Number == 2)
                 *The following elements did not match any predicate:
@@ -183,13 +182,12 @@ public partial class CollectionAssertionSpecs
                         element => element == 1,
                         element => element == 2,
                     },
-                    because: "we want to test the failure message ({0})",
-                    becauseArgs: "args");
+                    "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to satisfy all predicates because we want to test the failure message (args), but collection is <null>.");
+                "Expected collection to satisfy all predicates because*failure message, but collection is <null>.");
         }
 
         [Fact]
@@ -205,12 +203,11 @@ public partial class CollectionAssertionSpecs
                     element => element == 1,
                     element => element == 2,
                 },
-                because: "we want to test the failure message ({0})",
-                becauseArgs: "args");
+                "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to satisfy all predicates because we want to test the failure message (args), but collection is empty.");
+                "Expected collection to satisfy all predicates because*failure message, but collection is empty.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.SatisfyRespectively.cs
@@ -53,12 +53,12 @@ public partial class CollectionAssertionSpecs
                 using var _ = new AssertionScope();
 
                 collection.Should().SatisfyRespectively(
-                    new Action<int>[] { x => x.Should().Be(1) }, "because we want to test the failure {0}", "message");
+                    new Action<int>[] { x => x.Should().Be(1) }, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to satisfy all inspectors because we want to test the failure message, but collection is <null>.");
+                "Expected collection to satisfy all inspectors because*failure message, but collection is <null>.");
         }
 
         [Fact]
@@ -69,11 +69,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () => collection.Should().SatisfyRespectively(new Action<int>[] { x => x.Should().Be(1) },
-                "because we want to test the failure {0}", "message");
+                "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to satisfy all inspectors because we want to test the failure message, but collection is empty.");
+                "Expected collection to satisfy all inspectors because*failure message, but collection is empty.");
         }
 
         [Fact]
@@ -123,11 +123,11 @@ public partial class CollectionAssertionSpecs
                         customer.Age.Should().BeLessThan(22);
                         customer.Items.Should().SatisfyRespectively(item => item.Should().Be(2));
                     }
-                }, "because we want to test {0}", "nested assertions");
+                }, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("""
-                Expected customers to satisfy all inspectors because we want to test nested assertions, but some inspectors are not satisfied:
+                Expected customers to satisfy all inspectors because*failure message, but some inspectors are not satisfied:
                 *At index 0:
                 *Expected customer.Age to be less than 21, but found 21
                 *Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
@@ -165,11 +165,11 @@ public partial class CollectionAssertionSpecs
             // Act
             Action act = () => collection.Should().SatisfyRespectively(
                 new Action<int>[] { value => value.Should().Be(1), value => value.Should().Be(2) },
-                "because we want to test the failure {0}", "message");
+                "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain exactly 2 items*we want to test the failure message*, but it contains 3 items");
+                "Expected collection to contain exactly 2 items*because*failure message, but it contains 3 items");
         }
 
         [Fact]
@@ -180,10 +180,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () => collection.Should().SatisfyRespectively(
-                new Action<int>[] { value => value.Should().Be(1), }, "because we want to test the failure {0}", "message");
+                new Action<int>[] { value => value.Should().Be(1), }, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*because we want to test the failure*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection to satisfy all inspectors because*failure message, but collection is empty.");
         }
     }
 

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.StartWith.cs
@@ -20,11 +20,11 @@ public partial class CollectionAssertionSpecs
             string[] collection = ["john", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().StartWith("ryan", "of some reason");
+            Action act = () => collection.Should().StartWith("ryan", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*start*ryan*because of some reason*but*john*");
+                "Expected*start*ryan*because*failure message*but*john*");
         }
 
         [Fact]
@@ -62,11 +62,11 @@ public partial class CollectionAssertionSpecs
             string[] collection = ["john", "bill", "jane", "mike"];
 
             // Act
-            Action act = () => collection.Should().StartWith(["john", "ryan", "jane"], "of some reason");
+            Action act = () => collection.Should().StartWith(["john", "ryan", "jane"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*start*ryan*because of some reason*but*differs at index 1*");
+                "Expected*start*ryan*because*failure message*but*differs at index 1*");
         }
 
         [Fact]
@@ -78,11 +78,11 @@ public partial class CollectionAssertionSpecs
 
             // Act
             Action act = () => collection.Should().StartWith(["john", "ryan", "jane"],
-                (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "of some reason");
+                (s1, s2) => string.Equals(s1, s2, StringComparison.Ordinal), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*start*ryan*because of some reason*but*differs at index 1*");
+                "Expected*start*ryan*because*failure message*but*differs at index 1*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -263,14 +263,14 @@ public partial class CollectionAssertionSpecs
             {
                 using (new AssertionScope())
                 {
-                    collection.Should().BeInAscendingOrder("because numbers are ordered")
+                    collection.Should().BeInAscendingOrder("we want to test the {0} message", "failure")
                         .And.BeEmpty("this won't be asserted");
                 }
             };
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*item at index 1 is in wrong order.");
+                .WithMessage("*because*failure message*item at index 1 is in wrong order.");
         }
     }
 

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.AllSatisfy.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.AllSatisfy.cs
@@ -25,17 +25,15 @@ public partial class GenericCollectionAssertionOfStringSpecs
             string[] collection = ["Jack", "Jessica"];
 
             // Act
-            Action act = () => collection.Should()
-                .AllSatisfy(
-                    value => value.Should().Be("John"),
-                    "because we want to test the failure {0}",
-                    "message");
+            Action act = () => collection.Should().AllSatisfy(
+                value => value.Should().Be("John"),
+                "we want to test the {0} message", "failure");
 
             // Assert
             act.Should()
                 .Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain only items satisfying the inspector because we want to test the failure message:"
+                    "Expected collection to contain only items satisfying the inspector because*failure message:"
                     + "*Jack*John"
                     + "*Jessica*John*");
         }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEmpty.cs
@@ -39,11 +39,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = null;
 
             // Act
-            Action act = () => collection.Should().BeEmpty("because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().BeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to be empty because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to be empty because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -53,13 +53,13 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().BeEmpty("because we want to test the failure {0}", "message");
+            Action act = () => collection.Should().BeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to be empty because we want to test the failure message, but found at least one item*one*");
+                    "Expected collection to be empty because*failure message, but found at least one item*one*");
         }
     }
 
@@ -72,11 +72,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = null;
 
             // Act
-            Action act = () => collection.Should().NotBeEmpty("because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to be empty because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection not to be empty because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -109,11 +109,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = new string[0];
 
             // Act
-            Action act = () => collection.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+            Action act = () => collection.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection not to be empty because we want to test the failure message.");
+                .WithMessage("Expected collection not to be empty because*failure message.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEquivalentTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeEquivalentTo.cs
@@ -18,12 +18,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
 
             // Act
             Action act =
-                () => collection.Should()
-                    .BeEquivalentTo(collection1, "because we want to test the behaviour with a null subject");
+                () => collection.Should().BeEquivalentTo(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*not to be <null>*");
+                .WithMessage("Expected collection*not to be <null> because*failure message*");
         }
 
         [Fact]
@@ -126,12 +125,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> expectation = ["one", "two", "three"];
 
             // Act
-            Action act = () => actual.Should().NotBeEquivalentTo(expectation,
-                "because we want to test the behaviour with a null subject");
+            Action act = () => actual.Should().NotBeEquivalentTo(expectation, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected actual not to be equivalent because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected actual not to be equivalent because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -183,12 +181,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection1 = collection;
 
             // Act
-            Action act = () => collection.Should().NotBeEquivalentTo(collection1,
-                "because we want to test the behaviour with same objects");
+            Action act = () => collection.Should().NotBeEquivalentTo(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*not to be equivalent*because we want to test the behaviour with same objects*but they both reference the same object.");
+                "*not to be equivalent*because*failure message*but they both reference the same object.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeNull.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeNull.cs
@@ -26,11 +26,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> someCollection = new string[0];
 
             // Act
-            Action act = () => someCollection.Should().BeNull("because {0} is valid", "null");
+            Action act = () => someCollection.Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someCollection to be <null> because null is valid, but found {empty}.");
+                "Expected someCollection to be <null> because*failure message, but found {empty}.");
         }
     }
 
@@ -43,11 +43,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> someCollection = null;
 
             // Act
-            Action act = () => someCollection.Should().NotBeNull("because {0} should not", "someCollection");
+            Action act = () => someCollection.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someCollection not to be <null> because someCollection should not.");
+                "Expected someCollection not to be <null> because*failure message.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeSubsetOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.BeSubsetOf.cs
@@ -44,11 +44,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
 
             // Act
             Action act =
-                () => collection.Should().BeSubsetOf(collection1, "because we want to test the behaviour with a null subject");
+                () => collection.Should().BeSubsetOf(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to be a subset of {\"one\", \"two\", \"three\"} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to be a subset of {\"one\", \"two\", \"three\"} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -59,11 +59,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> superset = ["one", "two", "four", "five"];
 
             // Act
-            Action act = () => subset.Should().BeSubsetOf(superset, "because we want to test the failure {0}", "message");
+            Action act = () => subset.Should().BeSubsetOf(superset, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subset to be a subset of {\"one\", \"two\", \"four\", \"five\"} because we want to test the failure message, " +
+                "Expected subset to be a subset of {\"one\", \"two\", \"four\", \"five\"} because*failure message, " +
                 "but items {\"three\", \"six\"} are not part of the superset.");
         }
 
@@ -89,11 +89,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> otherSet = ["one", "two", "three"];
 
             // Act
-            Action act = () => subject.Should().NotBeSubsetOf(otherSet, "because I'm {0}", "mistaken");
+            Action act = () => subject.Should().NotBeSubsetOf(otherSet, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect subject {\"one\", \"two\"} to be a subset of {\"one\", \"two\", \"three\"} because I'm mistaken.");
+                "Did not expect subject {\"one\", \"two\"} to be a subset of {\"one\", \"two\", \"three\"} because*failure message.");
         }
 
         [Fact]
@@ -130,12 +130,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> otherCollection = collection;
 
             // Act
-            Action act = () => collection.Should().NotBeSubsetOf(otherCollection,
-                "because we want to test the behaviour with same objects");
+            Action act = () => collection.Should().NotBeSubsetOf(otherCollection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect*to be a subset of*because we want to test the behaviour with same objects*but they both reference the same object.");
+                "Did not expect*to be a subset of*because*failure message, but they both reference the same object.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.Contain.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.Contain.cs
@@ -16,11 +16,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().Contain(["three", "four", "five"], "because {0}", "we do");
+            Action act = () => collection.Should().Contain(["three", "four", "five"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {\"one\", \"two\", \"three\"} to contain {\"three\", \"four\", \"five\"} because we do, but could not find {\"four\", \"five\"}.");
+                "Expected collection {\"one\", \"two\", \"three\"} to contain {\"three\", \"four\", \"five\"} because*failure message, but could not find {\"four\", \"five\"}.");
         }
 
         [Fact]
@@ -30,11 +30,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().Contain("four", "because {0}", "we do");
+            Action act = () => collection.Should().Contain("four", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {\"one\", \"two\", \"three\"} to contain \"four\" because we do.");
+                "Expected collection {\"one\", \"two\", \"three\"} to contain \"four\" because*failure message.");
         }
 
         [Fact]
@@ -46,7 +46,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
             var actual = new List<string> { "hello", "world" };
 
             // Act / Assert
-            actual.Should().Contain(expected, "they are in the collection");
+            actual.Should().Contain(expected);
         }
 
         [Fact]
@@ -109,12 +109,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = null;
 
             // Act
-            Action act = () => collection.Should()
-                .NotContain("one", "because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().NotContain("one", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to not contain \"one\" because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to not contain \"one\" because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -124,11 +123,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().NotContain("one", "because we {0} like it, but found it anyhow", "don't");
+            Action act = () => collection.Should().NotContain("one", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {\"one\", \"two\", \"three\"} to not contain \"one\" because we don't like it, but found it anyhow.");
+                "Expected collection {\"one\", \"two\", \"three\"} to not contain \"one\" because*failure message.");
         }
 
         [Fact]
@@ -138,11 +137,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().NotContain(item => item == "two", "because {0}s are evil", "two");
+            Action act = () => collection.Should().NotContain(item => item == "two", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {\"one\", \"two\", \"three\"} to not have any items matching (item == \"two\") because twos are evil,*{\"two\"}*");
+                "Expected collection {\"one\", \"two\", \"three\"} to not have any items matching (item == \"two\") because*failure message,*{\"two\"}*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainInOrder.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainInOrder.cs
@@ -27,11 +27,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
         public void When_a_collection_does_not_contain_an_ordered_item_it_should_throw_with_a_clear_explanation()
         {
             // Act
-            Action act = () => new[] { "one", "two", "three" }.Should().ContainInOrder(["four", "one"], "we failed");
+            Action act = () => new[] { "one", "two", "three" }.Should().ContainInOrder(["four", "one"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {\"one\", \"two\", \"three\"} to contain items {\"four\", \"one\"} in order because we failed, " +
+                "Expected collection {\"one\", \"two\", \"three\"} to contain items {\"four\", \"one\"} in order because*failure message, " +
                 "but \"four\" (index 0) did not appear (in the right order).");
         }
 
@@ -44,11 +44,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             // Act
             Action act =
                 () => strings.Should()
-                    .ContainInOrder(["string4"], "because we're checking how it reacts to a null subject");
+                    .ContainInOrder(["string4"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings to contain {\"string4\"} in order because we're checking how it reacts to a null subject, but found <null>.");
+                "Expected strings to contain {\"string4\"} in order because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -97,11 +97,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
         {
             // Act
             Action act = () =>
-                new[] { "one", "two", "three" }.Should().ContainInOrder(["three", "one"], "because we said so");
+                new[] { "one", "two", "three" }.Should().ContainInOrder(["three", "one"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {\"one\", \"two\", \"three\"} to contain items {\"three\", \"one\"} in order because we said so, but \"one\" (index 1) did not appear (in the right order).");
+                "Expected collection {\"one\", \"two\", \"three\"} to contain items {\"three\", \"one\"} in order because*failure message, but \"one\" (index 1) did not appear (in the right order).");
         }
 
         [Fact]
@@ -178,12 +178,12 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().NotContainInOrder(["one", "two", "three"], "that's what we expect");
+            Action act = () => collection.Should().NotContainInOrder(["one", "two", "three"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection {\"one\", \"two\", \"two\", \"three\"} to not contain items {\"one\", \"two\", \"three\"} " +
-                "in order because that's what we expect, but items appeared in order ending at index 3.");
+                "in order because*failure message, but items appeared in order ending at index 3.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainMatch.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.ContainMatch.cs
@@ -66,12 +66,12 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
-            Action action = () => collection.Should().ContainMatch("* stopped", "because {0}", "we do");
+            Action action = () => collection.Should().ContainMatch("* stopped", "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection {\"build succeded\", \"test failed\"} to contain a match of \"* stopped\" because we do.");
+                    "Expected collection {\"build succeded\", \"test failed\"} to contain a match of \"* stopped\" because*failure message.");
         }
 
         [Fact]
@@ -112,12 +112,12 @@ public partial class GenericCollectionAssertionOfStringSpecs
             Action action = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().ContainMatch("* failed", "because {0}", "we do");
+                collection.Should().ContainMatch("* failed", "we want to test the {0} message", "failure");
             };
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to contain a match of \"* failed\" because we do, but found <null>.");
+                .WithMessage("Expected collection to contain a match of \"* failed\" because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -182,12 +182,12 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["build succeded", "test failed"];
 
             // Act
-            Action action = () => collection.Should().NotContainMatch("* failed", "because {0}", "it shouldn't");
+            Action action = () => collection.Should().NotContainMatch("* failed", "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Did not expect collection {\"build succeded\", \"test failed\"} to contain a match of \"* failed\" because it shouldn't.");
+                    "Did not expect collection {\"build succeded\", \"test failed\"} to contain a match of \"* failed\" because*failure message.");
         }
 
         [Fact]
@@ -197,12 +197,12 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["build failed", "test failed"];
 
             // Act
-            Action action = () => collection.Should().NotContainMatch("* failed", "because {0}", "it shouldn't");
+            Action action = () => collection.Should().NotContainMatch("* failed", "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Did not expect collection {\"build failed\", \"test failed\"} to contain a match of \"* failed\" because it shouldn't.");
+                    "Did not expect collection {\"build failed\", \"test failed\"} to contain a match of \"* failed\" because*failure message.");
         }
 
         [Fact]
@@ -260,12 +260,12 @@ public partial class GenericCollectionAssertionOfStringSpecs
             Action action = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().NotContainMatch("* Failed", "we want to test the failure {0}", "message");
+                collection.Should().NotContainMatch("* Failed", "we want to test the {0} message", "failure");
             };
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to contain a match of \"* failed\" *failure message*, but found <null>.");
+                .WithMessage("Did not expect collection to contain a match of \"* failed\" because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.Equal.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.Equal.cs
@@ -98,8 +98,7 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection1 = null;
 
             // Act
-            Action act = () =>
-                collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().Equal(collection1);
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -116,11 +115,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
 
             // Act
             Action act = () =>
-                collection.Should().Equal(collection1, "because we want to test the behaviour with a null subject");
+                collection.Should().Equal(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to be equal to {\"one\", \"two\", \"three\"} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to be equal to {\"one\", \"two\", \"three\"} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -141,11 +140,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection2 = ["one", "two", "five"];
 
             // Act
-            Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
+            Action act = () => collection1.Should().Equal(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {\"one\", \"two\", \"five\"} because we want to test the failure message, but {\"one\", \"two\", \"three\"} differs at index 2.");
+                "Expected collection1 to be equal to {\"one\", \"two\", \"five\"} because*failure message, but {\"one\", \"two\", \"three\"} differs at index 2.");
         }
 
         [Fact]
@@ -157,11 +156,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection2 = ["one", "two", "three", "four"];
 
             // Act
-            Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
+            Action act = () => collection1.Should().Equal(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {\"one\", \"two\", \"three\", \"four\"} because we want to test the failure message, but {\"one\", \"two\", \"three\"} contains 1 item(s) less.");
+                "Expected collection1 to be equal to {\"one\", \"two\", \"three\", \"four\"} because*failure message, but {\"one\", \"two\", \"three\"} contains 1 item(s) less.");
         }
 
         [Fact]
@@ -173,11 +172,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection2 = ["one", "two"];
 
             // Act
-            Action act = () => collection1.Should().Equal(collection2, "because we want to test the failure {0}", "message");
+            Action act = () => collection1.Should().Equal(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 to be equal to {\"one\", \"two\"} because we want to test the failure message, but {\"one\", \"two\", \"three\"} contains 1 item(s) too many.");
+                "Expected collection1 to be equal to {\"one\", \"two\"} because*failure message, but {\"one\", \"two\", \"three\"} contains 1 item(s) too many.");
         }
 
         [Fact]
@@ -213,12 +212,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection2 = collection1;
 
             // Act
-            Action act = () =>
-                collection1.Should().NotEqual(collection2, "because we want to test the behaviour with same objects");
+            Action act = () => collection1.Should().NotEqual(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collections not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
+                "Expected collections not to be equal because*failure Message, but they both reference the same object.");
         }
 
         [Fact]
@@ -230,8 +228,9 @@ public partial class GenericCollectionAssertionOfStringSpecs
 
             // Act
             Action act =
-                () => collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
+                () => collection.Should().NotEqual(collection1, "we want to test the {0} message", "failure");
 
+            // TODO should the message contain the because text?
             // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot compare collection with <null>.*")
@@ -247,11 +246,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
 
             // Act
             Action act =
-                () => collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
+                () => collection.Should().NotEqual(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collections not to be equal because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collections not to be equal because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -262,11 +261,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection2 = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the failure {0}", "message");
+            Action act = () => collection1.Should().NotEqual(collection2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect collections {\"one\", \"two\", \"three\"} and {\"one\", \"two\", \"three\"} to be equal because we want to test the failure message.");
+                "Did not expect collections {\"one\", \"two\", \"three\"} and {\"one\", \"two\", \"three\"} to be equal because*failure message.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveCount.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveCount.cs
@@ -68,11 +68,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
 
             // Act
             Action act =
-                () => collection.Should().HaveCount(c => c < 3, "we want to test the behaviour with a null subject");
+                () => collection.Should().HaveCount(c => c < 3, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain (c < 3) items because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to contain (c < 3) items because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -82,11 +82,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = null;
 
             // Act
-            Action act = () => collection.Should().HaveCount(1, "we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().HaveCount(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain 1 item(s) because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to contain 1 item(s) because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -107,12 +107,12 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action action = () => collection.Should().HaveCount(4, "because we want to test the failure {0}", "message");
+            Action action = () => collection.Should().HaveCount(4, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain 4 item(s) because we want to test the failure message, but found 3: {\"one\", \"two\", \"three\"}.");
+                    "Expected collection to contain 4 item(s) because*failure message, but found 3: {\"one\", \"two\", \"three\"}.");
         }
 
         [Fact]
@@ -122,11 +122,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().HaveCount(c => c >= 4, "a minimum of 4 is required");
+            Action act = () => collection.Should().HaveCount(c => c >= 4, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {\"one\", \"two\", \"three\"}.");
+                "Expected collection to have a count (c >= 4) because*failure message, but count is 3: {\"one\", \"two\", \"three\"}.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveElementAt.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveElementAt.cs
@@ -16,12 +16,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = null;
 
             // Act
-            Action act = () => collection.Should().HaveElementAt(1, "one",
-                "because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().HaveElementAt(1, "one", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to have element at index 1 because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to have element at index 1 because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -31,11 +30,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().HaveElementAt(4, "three", "we put it {0}", "there");
+            Action act = () => collection.Should().HaveElementAt(4, "three", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected \"three\" at index 4 because we put it there, but found no element.");
+                "Expected \"three\" at index 4 because*failure message, but found no element.");
         }
 
         [Fact]
@@ -45,11 +44,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().HaveElementAt(1, "three", "we put it {0}", "there");
+            Action act = () => collection.Should().HaveElementAt(1, "three", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected \"three\" at index 1 because we put it there, but found \"two\".");
+                "Expected \"three\" at index 1 because*failure message, but found \"two\".");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveSameCount.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.HaveSameCount.cs
@@ -32,12 +32,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection1 = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().HaveSameCount(collection1,
-                "because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().HaveSameCount(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to have the same count as {\"one\", \"two\", \"three\"} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to have the same count as {\"one\", \"two\", \"three\"} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -74,11 +73,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> secondCollection = ["four", "six"];
 
             // Act
-            Action act = () => firstCollection.Should().HaveSameCount(secondCollection, "we want to test the {0}", "reason");
+            Action act = () => firstCollection.Should().HaveSameCount(secondCollection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected firstCollection to have 2 item(s) because we want to test the reason, but found 3.");
+                "Expected firstCollection to have 2 item(s) because*failure message, but found 3.");
         }
     }
 
@@ -107,12 +106,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection1 = ["one", "two", "three"];
 
             // Act
-            Action act = () => collection.Should().NotHaveSameCount(collection1,
-                "because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().NotHaveSameCount(collection1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to not have the same count as {\"one\", \"two\", \"three\"} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to not have the same count as {\"one\", \"two\", \"three\"} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -124,12 +122,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> otherCollection = collection;
 
             // Act
-            Action act = () => collection.Should().NotHaveSameCount(otherCollection,
-                "because we want to test the behaviour with same objects");
+            Action act = () => collection.Should().NotHaveSameCount(otherCollection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
+                "*not have the same count*because*failure message, but they both reference the same object.");
         }
 
         [Fact]
@@ -166,11 +163,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> secondCollection = ["four", "five", "six"];
 
             // Act
-            Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection, "we want to test the {0}", "reason");
+            Action act = () => firstCollection.Should().NotHaveSameCount(secondCollection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected firstCollection to not have 3 item(s) because we want to test the reason, but found 3.");
+                "Expected firstCollection to not have 3 item(s) because*failure message, but found 3.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.IntersectWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.IntersectWith.cs
@@ -28,11 +28,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> otherCollection = ["four", "five"];
 
             // Act
-            Action action = () => collection.Should().IntersectWith(otherCollection, "they should share items");
+            Action action = () => collection.Should().IntersectWith(otherCollection, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to intersect with {\"four\", \"five\"} because they should share items," +
+                .WithMessage("Expected collection to intersect with {\"four\", \"five\"} because*failure message," +
                     " but {\"one\", \"two\", \"three\"} does not contain any shared items.");
         }
 
@@ -59,12 +59,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> otherCollection = collection;
 
             // Act
-            Action act = () => collection.Should().NotIntersectWith(otherCollection,
-                "because we want to test the behaviour with same objects");
+            Action act = () => collection.Should().NotIntersectWith(otherCollection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*to intersect with*because we want to test the behaviour with same objects*but they both reference the same object.");
+                "*to intersect with*because*failure message, but they both reference the same object.");
         }
 
         [Fact]
@@ -75,12 +74,12 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> otherCollection = ["two", "three", "four"];
 
             // Act
-            Action action = () => collection.Should().NotIntersectWith(otherCollection, "they should not share items");
+            Action action = () => collection.Should().NotIntersectWith(otherCollection, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Did not expect collection to intersect with {\"two\", \"three\", \"four\"} because they should not share items," +
+                    "Did not expect collection to intersect with {\"two\", \"three\", \"four\"} because*failure message," +
                     " but found the following shared items {\"two\", \"three\"}.");
         }
 

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.NotContainNulls.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.NotContainNulls.cs
@@ -16,11 +16,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = null;
 
             // Act
-            Action act = () => collection.Should().NotContainNulls("because we want to test the behaviour with a null subject");
+            Action act = () => collection.Should().NotContainNulls("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
+                "Expected collection not to contain <null>s because*failure message, but collection is <null>.");
         }
 
         [Fact]
@@ -30,11 +30,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["", null, "", null];
 
             // Act
-            Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
+            Action act = () => collection.Should().NotContainNulls("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s*because they are evil*{1, 3}*");
+                "Expected collection not to contain <null>s*because*failure message*{1, 3}*");
         }
 
         [Fact]
@@ -44,11 +44,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["", null];
 
             // Act
-            Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
+            Action act = () => collection.Should().NotContainNulls("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s because they are evil, but found one at index 1.");
+                "Expected collection not to contain <null>s because*failure message, but found one at index 1.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.OnlyHaveUniqueItems.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.OnlyHaveUniqueItems.cs
@@ -26,11 +26,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "three", "three"];
 
             // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
+            Action act = () => collection.Should().OnlyHaveUniqueItems("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we don't like duplicates, but item \"three\" is not unique.");
+                "Expected collection to only have unique items because*failure message, but item \"three\" is not unique.");
         }
 
         [Fact]
@@ -40,11 +40,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             IEnumerable<string> collection = ["one", "two", "two", "three", "three"];
 
             // Act
-            Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
+            Action act = () => collection.Should().OnlyHaveUniqueItems("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we don't like duplicates, but items {\"two\", \"three\"} are not unique.");
+                "Expected collection to only have unique items because*failure message, but items {\"two\", \"three\"} are not unique.");
         }
 
         [Fact]
@@ -55,11 +55,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
 
             // Act
             Action act =
-                () => collection.Should().OnlyHaveUniqueItems("because we want to test the behaviour with a null subject");
+                () => collection.Should().OnlyHaveUniqueItems("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to only have unique items because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.SatisfyRespectively.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.SatisfyRespectively.cs
@@ -32,11 +32,11 @@ public partial class GenericCollectionAssertionOfStringSpecs
             {
                 value => value.Should().Be("John"),
                 value => value.Should().Be("Jane")
-            }, "because we want to test the failure {0}", "message");
+            }, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("""
-                Expected collection to satisfy all inspectors because we want to test the failure message, but some inspectors are not satisfied
+                Expected collection to satisfy all inspectors because*failure message, but some inspectors are not satisfied
                 *Jack*John
                 *Jessica*Jane*
                 """);

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeEmpty.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeEmpty.cs
@@ -45,12 +45,12 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().BeEmpty("because we want to test the failure {0}", "message");
+            Action act = () => dictionary.Should().BeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to be empty because we want to test the failure message, but found at least one item {[1, One]}.");
+                    "Expected dictionary to be empty because*failure message, but found at least one item {[1, One]}.");
         }
 
         [Fact]
@@ -60,11 +60,11 @@ public partial class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().BeEmpty("because we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().BeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to be empty because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary to be empty because*failure message, but found <null>.");
         }
     }
 
@@ -119,11 +119,11 @@ public partial class GenericDictionaryAssertionSpecs
             var dictionary = new Dictionary<int, string>();
 
             // Act
-            Action act = () => dictionary.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+            Action act = () => dictionary.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary not to be empty because we want to test the failure message.");
+                .WithMessage("Expected dictionary not to be empty because*failure message.");
         }
 
         [Fact]
@@ -133,11 +133,11 @@ public partial class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().NotBeEmpty("because we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to be empty because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary not to be empty because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeNull.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.BeNull.cs
@@ -26,11 +26,11 @@ public partial class GenericDictionaryAssertionSpecs
             var someDictionary = new Dictionary<int, string>();
 
             // Act
-            Action act = () => someDictionary.Should().BeNull("because {0} is valid", "null");
+            Action act = () => someDictionary.Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someDictionary to be <null> because null is valid, but found {empty}.");
+                "Expected someDictionary to be <null> because*failure message, but found {empty}.");
         }
     }
 
@@ -63,11 +63,11 @@ public partial class GenericDictionaryAssertionSpecs
             IDictionary<int, string> someDictionary = null;
 
             // Act
-            Action act = () => someDictionary.Should().NotBeNull("because {0} should not", "someDictionary");
+            Action act = () => someDictionary.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someDictionary not to be <null> because someDictionary should not.");
+                "Expected someDictionary not to be <null> because*failure message.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.Contain.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.Contain.cs
@@ -85,11 +85,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+            Action act = () => dictionary.Should().Contain(keyValuePairs, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"Three\" at key 2 because we do, but found \"Two\".");
+                "Expected dictionary to contain value \"Three\" at key 2 because*failure message, but found \"Two\".");
         }
 
         [Fact]
@@ -110,11 +110,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+            Action act = () => dictionary.Should().Contain(keyValuePairs, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain {[1, Two], [2, Three]} because we do, but dictionary differs at keys {1, 2}.");
+                "Expected dictionary to contain {[1, Two], [2, Three]} because*failure message, but dictionary differs at keys {1, 2}.");
         }
 
         [Fact]
@@ -133,11 +133,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+            Action act = () => dictionary.Should().Contain(keyValuePairs, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because*failure message.");
         }
 
         [Fact]
@@ -158,11 +158,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().Contain(keyValuePairs, "because {0}", "we do");
+            Action act = () => dictionary.Should().Contain(keyValuePairs, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key(s) {1, 3, 4} because we do, but could not find keys {3, 4}.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key(s) {1, 3, 4} because*failure message, but could not find keys {3, 4}.");
         }
 
         [Fact]
@@ -181,12 +181,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().Contain(keyValuePairs, "because we want to test the behaviour with a null subject");
+                dictionary.Should().Contain(keyValuePairs, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain key/value pairs {[1, One], [1, Two]} because we want to test the behaviour with a null subject, but dictionary is <null>.");
+                "Expected dictionary to contain key/value pairs {[1, One], [1, Two]} because*failure message, but dictionary is <null>.");
         }
 
         [Fact]
@@ -202,8 +202,7 @@ public partial class GenericDictionaryAssertionSpecs
             List<KeyValuePair<int, string>> keyValuePairs = [];
 
             // Act
-            Action act = () => dictionary1.Should().Contain(keyValuePairs,
-                "because we want to test the behaviour with an empty set of key/value pairs");
+            Action act = () => dictionary1.Should().Contain(keyValuePairs);
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -223,8 +222,7 @@ public partial class GenericDictionaryAssertionSpecs
             List<KeyValuePair<int, string>> keyValuePairs = null;
 
             // Act
-            Action act = () =>
-                dictionary1.Should().Contain(keyValuePairs, "because we want to test the behaviour with a null subject");
+            Action act = () => dictionary1.Should().Contain(keyValuePairs);
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -306,11 +304,11 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             var item = new KeyValuePair<int, string>(1, "Two");
-            Action act = () => dictionary.Should().Contain(item, "we put it {0}", "there");
+            Action act = () => dictionary.Should().Contain(item, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"Two\" at key 1 because we put it there, but found \"One\".");
+                "Expected dictionary to contain value \"Two\" at key 1 because*failure message, but found \"One\".");
         }
 
         [Fact]
@@ -330,11 +328,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().Contain(items, "we put them {0}", "there");
+            Action act = () => dictionary.Should().Contain(items, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain {[1, Two], [2, Three]} because we put them there, but dictionary differs at keys {1, 2}.");
+                "Expected dictionary to contain {[1, Two], [2, Three]} because*failure message, but dictionary differs at keys {1, 2}.");
         }
 
         [Fact]
@@ -348,11 +346,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().Contain(1, "Two", "we put it {0}", "there");
+            Action act = () => dictionary.Should().Contain(1, "Two", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"Two\" at key 1 because we put it there, but found \"One\".");
+                "Expected dictionary to contain value \"Two\" at key 1 because*failure message, but found \"One\".");
         }
 
         [Fact]
@@ -366,11 +364,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().Contain(3, "Two", "we put it {0}", "there");
+            Action act = () => dictionary.Should().Contain(3, "Two", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"Two\" at key 3 because we put it there, but the key was not found.");
+                "Expected dictionary to contain value \"Two\" at key 3 because*failure message, but the key was not found.");
         }
 
         [Fact]
@@ -383,12 +381,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().Contain(1, "One", "because we want to test the behaviour with a null subject");
+                dictionary.Should().Contain(1, "One", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain value \"One\" at key 1 because we want to test the behaviour with a null subject, but dictionary is <null>.");
+                "Expected dictionary to contain value \"One\" at key 1 because*failure message, but dictionary is <null>.");
         }
 
         [Fact]
@@ -518,11 +516,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContain(keyValuePairs, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain value \"One\" at key 1 because we do, but found it anyhow.");
+                "Expected dictionary to not contain value \"One\" at key 1 because*failure message, but found it anyhow.");
         }
 
         [Fact]
@@ -542,11 +540,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContain(keyValuePairs, "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContain(keyValuePairs, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because we do, but found them anyhow.");
+                "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because*failure message, but found them anyhow.");
         }
 
         [Fact]
@@ -565,12 +563,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().NotContain(keyValuePairs, "because we want to test the behaviour with a null subject");
+                dictionary.Should().NotContain(keyValuePairs, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain key/value pairs {[1, One], [1, Two]} because we want to test the behaviour with a null subject, but dictionary is <null>.");
+                "Expected dictionary to not contain key/value pairs {[1, One], [1, Two]} because*failure message, but dictionary is <null>.");
         }
 
         [Fact]
@@ -587,9 +585,9 @@ public partial class GenericDictionaryAssertionSpecs
             List<KeyValuePair<int, string>> keyValuePair = [];
 
             // Act
-            Action act = () => dictionary1.Should().NotContain(keyValuePair,
-                "because we want to test the behaviour with an empty set of key/value pairs");
+            Action act = () => dictionary1.Should().NotContain(keyValuePair, "we want to test the {0} message", "failure");
 
+            // TODO should the message contain the because text?
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
                 "Cannot verify key containment against an empty collection of key/value pairs*");
@@ -610,8 +608,9 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             Action act = () =>
-                dictionary1.Should().NotContain(keyValuePairs, "because we want to test the behaviour with a null subject");
+                dictionary1.Should().NotContain(keyValuePairs, "we want to test the {0} message", "failure");
 
+            // TODO should the message contain the because text?
             // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot compare dictionary with <null>.*")
@@ -706,11 +705,11 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             var item = new KeyValuePair<int, string>(1, "One");
-            Action act = () => dictionary.Should().NotContain(item, "we put it {0}", "there");
+            Action act = () => dictionary.Should().NotContain(item, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain value \"One\" at key 1 because we put it there, but found it anyhow.");
+                "Expected dictionary not to contain value \"One\" at key 1 because*failure message, but found it anyhow.");
         }
 
         [Fact]
@@ -730,11 +729,11 @@ public partial class GenericDictionaryAssertionSpecs
                 new(2, "Two")
             };
 
-            Action act = () => dictionary.Should().NotContain(items, "we did not put them {0}", "there");
+            Action act = () => dictionary.Should().NotContain(items, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because we did not put them there, but found them anyhow.");
+                "Expected dictionary to not contain key/value pairs {[1, One], [2, Two]} because*failure message, but found them anyhow.");
         }
 
         [Fact]
@@ -748,11 +747,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContain(1, "One", "we did not put it {0}", "there");
+            Action act = () => dictionary.Should().NotContain(1, "One", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain value \"One\" at key 1 because we did not put it there, but found it anyhow.");
+                "Expected dictionary not to contain value \"One\" at key 1 because*failure message, but found it anyhow.");
         }
 
         [Fact]
@@ -765,12 +764,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().NotContain(1, "One", "because we want to test the behaviour with a null subject");
+                dictionary.Should().NotContain(1, "One", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain value \"One\" at key 1 because we want to test the behaviour with a null subject, but dictionary is <null>.");
+                "Expected dictionary not to contain value \"One\" at key 1 because*failure message, but dictionary is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainKey.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainKey.cs
@@ -53,11 +53,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().ContainKey(3, "because {0}", "we do");
+            Action act = () => dictionary.Should().ContainKey(3, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because*failure message.");
         }
 
         [Fact]
@@ -124,11 +124,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainKey(1, "because we {0} like it", "don't");
+            Action act = () => dictionary.Should().NotContainKey(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain key 1 because we don't like it, but found it anyhow.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain key 1 because*failure message, but found it anyhow.");
         }
 
         [Fact]
@@ -141,12 +141,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().NotContainKey(1, "because we want to test the behaviour with a null subject");
+                dictionary.Should().NotContainKey(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain key 1 because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary not to contain key 1 because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainKeys.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainKeys.cs
@@ -35,11 +35,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().ContainKeys([2, 3], "because {0}", "we do");
+            Action act = () => dictionary.Should().ContainKeys([2, 3], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain keys {2, 3} because we do, but could not find {3}.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain keys {2, 3} because*failure message, but could not find {3}.");
         }
 
         [Fact]
@@ -52,12 +52,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().ContainKeys([2, 3], "because {0}", "we do");
+                dictionary.Should().ContainKeys([2, 3], "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain keys {2, 3} because we do, but found <null>.");
+                "Expected dictionary to contain keys {2, 3} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -110,11 +110,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainKeys([2, 3], "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContainKeys([2, 3], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain keys {2, 3} because we do, but found {2}.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain keys {2, 3} because*failure message, but found {2}.");
         }
 
         [Fact]
@@ -128,11 +128,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainKeys([2], "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContainKeys([2], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain key 2 because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain key 2 because*failure message.");
         }
 
         [Fact]
@@ -145,12 +145,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().NotContainKeys([2], "because {0}", "we do");
+                dictionary.Should().NotContainKeys([2], "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain keys {2} because we do, but found <null>.");
+                "Expected dictionary to not contain keys {2} because*failure message, but found <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainValue.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainValue.cs
@@ -51,12 +51,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().ContainValue("One", "because {0}", "we do");
+                dictionary.Should().ContainValue("One", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to contain values {\"One\"} because we do, but found <null>.");
+                .WithMessage("Expected dictionary to contain values {\"One\"} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -104,11 +104,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().ContainValue("Three", "because {0}", "we do");
+            Action act = () => dictionary.Should().ContainValue("Three", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain value \"Three\" because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain value \"Three\" because*failure message.");
         }
     }
 
@@ -142,11 +142,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainValue("One", "because we {0} like it", "don't");
+            Action act = () => dictionary.Should().NotContainValue("One", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain value \"One\" because we don't like it, but found it anyhow.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain value \"One\" because*failure message, but found it anyhow.");
         }
 
         [Fact]
@@ -159,12 +159,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().NotContainValue("One", "because we want to test the behaviour with a null subject");
+                dictionary.Should().NotContainValue("One", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary not to contain value \"One\" because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary not to contain value \"One\" because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainValues.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.ContainValues.cs
@@ -38,11 +38,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().ContainValues(["Two", "Three"], "because {0}", "we do");
+            Action act = () => dictionary.Should().ContainValues(["Two", "Three"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain values {\"Two\", \"Three\"} because we do, but could not find \"Three\".");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain values {\"Two\", \"Three\"} because*failure message, but could not find \"Three\".");
         }
 
         [Fact]
@@ -112,11 +112,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainValues(["Two"], "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContainValues(["Two"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value \"Two\" because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value \"Two\" because*failure message.");
         }
 
         [Fact]
@@ -130,11 +130,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().NotContainValues(["Two", "Three"], "because {0}", "we do");
+            Action act = () => dictionary.Should().NotContainValues(["Two", "Three"], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value {\"Two\", \"Three\"} because we do, but found {\"Two\"}.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value {\"Two\", \"Three\"} because*failure message, but found {\"Two\"}.");
         }
 
         [Fact]
@@ -166,12 +166,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary.Should().NotContainValues(["Two", "Three"], "because {0}", "we do");
+                dictionary.Should().NotContainValues(["Two", "Three"], "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not contain values {\"Two\", \"Three\"} because we do, but found <null>.");
+                "Expected dictionary to not contain values {\"Two\", \"Three\"} because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.Equal.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.Equal.cs
@@ -67,11 +67,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the failure {0}", "message");
+            Action act = () => dictionary1.Should().Equal(dictionary2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1] = \"One\", [22] = \"Two\"} because we want to test the failure message, but could not find keys {22}.");
+                "Expected dictionary1 to be equal to {[1] = \"One\", [22] = \"Two\"} because*failure message, but could not find keys {22}.");
         }
 
         [Fact]
@@ -92,11 +92,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the failure {0}", "message");
+            Action act = () => dictionary1.Should().Equal(dictionary2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because we want to test the failure message, but found additional keys {3}.");
+                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because*failure message, but found additional keys {3}.");
         }
 
         [Fact]
@@ -116,11 +116,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary1.Should().Equal(dictionary2, "because we want to test the failure {0}", "message");
+            Action act = () => dictionary1.Should().Equal(dictionary2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Three\"} because we want to test the failure message, but {[1] = \"One\", [2] = \"Two\"} differs at key 2.");
+                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Three\"} because*failure message, but {[1] = \"One\", [2] = \"Two\"} differs at key 2.");
         }
 
         [Fact]
@@ -139,12 +139,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
+                dictionary1.Should().Equal(dictionary2, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -160,9 +160,9 @@ public partial class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary2 = null;
 
             // Act
-            Action act = () =>
-                dictionary1.Should().Equal(dictionary2, "because we want to test the behaviour with a null subject");
+            Action act = () => dictionary1.Should().Equal(dictionary2, "we want to test the {0} message", "failure");
 
+            // TODO should the message contain the because text?
             // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot compare dictionary with <null>.*")
@@ -273,11 +273,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the failure {0}", "message");
+            Action act = () => dictionary1.Should().NotEqual(dictionary2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect dictionaries {[1] = \"One\", [2] = \"Two\"} and {[1] = \"One\", [2] = \"Two\"} to be equal because we want to test the failure message.");
+                "Did not expect dictionaries {[1] = \"One\", [2] = \"Two\"} and {[1] = \"One\", [2] = \"Two\"} to be equal because*failure message.");
         }
 
         [Fact]
@@ -296,12 +296,12 @@ public partial class GenericDictionaryAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with a null subject");
+                dictionary1.Should().NotEqual(dictionary2, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionaries not to be equal because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionaries not to be equal because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -318,8 +318,9 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             Action act =
-                () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with a null subject");
+                () => dictionary1.Should().NotEqual(dictionary2, "we want to test the {0} message", "failure");
 
+            // TODO should the message contain the because text?
             // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot compare dictionary with <null>.*")
@@ -341,11 +342,11 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             Action act =
-                () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with same objects");
+                () => dictionary1.Should().NotEqual(dictionary2, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionaries not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
+                "Expected dictionaries not to be equal because*failure message, but they both reference the same object.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCount.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCount.cs
@@ -55,12 +55,12 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action action = () => dictionary.Should().HaveCount(4, "because we want to test the failure {0}", "message");
+            Action action = () => dictionary.Should().HaveCount(4, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to contain 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                    "Expected dictionary to contain 4 item(s) because*failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -90,11 +90,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action act = () => dictionary.Should().HaveCount(c => c >= 4, "a minimum of 4 is required");
+            Action act = () => dictionary.Should().HaveCount(c => c >= 4, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have a count (c >= 4) because a minimum of 4 is required, but count is 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                "Expected dictionary to have a count (c >= 4) because*failure message, but count is 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -123,11 +123,11 @@ public partial class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().HaveCount(1, "we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().HaveCount(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain 1 item(s) because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary to contain 1 item(s) because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -137,11 +137,11 @@ public partial class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().HaveCount(c => c < 3, "we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().HaveCount(c => c < 3, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to contain (c < 3) items because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary to contain (c < 3) items because*failure message, but found <null>.");
         }
     }
 
@@ -192,11 +192,11 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action action = () => dictionary.Should().NotHaveCount(3, "because we want to test the failure {0}", "message");
+            Action action = () => dictionary.Should().NotHaveCount(3, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*not contain*3*because we want to test the failure message*3*");
+                .WithMessage("*not contain*3*because*failure message*3*");
         }
 
         [Fact]
@@ -206,11 +206,11 @@ public partial class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().NotHaveCount(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*not contain*1*because*failure message, but found <null>*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountGreaterThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountGreaterThan.cs
@@ -55,12 +55,12 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             Action action = () =>
-                dictionary.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
+                dictionary.Should().HaveCountGreaterThan(3, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to contain more than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                    "Expected dictionary to contain more than 3 item(s) because*failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -70,11 +70,11 @@ public partial class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().HaveCountGreaterThan(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*more than*1*because*failure message, but found <null>*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
@@ -56,12 +56,12 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             Action action = () =>
-                dictionary.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
+                dictionary.Should().HaveCountGreaterThanOrEqualTo(4, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to contain at least 4 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                    "Expected dictionary to contain at least 4 item(s) because*failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -72,11 +72,11 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             Action act = () =>
-                dictionary.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
+                dictionary.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*at least*1*because*failure message, but found <null>*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountLessThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountLessThan.cs
@@ -54,12 +54,12 @@ public partial class GenericDictionaryAssertionSpecs
             };
 
             // Act
-            Action action = () => dictionary.Should().HaveCountLessThan(3, "because we want to test the failure {0}", "message");
+            Action action = () => dictionary.Should().HaveCountLessThan(3, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to contain fewer than 3 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                    "Expected dictionary to contain fewer than 3 item(s) because*failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -69,11 +69,11 @@ public partial class GenericDictionaryAssertionSpecs
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().HaveCountLessThan(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*fewer than*1*because*failure message, but found <null>*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountLessThanOrEqualTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveCountLessThanOrEqualTo.cs
@@ -56,12 +56,12 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             Action action = () =>
-                dictionary.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
+                dictionary.Should().HaveCountLessThanOrEqualTo(2, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected dictionary to contain at most 2 item(s) because we want to test the failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
+                    "Expected dictionary to contain at most 2 item(s) because*failure message, but found 3: {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"}.");
         }
 
         [Fact]
@@ -72,11 +72,11 @@ public partial class GenericDictionaryAssertionSpecs
 
             // Act
             Action act = () =>
-                dictionary.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
+                dictionary.Should().HaveCountLessThanOrEqualTo(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
+                .WithMessage("*at most*1*because*failure message, but found <null>*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveSameCount.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.HaveSameCount.cs
@@ -61,11 +61,11 @@ public partial class GenericDictionaryAssertionSpecs
             int[] collection = [4, 6];
 
             // Act
-            Action act = () => dictionary.Should().HaveSameCount(collection, "we want to test the {0}", "reason");
+            Action act = () => dictionary.Should().HaveSameCount(collection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have 2 item(s) because we want to test the reason, but found 3.");
+                "Expected dictionary to have 2 item(s) because*failure message, but found 3.");
         }
 
         [Fact]
@@ -76,12 +76,11 @@ public partial class GenericDictionaryAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => dictionary.Should().HaveSameCount(collection,
-                "because we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().HaveSameCount(collection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary to have the same count as {1, 2, 3} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -160,11 +159,11 @@ public partial class GenericDictionaryAssertionSpecs
             int[] collection = [4, 5, 6];
 
             // Act
-            Action act = () => dictionary.Should().NotHaveSameCount(collection, "we want to test the {0}", "reason");
+            Action act = () => dictionary.Should().NotHaveSameCount(collection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not have 3 item(s) because we want to test the reason, but found 3.");
+                "Expected dictionary to not have 3 item(s) because*failure message, but found 3.");
         }
 
         [Fact]
@@ -175,12 +174,11 @@ public partial class GenericDictionaryAssertionSpecs
             int[] collection = [1, 2, 3];
 
             // Act
-            Action act = () => dictionary.Should().NotHaveSameCount(collection,
-                "because we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().NotHaveSameCount(collection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary to not have the same count as {1, 2, 3} because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -219,12 +217,11 @@ public partial class GenericDictionaryAssertionSpecs
             var collection = dictionary;
 
             // Act
-            Action act = () => dictionary.Should().NotHaveSameCount(collection,
-                "because we want to test the behaviour with same objects");
+            Action act = () => dictionary.Should().NotHaveSameCount(collection, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
+                "*not have the same count*because*failure message, but they both reference the same object.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -59,12 +59,12 @@ public class EventAssertionSpecs
             using var monitor = subject.Monitor();
 
             // Act
-            Action act = () => monitor.Should().Raise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
+            Action act = () => monitor.Should().Raise("PropertyChanged", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected object " + Formatter.ToString(subject) +
-                " to raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did not.");
+                " to raise event \"PropertyChanged\" because*failure message, but it did not.");
         }
 
         [Fact]
@@ -89,12 +89,12 @@ public class EventAssertionSpecs
 
             // Act
             Action act = () =>
-                monitor.Should().NotRaise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
+                monitor.Should().NotRaise("PropertyChanged", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected object " + Formatter.ToString(subject) +
-                    " to not raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did.");
+                    " to not raise event \"PropertyChanged\" because*failure message, but it did.");
         }
 
         [Fact]
@@ -470,12 +470,12 @@ public class EventAssertionSpecs
             using var monitor = subject.Monitor();
 
             // Act
-            Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty, "the property was changed");
+            Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected object " + Formatter.ToString(subject) +
-                " to raise event \"PropertyChanged\" for property \"SomeProperty\" because the property was changed, but it did not*");
+                " to raise event \"PropertyChanged\" for property \"SomeProperty\" because*failure message, but it did not*");
         }
 
         [Fact]
@@ -591,12 +591,12 @@ public class EventAssertionSpecs
             subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
 
             // Act
-            Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty, "nothing happened");
+            Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Did not expect object " + Formatter.ToString(subject) +
-                " to raise the \"PropertyChanged\" event for property \"SomeProperty\" because nothing happened, but it did.");
+                " to raise the \"PropertyChanged\" event for property \"SomeProperty\" because*failure message, but it did.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -37,12 +37,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> testAction = async () =>
         {
             using var _ = new AssertionScope();
-            await action.Should().ThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
+            await action.Should().ThrowAsync<ArgumentException>("we want to test the {0} message", "failure");
         };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
+            .WithMessage("*because*failure message, but found <null>*")
             .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
@@ -56,12 +56,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> testAction = async () =>
         {
             using var _ = new AssertionScope();
-            await action.Should().NotThrowAsync<ArgumentException>("because we want to test the failure {0}", "message");
+            await action.Should().NotThrowAsync<ArgumentException>("we want to test the {0} message", "failure");
         };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
+            .WithMessage("*because*failure message, but found <null>*")
             .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
@@ -75,12 +75,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> testAction = async () =>
         {
             using var _ = new AssertionScope();
-            await action.Should().NotThrowAsync("because we want to test the failure {0}", "message");
+            await action.Should().NotThrowAsync("we want to test the {0} message", "failure");
         };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
+            .WithMessage("*because*failure message, but found <null>*")
             .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
@@ -280,12 +280,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject
             .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
-            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            .Should().ThrowExactlyAsync<ArgumentException>("we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
             .WithMessage(
-                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
+                "Expected type to be System.ArgumentException because*failure message, but found System.ArgumentNullException.");
     }
 
     [Fact]
@@ -297,12 +297,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject
             .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
-            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            .Should().ThrowExactlyAsync<ArgumentException>("we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
             .WithMessage(
-                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
+                "Expected type to be System.ArgumentException because*failure message, but found System.ArgumentNullException.");
     }
 
     [Fact]
@@ -314,12 +314,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject
             .Awaiting(x => x.ThrowAggregateExceptionAsync<ArgumentException>())
-            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            .Should().ThrowExactlyAsync<ArgumentException>("we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
             .WithMessage(
-                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
+                "Expected type to be System.ArgumentException because*failure message, but found System.AggregateException.");
     }
 
     [Fact]
@@ -331,12 +331,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject
             .Awaiting(x => x.ThrowAggregateExceptionAsyncValueTask<ArgumentException>())
-            .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            .Should().ThrowExactlyAsync<ArgumentException>("we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
             .WithMessage(
-                "Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
+                "Expected type to be System.ArgumentException because*failure message, but found System.AggregateException.");
     }
 
     [Fact]
@@ -429,12 +429,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject
             .Awaiting(x => x.SucceedAsync())
-            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+            .Should().ThrowAsync<InvalidOperationException>("we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
             .WithMessage(
-                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
+                "Expected a <System.InvalidOperationException> to be thrown because*failure message, but no exception was thrown.");
     }
 
     [Fact]
@@ -446,12 +446,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject
             .Awaiting(x => x.SucceedAsyncValueTask())
-            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+            .Should().ThrowAsync<InvalidOperationException>("we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
             .WithMessage(
-                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
+                "Expected a <System.InvalidOperationException> to be thrown because*failure message, but no exception was thrown.");
     }
 
     [Fact]
@@ -463,12 +463,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject
             .Awaiting(x => x.ThrowAsync<ArgumentException>())
-            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+            .Should().ThrowAsync<InvalidOperationException>("we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
             .WithMessage(
-                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
+                "Expected a <System.InvalidOperationException> to be thrown because*failure message, but found <System.ArgumentException>*");
     }
 
     [Fact]
@@ -480,12 +480,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject
             .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-            .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+            .Should().ThrowAsync<InvalidOperationException>("we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
             .WithMessage(
-                "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
+                "Expected a <System.InvalidOperationException> to be thrown because*failure message, but found <System.ArgumentException>*");
     }
 
     [Fact]
@@ -556,6 +556,7 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
 
+        // TODO The because arguments are not relevant here!?
         // Assert
         await action.Should().ThrowAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
     }
@@ -592,12 +593,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> testAction = async () =>
         {
             using var _ = new AssertionScope();
-            await action.Should().ThrowExactlyAsync<ArgumentException>("because we want to test the failure {0}", "message");
+            await action.Should().ThrowExactlyAsync<ArgumentException>("we want to test the {0} message", "failure");
         };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
+            .WithMessage("*because*failure message, but found <null>*")
             .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
@@ -640,6 +641,7 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
+        // TODO The because arguments are not relevant here!?
         // Assert
         await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
     }
@@ -655,6 +657,7 @@ public class AsyncFunctionExceptionAssertionSpecs
             // Act
             Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
+            // TODO The because arguments are not relevant here!?
             // Assert
             await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
         }
@@ -1106,11 +1109,11 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> act = () =>
             task.Should().ThrowAsync<ArgumentException>()
-                .WithParameterName("someParameter", "we want to test the failure {0}", "message");
+                .WithParameterName("someParameter", "we want to test the {0} message", "failure");
 
         // Assert
         await act.Should().ThrowAsync<XunitException>()
-            .WithMessage("*with parameter name \"someParameter\"*we want to test the failure message*\"someOtherParameter\"*");
+            .WithMessage("*with parameter name \"someParameter\" because*failure message*\"someOtherParameter\"*");
     }
 
     #region NotThrowAfterAsync
@@ -1163,14 +1166,12 @@ public class AsyncFunctionExceptionAssertionSpecs
         Func<Task> testAction = async () =>
         {
             using var _ = new AssertionScope();
-
-            await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
-                "because we want to test the failure {0}", "message");
+            await action.Should().NotThrowAfterAsync(waitTime, pollInterval, "we want to test the {0} message", "failure");
         };
 
         // Assert
         await testAction.Should().ThrowAsync<XunitException>()
-            .WithMessage("*because we want to test the failure message*found <null>*")
+            .WithMessage("*because*failure message, but found <null>*")
             .Where(e => !e.Message.Contains("NullReferenceException"));
     }
 
@@ -1223,11 +1224,11 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Act
         Func<Task> action = () => func.Should()
-            .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+            .NotThrowAfterAsync(waitTime, pollInterval, "we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("*but found <null>*");
+            .WithMessage("*because*failure message, but found <null>*");
     }
 
     [Fact]
@@ -1253,11 +1254,11 @@ public class AsyncFunctionExceptionAssertionSpecs
 
         // Act
         Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-            .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+            .NotThrowAfterAsync(waitTime, pollInterval, "we want to test the {0} message", "failure");
 
         // Assert
         await action.Should().ThrowAsync<XunitException>()
-            .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+            .WithMessage("Did not expect any exceptions after 2s because*failure message*");
     }
 
     public partial class UIFacts
@@ -1286,11 +1287,11 @@ public class AsyncFunctionExceptionAssertionSpecs
 
             // Act
             Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                .NotThrowAfterAsync(waitTime, pollInterval, "we want to test the {0} message", "failure");
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+                .WithMessage("Did not expect any exceptions after 2s because*failure message*");
         }
     }
 

--- a/Tests/AwesomeAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -105,7 +105,7 @@ public class ExceptionAssertionSpecs
         try
         {
             // Act
-            act.Should().ThrowExactly<ArgumentException>("because {0} should do that", "Does.Do");
+            act.Should().ThrowExactly<ArgumentException>("we want to test the failure {0}", "message");
 
             throw new XunitException("This point should not be reached.");
         }
@@ -114,7 +114,7 @@ public class ExceptionAssertionSpecs
             // Assert
             ex.Message.Should()
                 .Match(
-                    "Expected type to be System.ArgumentException because Does.Do should do that, but found System.ArgumentNullException.");
+                    "Expected type to be System.ArgumentException because*failure message, but found System.ArgumentNullException.");
         }
     }
 
@@ -127,7 +127,7 @@ public class ExceptionAssertionSpecs
         try
         {
             // Act
-            act.Should().ThrowExactly<ArgumentException>("because {0} should do that", "Does.Do");
+            act.Should().ThrowExactly<ArgumentException>("we want to test the failure {0}", "message");
 
             throw new XunitException("This point should not be reached.");
         }
@@ -136,7 +136,7 @@ public class ExceptionAssertionSpecs
             // Assert
             ex.Message.Should()
                 .Match(
-                    "Expected type to be System.ArgumentException because Does.Do should do that, but found System.AggregateException.");
+                    "Expected type to be System.ArgumentException because*failure message, but found System.AggregateException.");
         }
     }
 

--- a/Tests/AwesomeAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -21,7 +21,7 @@ public class FunctionExceptionAssertionSpecs
         Action testAction = () =>
         {
             using var _ = new AssertionScope();
-            action.Should().NotThrow("because we want to test the failure {0}", "message");
+            action.Should().NotThrow("we want to test the {0} message", "failure");
         };
 
         // Assert
@@ -144,7 +144,7 @@ public class FunctionExceptionAssertionSpecs
         Action action = () =>
         {
             using var _ = new AssertionScope();
-            act.Should().Throw<ArgumentNullException>("because we want to test the failure {0}", "message");
+            act.Should().Throw<ArgumentNullException>("we want to test the {0} message", "failure");
         };
 
         // Assert
@@ -243,11 +243,11 @@ public class FunctionExceptionAssertionSpecs
         Func<int> f = () => 12;
 
         // Act
-        Action action = () => f.Should().Throw<InvalidCastException>("that's what I {0}", "said");
+        Action action = () => f.Should().Throw<InvalidCastException>("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Expected*InvalidCastException*that's what I said*but*no exception*");
+            .WithMessage("Expected*InvalidCastException*because*failure message*but*no exception*");
     }
 
     #endregion
@@ -264,7 +264,7 @@ public class FunctionExceptionAssertionSpecs
         Action action = () =>
         {
             using var _ = new AssertionScope();
-            act.Should().ThrowExactly<ArgumentNullException>("because we want to test the failure {0}", "message");
+            act.Should().ThrowExactly<ArgumentNullException>("we want to test the {0} message", "failure");
         };
 
         // Assert
@@ -332,11 +332,11 @@ public class FunctionExceptionAssertionSpecs
         Func<int> f = () => 12;
 
         // Act
-        Action action = () => f.Should().ThrowExactly<InvalidCastException>("that's what I {0}", "said");
+        Action action = () => f.Should().ThrowExactly<InvalidCastException>("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Expected*InvalidCastException*that's what I said*but*no exception*");
+            .WithMessage("Expected*InvalidCastException*because*failure message*but*no exception*");
     }
 
     #endregion
@@ -350,7 +350,7 @@ public class FunctionExceptionAssertionSpecs
         Func<int> act = null;
 
         // Act
-        Action action = () => act.Should().NotThrow("because we want to test the failure {0}", "message");
+        Action action = () => act.Should().NotThrow("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
@@ -367,7 +367,7 @@ public class FunctionExceptionAssertionSpecs
         Action action = () =>
         {
             using var _ = new AssertionScope();
-            act.Should().NotThrow<ArgumentNullException>("because we want to test the failure {0}", "message");
+            act.Should().NotThrow<ArgumentNullException>("we want to test the {0} message", "failure");
         };
 
         // Assert
@@ -393,11 +393,11 @@ public class FunctionExceptionAssertionSpecs
         Func<int> f = () => throw new ArgumentNullException();
 
         // Act
-        Action action = () => f.Should().NotThrow("that's what he {0}", "told me");
+        Action action = () => f.Should().NotThrow("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*no*exception*that's what he told me*but*ArgumentNullException*");
+            .WithMessage("*no*exception*because*failure message*but*ArgumentNullException*");
     }
 
     [Fact]
@@ -407,11 +407,11 @@ public class FunctionExceptionAssertionSpecs
         Func<int> f = () => throw new AggregateException(new ArgumentNullException());
 
         // Act
-        Action action = () => f.Should().NotThrow("that's what he {0}", "told me");
+        Action action = () => f.Should().NotThrow("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*no*exception*that's what he told me*but*ArgumentNullException*");
+            .WithMessage("*no*exception*because*failure message*but*ArgumentNullException*");
     }
 
     [Fact]
@@ -422,11 +422,11 @@ public class FunctionExceptionAssertionSpecs
         Func<int> f = () => throw new AggregateException(new AggregateException(new ArgumentNullException()));
 
         // Act
-        Action action = () => f.Should().NotThrow("that's what he {0}", "told me");
+        Action action = () => f.Should().NotThrow("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("*no*exception*that's what he told me*but*ArgumentNullException*");
+            .WithMessage("*no*exception*because*failure message*but*ArgumentNullException*");
     }
 
     #endregion
@@ -445,7 +445,7 @@ public class FunctionExceptionAssertionSpecs
         Action testAction = () =>
         {
             using var _ = new AssertionScope();
-            action.Should().NotThrowAfter(waitTime, pollInterval, "because we want to test the failure {0}", "message");
+            action.Should().NotThrowAfter(waitTime, pollInterval, "we want to test the {0} message", "failure");
         };
 
         // Assert
@@ -511,11 +511,11 @@ public class FunctionExceptionAssertionSpecs
 
         // Act
         Action action = () =>
-            throwLongerThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval, "we passed valid arguments");
+            throwLongerThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval, "we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Did not expect any exceptions after 100ms because we passed valid arguments*");
+            .WithMessage("Did not expect any exceptions after 100ms because*failure message*");
     }
 
     [Fact]
@@ -612,12 +612,12 @@ public class FunctionExceptionAssertionSpecs
         Func<int> f = () => throw new InvalidOperationException("custom message");
 
         // Act
-        Action action = () => f.Should().NotThrow<InvalidOperationException>("it was so {0}", "fast");
+        Action action = () => f.Should().NotThrow<InvalidOperationException>("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
             .WithMessage(
-                "*Did not expect System.InvalidOperationException because it was so fast, but found System.InvalidOperationException: custom message*");
+                "*Did not expect System.InvalidOperationException because*failure message, but found System.InvalidOperationException: custom message*");
     }
 
     [Fact]

--- a/Tests/AwesomeAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/InnerExceptionSpecs.cs
@@ -93,7 +93,7 @@ public class InnerExceptionSpecs
         {
             // Act
             act.Should().Throw<BadImageFormatException>()
-                .WithInnerExceptionExactly<ArgumentException>("because {0} should do just that", "the action");
+                .WithInnerExceptionExactly<ArgumentException>("we want to test the {0} message", "failure");
 
             throw new XunitException("This point should not be reached.");
         }
@@ -101,7 +101,7 @@ public class InnerExceptionSpecs
         {
             // Assert
             ex.Message.Should()
-                .Match("Expected*ArgumentException*the action should do just that*ArgumentNullException*InnerExceptionMessage*");
+                .Match("Expected*ArgumentException*because*failure message*ArgumentNullException*InnerExceptionMessage*");
         }
     }
 
@@ -114,7 +114,7 @@ public class InnerExceptionSpecs
 
         // Act / Assert
         act.Should().Throw<BadImageFormatException>()
-            .WithInnerExceptionExactly(typeof(ArgumentNullException), "because {0} should do just that", "the action");
+            .WithInnerExceptionExactly(typeof(ArgumentNullException), "the parameter is {0} relevant for this test", "parameter");
     }
 
     [Fact]
@@ -142,7 +142,7 @@ public class InnerExceptionSpecs
         {
             // Act
             act.Should().Throw<BadImageFormatException>()
-                .WithInnerExceptionExactly(typeof(ArgumentException), "because {0} should do just that", "the action");
+                .WithInnerExceptionExactly(typeof(ArgumentException), "we want to test the {0} message", "failure");
 
             throw new XunitException("This point should not be reached.");
         }
@@ -150,7 +150,7 @@ public class InnerExceptionSpecs
         {
             // Assert
             ex.Message.Should()
-                .Match("Expected*ArgumentException*the action should do just that*ArgumentNullException*InnerExceptionMessage*");
+                .Match("Expected*ArgumentException*because*failure message*ArgumentNullException*InnerExceptionMessage*");
         }
     }
 
@@ -162,7 +162,7 @@ public class InnerExceptionSpecs
 
         // Act / Assert
         act.Should().Throw<BadImageFormatException>()
-            .WithInnerExceptionExactly<ArgumentNullException>("because {0} should do just that", "the action");
+            .WithInnerExceptionExactly<ArgumentNullException>("the parameter is {0} relevant for this test", "parameter");
     }
 
     [Fact]
@@ -173,11 +173,11 @@ public class InnerExceptionSpecs
 
         // Act
         Action act = () => subject.Should().Throw<BadImageFormatException>()
-            .WithInnerExceptionExactly<ArgumentNullException>("some {0}", "message");
+            .WithInnerExceptionExactly<ArgumentNullException>("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("*some message*no inner exception*");
+            .WithMessage("*we want to test the failure message*no inner exception*");
     }
 
     [Fact]
@@ -194,7 +194,7 @@ public class InnerExceptionSpecs
             testSubject
                 .Invoking(x => x.Do())
                 .Should().Throw<Exception>()
-                .WithInnerException<ArgumentException>("because {0} should do just that", "Does.Do");
+                .WithInnerException<ArgumentException>("we want to test the {0} message", "failure");
 
             throw new XunitException("This point should not be reached");
         }
@@ -202,7 +202,7 @@ public class InnerExceptionSpecs
         {
             // Assert
             exc.Message.Should().Match(
-                "Expected*ArgumentException*Does.Do should do just that*NullReferenceException*InnerExceptionMessage*");
+                "Expected*ArgumentException*because*failure message*NullReferenceException*InnerExceptionMessage*");
         }
     }
 
@@ -214,14 +214,15 @@ public class InnerExceptionSpecs
             Does testSubject = Does.Throw<Exception>();
 
             testSubject.Invoking(x => x.Do()).Should().Throw<Exception>()
-                .WithInnerException<InvalidOperationException>("because {0} should do that", "Does.Do");
+                .WithInnerException<InvalidOperationException>("we want to test the {0} message", "failure");
 
             throw new XunitException("This point should not be reached");
         }
         catch (XunitException ex)
         {
             ex.Message.Should().Be(
-                "Expected inner System.InvalidOperationException because Does.Do should do that, but the thrown exception has no inner exception.");
+                "Expected inner System.InvalidOperationException because we want to test the failure message,"
+                + " but the thrown exception has no inner exception.");
         }
     }
 

--- a/Tests/AwesomeAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
@@ -171,10 +171,10 @@ public class MiscellaneousExceptionSpecs
         // Act
         Action act = () =>
             throwException.Should().Throw<ArgumentException>()
-                .WithParameterName("someParameter", "we want to test the failure {0}", "message");
+                .WithParameterName("someParameter", "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("*with parameter name \"someParameter\"*we want to test the failure message*\"someOtherParameter\"*");
+            .WithMessage("*with parameter name \"someParameter\"*because*failure message*\"someOtherParameter\"*");
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Exceptions/NotThrowSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/NotThrowSpecs.cs
@@ -21,7 +21,7 @@ public class NotThrowSpecs
         Action action = () =>
         {
             using var _ = new AssertionScope();
-            act.Should().NotThrow("because we want to test the failure {0}", "message");
+            act.Should().NotThrow("we want to test the {0} message", "failure");
         };
 
         // Assert
@@ -38,12 +38,12 @@ public class NotThrowSpecs
 
         // Act
         Action action =
-            () => foo.Invoking(f => f.Do()).Should().NotThrow<ArgumentException>("we passed valid arguments");
+            () => foo.Invoking(f => f.Do()).Should().NotThrow<ArgumentException>("we want to test the {0} message", "failure");
 
         // Assert
         action
             .Should().Throw<XunitException>().WithMessage(
-                "Did not expect System.ArgumentException because we passed valid arguments, " +
+                "Did not expect System.ArgumentException because*failure message, " +
                 "but found System.ArgumentException: An exception was forced*");
     }
 
@@ -64,12 +64,12 @@ public class NotThrowSpecs
         Does foo = Does.Throw(new ArgumentException("An exception was forced"));
 
         // Act
-        Action action = () => foo.Invoking(f => f.Do()).Should().NotThrow("we passed valid arguments");
+        Action action = () => foo.Invoking(f => f.Do()).Should().NotThrow("we want to test the {0} message", "failure");
 
         // Assert
         action
             .Should().Throw<XunitException>().WithMessage(
-                "Did not expect any exception because we passed valid arguments, " +
+                "Did not expect any exception because*failure message, " +
                 "but found System.ArgumentException: An exception was forced*");
     }
 
@@ -94,8 +94,7 @@ public class NotThrowSpecs
         {
             using var _ = new AssertionScope();
 
-            act.Should().NotThrowAfter(0.Milliseconds(), 0.Milliseconds(),
-                "because we want to test the failure {0}", "message");
+            act.Should().NotThrowAfter(0.Milliseconds(), 0.Milliseconds(), "we want to test the {0} message", "failure");
         };
 
         // Assert
@@ -177,11 +176,11 @@ public class NotThrowSpecs
 
         // Act
         Action action = () =>
-            throwLongerThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval, "we passed valid arguments");
+            throwLongerThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval, "we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
-            .WithMessage("Did not expect any exceptions after 100ms because we passed valid arguments*");
+            .WithMessage("Did not expect any exceptions after 100ms because*failure message*");
     }
 
     [Fact]

--- a/Tests/AwesomeAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/OuterExceptionSpecs.cs
@@ -120,7 +120,7 @@ public class OuterExceptionSpecs
             subjectThatThrows
                 .Invoking(x => x.Do())
                 .Should().Throw<InvalidOperationException>()
-                .WithMessage("message2", "because we want to test the failure {0}", "message");
+                .WithMessage("message2", "we want to test the {0} message", "failure");
 
             throw new XunitException("This point should not be reached");
         }
@@ -190,15 +190,15 @@ public class OuterExceptionSpecs
             Does testSubject = Does.NotThrow();
 
             // Act
-            testSubject.Invoking(x => x.Do()).Should().Throw<Exception>("because {0} should do that", "Does.Do");
+            testSubject.Invoking(x => x.Do()).Should().Throw<Exception>("we want to test the {0} message", "failure");
 
             throw new XunitException("This point should not be reached");
         }
         catch (XunitException ex)
         {
             // Assert
-            ex.Message.Should().Be(
-                "Expected a <System.Exception> to be thrown because Does.Do should do that, but no exception was thrown.");
+            ex.Message.Should().Match(
+                "Expected a <System.Exception> to be thrown because*failure message, but no exception was thrown.");
         }
     }
 
@@ -215,15 +215,15 @@ public class OuterExceptionSpecs
             // Act
             testSubject
                 .Invoking(x => x.Do())
-                .Should().Throw<InvalidOperationException>("because {0} should throw that one", "Does.Do");
+                .Should().Throw<InvalidOperationException>("we want to test the {0} message", "failure");
 
             throw new XunitException("This point should not be reached");
         }
         catch (XunitException ex)
         {
             // Assert
-            ex.Message.Should().StartWith(
-                "Expected a <System.InvalidOperationException> to be thrown because Does.Do should throw that one, but found <System.ArgumentException>:");
+            ex.Message.Should().Match(
+                "Expected a <System.InvalidOperationException> to be thrown because*failure message, but found <System.ArgumentException>:*");
 
             ex.Message.Should().Contain(actualException.Message);
         }

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
@@ -413,5 +413,31 @@ public partial class AssertionChainSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected because reasons");
         }
+
+        [Fact]
+        public void Message_should_contain_because_if_omitted_in_reason_format()
+        {
+            // Act
+            Action act = () => AssertionChain.GetOrCreate()
+                .BecauseOf("reasons")
+                .FailWith("Expected{reason}");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected because reasons");
+        }
+
+        [Fact]
+        public void Message_should_contain_because_if_omitted_in_reason_format_with_arguments()
+        {
+            // Act
+            Action act = () => AssertionChain.GetOrCreate()
+                .BecauseOf("reasons {0} arguments", "with")
+                .FailWith("Expected{reason}");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected because reasons with arguments");
+        }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Execution/CallerIdentificationSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/CallerIdentificationSpecs.cs
@@ -70,13 +70,13 @@ namespace AwesomeAssertions.Specs.Execution
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = () => bob.Should(timer).NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () => bob.Should(timer).NotCompleteWithinAsync(1.Seconds(), "we want to test the {0} message", "failure");
             bob.SetResult(true);
             timer.Complete();
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect bob to complete within 1s because test testArg.");
+                .WithMessage("Did not expect bob to complete within 1s because we want to test the failure message.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/ExtensibilitySpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/ExtensibilitySpecs.cs
@@ -18,11 +18,11 @@ public class ExtensibilitySpecs
         };
 
         // Act
-        Action act = () => myClient.Should().BeActive("because we don't work with old clients");
+        Action act = () => myClient.Should().BeActive("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
-            "Expected myClient to be true because we don't work with old clients, but found False.");
+            "Expected myClient to be true because we want to test the failure message, but found False.");
     }
 
     [Fact]

--- a/Tests/AwesomeAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -43,13 +43,13 @@ public class ComparableSpecs
             var other = new EquatableOfInt(2);
 
             // Act
-            Action act = () => subject.Should().Be(other, "they have the same property values");
+            Action act = () => subject.Should().Be(other, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected*2*because they have the same property values, but found*1*.");
+                    "Expected*2*because*failure message, but found*1*.");
         }
     }
 
@@ -78,13 +78,13 @@ public class ComparableSpecs
             var other = new EquatableOfInt(1);
 
             // Act
-            Action act = () => subject.Should().NotBe(other, "they represent different things");
+            Action act = () => subject.Should().NotBe(other, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "*Did not expect subject to be equal to*1*because they represent different things.*");
+                    "*Did not expect subject to be equal to*1*because*failure message.*");
         }
 
         [Fact]
@@ -109,12 +109,12 @@ public class ComparableSpecs
 
             // Act
             Action act = () => value.Should().BeOneOf(new[] { new EquatableOfInt(4), new EquatableOfInt(5) },
-                "because those are the valid {0}", "values");
+                "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {4, 5} because those are the valid values, but found 3.");
+                .WithMessage("Expected value to be one of {4, 5} because*failure message, but found 3.");
         }
 
         [Fact]
@@ -224,13 +224,13 @@ public class ComparableSpecs
             };
 
             // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected, "they have the same property values");
+            Action act = () => subject.Should().BeEquivalentTo(expected);
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expectation has property SomeOtherProperty*that the other object does not have*");
+                    "Expectation has property SomeOtherProperty that the other object does not have.*");
         }
     }
 
@@ -391,13 +391,13 @@ public class ComparableSpecs
             var other = new ComparableOfString("Forty two");
 
             // Act
-            Action act = () => subject.Should().BeRankedEquallyTo(other, "they represent the same number");
+            Action act = () => subject.Should().BeRankedEquallyTo(other, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected subject*42*to be ranked as equal to*Forty two*because they represent the same number.");
+                    "Expected subject*42*to be ranked as equal to*Forty two*because*failure message.");
         }
     }
 
@@ -422,13 +422,13 @@ public class ComparableSpecs
             var other = new ComparableOfString("Lead");
 
             // Act
-            Action act = () => subject.Should().NotBeRankedEquallyTo(other, "they represent different concepts");
+            Action act = () => subject.Should().NotBeRankedEquallyTo(other, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected subject*Lead*not to be ranked as equal to*Lead*because they represent different concepts.");
+                    "Expected subject*Lead*not to be ranked as equal to*Lead*because*failure message.");
         }
     }
 
@@ -453,12 +453,12 @@ public class ComparableSpecs
             var other = new ComparableOfString("City");
 
             // Act
-            Action act = () => subject.Should().BeLessThan(other, "a city is smaller than the world");
+            Action act = () => subject.Should().BeLessThan(other, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected subject*World*to be less than*City*because a city is smaller than the world.");
+                .WithMessage("Expected subject*World*to be less than*City*because*failure message.");
         }
 
         [Fact]
@@ -486,12 +486,12 @@ public class ComparableSpecs
             var other = new ComparableOfString("City");
 
             // Act
-            Action act = () => subject.Should().BeLessThanOrEqualTo(other, "we want to order them");
+            Action act = () => subject.Should().BeLessThanOrEqualTo(other, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected subject*World*to be less than or equal to*City*because we want to order them.");
+                .WithMessage("Expected subject*World*to be less than or equal to*City*because*failure message.");
         }
 
         [Fact]
@@ -563,12 +563,12 @@ public class ComparableSpecs
             var other = new ComparableOfString("def");
 
             // Act
-            Action act = () => subject.Should().BeGreaterThan(other, "'a' is smaller then 'e'");
+            Action act = () => subject.Should().BeGreaterThan(other, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected subject*abc*to be greater than*def*because 'a' is smaller then 'e'.");
+                .WithMessage("Expected subject*abc*to be greater than*def*because*failure message.");
         }
     }
 
@@ -582,12 +582,12 @@ public class ComparableSpecs
             var other = new ComparableOfString("def");
 
             // Act
-            Action act = () => subject.Should().BeGreaterThanOrEqualTo(other, "'d' is bigger then 'a'");
+            Action act = () => subject.Should().BeGreaterThanOrEqualTo(other, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected subject*abc*to be greater than or equal to*def*because 'd' is bigger then 'a'.");
+                .WithMessage("Expected subject*abc*to be greater than or equal to*def*because*failure message.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.Be.cs
@@ -53,11 +53,11 @@ public partial class NullableNumericAssertionSpecs
 
             // Act
             Action act = () =>
-                nullableIntegerA.Should().Be(nullableIntegerB, "because we want to test the failure {0}", "message");
+                nullableIntegerA.Should().Be(nullableIntegerB, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*2 because we want to test the failure message, but found 1.");
+                .WithMessage("Expected*2 because*failure message, but found 1.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.BeGreaterThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.BeGreaterThan.cs
@@ -137,7 +137,7 @@ public partial class NullableNumericAssertionSpecs
         public void To_test_the_null_path_for_difference_on_short()
         {
             // Arrange
-            var value = (short?)11;
+            var value = (short)11;
 
             // Act
             Action act = () => value.Should().BeGreaterThan(11);

--- a/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.BeNull.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.BeNull.cs
@@ -38,7 +38,7 @@ public partial class NullableNumericAssertionSpecs
             int? nullableInteger = 1;
 
             // Act
-            Action act = () => nullableInteger.Should().BeNull("because we want to test the failure {0}", "message");
+            Action act = () => nullableInteger.Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -79,7 +79,7 @@ public partial class NullableNumericAssertionSpecs
             int? nullableInteger = null;
 
             // Act
-            Action act = () => nullableInteger.Should().NotBeNull("because we want to test the failure {0}", "message");
+            Action act = () => nullableInteger.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.HaveValue.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.HaveValue.cs
@@ -39,7 +39,7 @@ public partial class NullableNumericAssertionSpecs
             int? nullableInteger = null;
 
             // Act
-            Action act = () => nullableInteger.Should().HaveValue("because we want to test the failure {0}", "message");
+            Action act = () => nullableInteger.Should().HaveValue("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -79,12 +79,12 @@ public partial class NullableNumericAssertionSpecs
             int? nullableInteger = 1;
 
             // Act
-            Action action = () => nullableInteger.Should().NotHaveValue("it was {0} expected", "not");
+            Action action = () => nullableInteger.Should().NotHaveValue("we want to test the {0} message", "failure");
 
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Did not expect a value because it was not expected, but found 1.");
+                .WithMessage("Did not expect a value because*failure message, but found 1.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.Match.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NullableNumericAssertionSpecs.Match.cs
@@ -26,7 +26,7 @@ public partial class NullableNumericAssertionSpecs
 
             // Act
             Action act = () =>
-                nullableInteger.Should().Match(o => !o.HasValue, "because we want to test the failure {0}", "message");
+                nullableInteger.Should().Match(o => !o.HasValue, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.Be.cs
@@ -27,7 +27,7 @@ public partial class NumericAssertionSpecs
             int differentValue = 2;
 
             // Act
-            Action act = () => value.Should().Be(differentValue, "because we want to test the failure {0}", "message");
+            Action act = () => value.Should().Be(differentValue, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -120,13 +120,13 @@ public partial class NumericAssertionSpecs
             float value = 3.5F;
 
             // Act
-            Action act = () => value.Should().Be(3.4F, "we want to test the error message");
+            Action act = () => value.Should().Be(3.4F, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to be *3.4* because we want to test the error message, but found *3.5*");
+                    "Expected value to be *3.4* because we want to test the failure message, but found *3.5*");
         }
 
         [Fact]
@@ -161,13 +161,13 @@ public partial class NumericAssertionSpecs
             double value = 3.5;
 
             // Act
-            Action act = () => value.Should().Be(3.4, "we want to test the error message");
+            Action act = () => value.Should().Be(3.4, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to be 3.4 because we want to test the error message, but found 3.5*.");
+                    "Expected value to be 3.4 because we want to test the failure message, but found 3.5*.");
         }
 
         [Fact]
@@ -202,12 +202,12 @@ public partial class NumericAssertionSpecs
             decimal value = 3.5m;
 
             // Act
-            Action act = () => value.Should().Be(3.4m, "we want to test the error message");
+            Action act = () => value.Should().Be(3.4m, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to be*3.4* because we want to test the error message, but found*3.5*");
+                    "Expected value to be*3.4* because we want to test the failure message, but found*3.5*");
         }
 
         [Fact]
@@ -307,7 +307,7 @@ public partial class NumericAssertionSpecs
             int sameValue = 1;
 
             // Act
-            Action act = () => value.Should().NotBe(sameValue, "because we want to test the failure {0}", "message");
+            Action act = () => value.Should().NotBe(sameValue, "we want to test the {0} message", "failure");
 
             // Assert
             act

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeApproximately.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeApproximately.cs
@@ -30,13 +30,13 @@ public partial class NumericAssertionSpecs
             float value = 3.1415927F;
 
             // Act
-            Action act = () => value.Should().BeApproximately(3.14F, 0.001F, "rockets will crash otherwise");
+            Action act = () => value.Should().BeApproximately(3.14F, 0.001F, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to approximate *3.14* +/- *0.001* because rockets will crash otherwise, but *3.1415927* differed by *0.001592*");
+                    "Expected value to approximate *3.14* +/- *0.001* because*failure message, but *3.1415927* differed by *0.001592*");
         }
 
         [Fact]
@@ -192,13 +192,13 @@ public partial class NumericAssertionSpecs
             double value = 3.1415927;
 
             // Act
-            Action act = () => value.Should().BeApproximately(3.14, 0.001, "rockets will crash otherwise");
+            Action act = () => value.Should().BeApproximately(3.14, 0.001, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to approximate 3.14 +/- 0.001 because rockets will crash otherwise, but 3.1415927 differed by 0.001592*");
+                    "Expected value to approximate 3.14 +/- 0.001 because*failure message, but 3.1415927 differed by 0.001592*");
         }
 
         [Fact]
@@ -339,11 +339,11 @@ public partial class NumericAssertionSpecs
             decimal value = 3.5011m;
 
             // Act
-            Action act = () => value.Should().BeApproximately(3.5m, 0.001m, "rockets will crash otherwise");
+            Action act = () => value.Should().BeApproximately(3.5m, 0.001m, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected value to approximate*3.5* +/-*0.001* because rockets will crash otherwise, but *3.5011* differed by*0.0011*");
+                "Expected value to approximate*3.5* +/-*0.001* because*failure message, but *3.5011* differed by*0.0011*");
         }
 
         [Fact]
@@ -427,13 +427,13 @@ public partial class NumericAssertionSpecs
             float value = 3.1415927F;
 
             // Act
-            Action act = () => value.Should().NotBeApproximately(3.14F, 0.1F, "rockets will crash otherwise");
+            Action act = () => value.Should().NotBeApproximately(3.14F, 0.1F, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to not approximate *3.14* +/- *0.1* because rockets will crash otherwise, but *3.1415927* only differed by *0.001592*");
+                    "Expected value to not approximate *3.14* +/- *0.1* because*failure message, but *3.1415927* only differed by *0.001592*");
         }
 
         [Fact]
@@ -586,13 +586,13 @@ public partial class NumericAssertionSpecs
             double value = 3.1415927;
 
             // Act
-            Action act = () => value.Should().NotBeApproximately(3.14, 0.1, "rockets will crash otherwise");
+            Action act = () => value.Should().NotBeApproximately(3.14, 0.1, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to not approximate *3.14* +/- *0.1* because rockets will crash otherwise, but *3.1415927* only differed by *0.001592*");
+                    "Expected value to not approximate *3.14* +/- *0.1* because*failure message, but *3.1415927* only differed by *0.001592*");
         }
 
         [Fact]
@@ -745,13 +745,13 @@ public partial class NumericAssertionSpecs
             decimal value = 3.5011m;
 
             // Act
-            Action act = () => value.Should().NotBeApproximately(3.5m, 0.1m, "rockets will crash otherwise");
+            Action act = () => value.Should().NotBeApproximately(3.5m, 0.1m, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to not approximate *3.5* +/- *0.1* because rockets will crash otherwise, but *3.5011* only differed by *0.0011*");
+                    "Expected value to not approximate *3.5* +/- *0.1* because*failure message, but *3.5011* only differed by *0.0011*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeGreaterThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeGreaterThan.cs
@@ -56,7 +56,7 @@ public partial class NumericAssertionSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(greaterValue, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(greaterValue, "we want to test the {0} message", "failure");
 
             // Assert
             act

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeGreaterThanOrEqualTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeGreaterThanOrEqualTo.cs
@@ -54,7 +54,7 @@ public partial class NumericAssertionSpecs
             // Act
             Action act =
                 () => value.Should()
-                    .BeGreaterThanOrEqualTo(greaterValue, "because we want to test the failure {0}", "message");
+                    .BeGreaterThanOrEqualTo(greaterValue, "we want to test the {0} message", "failure");
 
             // Assert
             act

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeInRange.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeInRange.cs
@@ -15,13 +15,13 @@ public partial class NumericAssertionSpecs
             float value = 3.99F;
 
             // Act
-            Action act = () => value.Should().BeInRange(4, 5, "because that's the valid range");
+            Action act = () => value.Should().BeInRange(4, 5, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to be between*4* and*5* because that\'s the valid range, but found*3.99*");
+                    "Expected value to be between*4* and*5* because*failure message, but found*3.99*");
         }
 
         [Fact]
@@ -127,13 +127,13 @@ public partial class NumericAssertionSpecs
             float value = 4.99F;
 
             // Act
-            Action act = () => value.Should().NotBeInRange(4, 5, "because that's the invalid range");
+            Action act = () => value.Should().NotBeInRange(4, 5, "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to not be between*4* and*5* because that\'s the invalid range, but found*4.99*");
+                    "Expected value to not be between*4* and*5* because*failure message, but found*4.99*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeLessThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeLessThan.cs
@@ -55,7 +55,7 @@ public partial class NumericAssertionSpecs
             int smallerValue = 1;
 
             // Act
-            Action act = () => value.Should().BeLessThan(smallerValue, "because we want to test the failure {0}", "message");
+            Action act = () => value.Should().BeLessThan(smallerValue, "we want to test the {0} message", "failure");
 
             // Assert
             act

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeLessThanOrEqualTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeLessThanOrEqualTo.cs
@@ -53,7 +53,7 @@ public partial class NumericAssertionSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeLessThanOrEqualTo(smallerValue, "because we want to test the failure {0}", "message");
+                value.Should().BeLessThanOrEqualTo(smallerValue, "we want to test the {0} message", "failure");
 
             // Assert
             act

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeNegative.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeNegative.cs
@@ -51,7 +51,7 @@ public partial class NumericAssertionSpecs
             int value = 1;
 
             // Act
-            Action act = () => value.Should().BeNegative("because we want to test the failure {0}", "message");
+            Action act = () => value.Should().BeNegative("we want to test the {0} message", "failure");
 
             // Assert
             act

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeOneOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BeOneOf.cs
@@ -30,12 +30,12 @@ public partial class NumericAssertionSpecs
             int value = 3;
 
             // Act
-            Action act = () => value.Should().BeOneOf([4, 5], "because those are the valid values");
+            Action act = () => value.Should().BeOneOf([4, 5], "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {4, 5} because those are the valid values, but found 3.");
+                .WithMessage("Expected value to be one of {4, 5} because*failure message, but found 3.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BePositive.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.BePositive.cs
@@ -77,7 +77,7 @@ public partial class NumericAssertionSpecs
             int value = -1;
 
             // Act
-            Action act = () => value.Should().BePositive("because we want to test the failure {0}", "message");
+            Action act = () => value.Should().BePositive("we want to test the {0} message", "failure");
 
             // Assert
             act

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.Match.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericAssertionSpecs.Match.cs
@@ -25,7 +25,7 @@ public partial class NumericAssertionSpecs
             int value = 1;
 
             // Act
-            Action act = () => value.Should().Match(o => o == 0, "because we want to test the failure {0}", "message");
+            Action act = () => value.Should().Match(o => o == 0, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Numeric/NumericDifferenceAssertionsSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Numeric/NumericDifferenceAssertionsSpecs.cs
@@ -15,7 +15,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -32,7 +32,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -48,7 +48,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -65,7 +65,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -82,7 +82,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(nullableValue, "because we want to test the failure {0}", "message");
+                value.Should().Be(nullableValue, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -100,7 +100,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -118,7 +118,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -134,7 +134,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -150,7 +150,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -166,7 +166,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -183,7 +183,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -199,7 +199,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -216,7 +216,7 @@ public class NumericDifferenceAssertionsSpecs
         {
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -234,7 +234,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -251,7 +251,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -269,7 +269,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -286,7 +286,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -304,7 +304,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -321,7 +321,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -339,7 +339,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -357,7 +357,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -375,7 +375,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -393,7 +393,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -411,7 +411,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -429,7 +429,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -447,7 +447,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -465,7 +465,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -483,7 +483,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().Be(expected, "because we want to test the failure {0}", "message");
+                value.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -504,7 +504,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeLessThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeLessThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -521,7 +521,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeLessThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeLessThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -538,7 +538,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeLessThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeLessThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -559,7 +559,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeLessThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeLessThanOrEqualTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -577,7 +577,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeLessThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeLessThanOrEqualTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -598,7 +598,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -615,7 +615,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -632,7 +632,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -650,7 +650,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -667,7 +667,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -684,7 +684,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -702,7 +702,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -720,7 +720,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -737,7 +737,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -758,7 +758,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThanOrEqualTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -776,7 +776,7 @@ public class NumericDifferenceAssertionsSpecs
 
             // Act
             Action act = () =>
-                value.Should().BeGreaterThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
+                value.Should().BeGreaterThanOrEqualTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act

--- a/Tests/AwesomeAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -37,7 +37,7 @@ public class BooleanAssertionSpecs
         {
             // Act
             Action action = () =>
-                false.Should().BeTrue("because we want to test the failure {0}", "message");
+                false.Should().BeTrue("we want to test the {0} message", "failure");
 
             // Assert
             action
@@ -71,7 +71,7 @@ public class BooleanAssertionSpecs
         {
             // Act
             Action action = () =>
-                true.Should().BeFalse("we want to test the failure {0}", "message");
+                true.Should().BeFalse("we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -104,7 +104,7 @@ public class BooleanAssertionSpecs
         {
             // Act
             Action action = () =>
-                false.Should().Be(true, "because we want to test the failure {0}", "message");
+                false.Should().Be(true, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -137,7 +137,7 @@ public class BooleanAssertionSpecs
         {
             // Act
             Action action = () =>
-                true.Should().NotBe(true, "because we want to test the failure {0}", "message");
+                true.Should().NotBe(true, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -175,11 +175,11 @@ public class BooleanAssertionSpecs
         public void Antecedent_does_not_imply_consequent(bool? antecedent, bool consequent)
         {
             // Act
-            Action act = () => antecedent.Should().Imply(consequent, "because we want to test the {0}", "failure");
+            Action act = () => antecedent.Should().Imply(consequent, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected antecedent*to imply consequent*test the failure*but*");
+                .WithMessage("Expected antecedent*to imply consequent*because*failure message*but*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateOnlyAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateOnlyAssertionSpecs.Be.cs
@@ -61,7 +61,7 @@ public partial class DateOnlyAssertionSpecs
             var otherDateOnly = new DateOnly(2012, 03, 11);
 
             // Act
-            Action act = () => dateOnly.Should().Be(otherDateOnly, "because we want to test the failure {0}", "message");
+            Action act = () => dateOnly.Should().Be(otherDateOnly, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -113,8 +113,7 @@ public partial class DateOnlyAssertionSpecs
 
             // Act
             Action action = () =>
-                nullableDateOnly.Should().Be(new DateOnly(2016, 06, 04), "because we want to test the failure {0}",
-                    "message");
+                nullableDateOnly.Should().Be(new DateOnly(2016, 06, 04), "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -167,7 +166,7 @@ public partial class DateOnlyAssertionSpecs
 
             // Act
             Action act =
-                () => date.Should().NotBe(sameDate, "because we want to test the failure {0}", "message");
+                () => date.Should().NotBe(sameDate, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -184,7 +183,7 @@ public partial class DateOnlyAssertionSpecs
 
             // Act
             Action act =
-                () => date.Should().NotBe(sameDate, "because we want to test the failure {0}", "message");
+                () => date.Should().NotBe(sameDate, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateOnlyAssertionSpecs.BeOneOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateOnlyAssertionSpecs.BeOneOf.cs
@@ -31,12 +31,12 @@ public partial class DateOnlyAssertionSpecs
 
             // Act
             Action action = () =>
-                value.Should().BeOneOf(new[] { value.AddDays(1), value.AddDays(2) }, "because it's true");
+                value.Should().BeOneOf(new[] { value.AddDays(1), value.AddDays(2) }, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to be one of {<2016-12-21>, <2016-12-22>} because it's true, but found <2016-12-20>.");
+                    "Expected value to be one of {<2016-12-21>, <2016-12-22>} because*failure message, but found <2016-12-20>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.Be.cs
@@ -61,7 +61,7 @@ public partial class DateTimeAssertionSpecs
             var otherDateTime = new DateTime(2012, 03, 11);
 
             // Act
-            Action act = () => dateTime.Should().Be(otherDateTime, "because we want to test the failure {0}", "message");
+            Action act = () => dateTime.Should().Be(otherDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -76,7 +76,7 @@ public partial class DateTimeAssertionSpecs
             DateTime? otherDateTime = 11.March(2012);
 
             // Act
-            Action act = () => dateTime.Should().Be(otherDateTime, "because we want to test the failure {0}", "message");
+            Action act = () => dateTime.Should().Be(otherDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -150,7 +150,7 @@ public partial class DateTimeAssertionSpecs
 
             // Act
             Action action = () =>
-                nullableDateTime.Should().Be(new DateTime(2016, 06, 04), "because we want to test the failure {0}", "message");
+                nullableDateTime.Should().Be(new DateTime(2016, 06, 04), "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -192,7 +192,7 @@ public partial class DateTimeAssertionSpecs
 
             // Act
             Action act =
-                () => dateTime.Should().NotBe(sameDateTime, "because we want to test the failure {0}", "message");
+                () => dateTime.Should().NotBe(sameDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -209,7 +209,7 @@ public partial class DateTimeAssertionSpecs
 
             // Act
             Action act =
-                () => dateTime.Should().NotBe(sameDateTime, "because we want to test the failure {0}", "message");
+                () => dateTime.Should().NotBe(sameDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeAtLeast.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeAtLeast.cs
@@ -17,11 +17,11 @@ public partial class DateTimeAssertionSpecs
             DateTime subject = target - 23.Hours();
 
             // Act
-            Action act = () => subject.Should().BeAtLeast(TimeSpan.FromDays(1)).Before(target, "we like {0}", "that");
+            Action act = () => subject.Should().BeAtLeast(TimeSpan.FromDays(1)).Before(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <2009-10-01 01:00:00> to be at least 1d before <2009-10-02> because we like that, but it is behind by 23h.");
+                "Expected subject <2009-10-01 01:00:00> to be at least 1d before <2009-10-02> because*failure message, but it is behind by 23h.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeExactly.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeExactly.cs
@@ -18,11 +18,11 @@ public partial class DateTimeAssertionSpecs
 
             // Act
             Action act =
-                () => subject.Should().BeExactly(TimeSpan.FromMinutes(20)).Before(target, "{0} minutes is enough", 20);
+                () => subject.Should().BeExactly(TimeSpan.FromMinutes(20)).Before(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <12:36:00> to be exactly 20m before <12:55:00> because 20 minutes is enough, but it is behind by 19m.");
+                "Expected subject <12:36:00> to be exactly 20m before <12:55:00> because*failure message, but it is behind by 19m.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeLessThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeLessThan.cs
@@ -18,11 +18,11 @@ public partial class DateTimeAssertionSpecs
 
             // Act
             Action act =
-                () => subject.Should().BeLessThan(TimeSpan.FromSeconds(30)).After(target, "{0}s is the max", 30);
+                () => subject.Should().BeLessThan(TimeSpan.FromSeconds(30)).After(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <12:01:00> to be less than 30s after <12:00:30> because 30s is the max, but it is ahead by 30s.");
+                "Expected subject <12:01:00> to be less than 30s after <12:00:30> because*failure message, but it is ahead by 30s.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeMoreThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeMoreThan.cs
@@ -17,11 +17,11 @@ public partial class DateTimeAssertionSpecs
             DateTime subject = target - 1.Days();
 
             // Act
-            Action act = () => subject.Should().BeMoreThan(TimeSpan.FromDays(1)).Before(target, "we like {0}", "that");
+            Action act = () => subject.Should().BeMoreThan(TimeSpan.FromDays(1)).Before(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <2009-10-01> to be more than 1d before <2009-10-02> because we like that, but it is behind by 1d.");
+                "Expected subject <2009-10-01> to be more than 1d before <2009-10-02> because*failure message, but it is behind by 1d.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeOneOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeOneOf.cs
@@ -32,12 +32,12 @@ public partial class DateTimeAssertionSpecs
 
             // Act
             Action action = () =>
-                value.Should().BeOneOf(new[] { value + 1.Days(), value + 1.Milliseconds() }, "because it's true");
+                value.Should().BeOneOf(new[] { value + 1.Days(), value + 1.Milliseconds() }, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>} because it's true, but found <2016-12-30 23:58:57>.");
+                    "Expected value to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>} because*failure message, but found <2016-12-30 23:58:57>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeWithin.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeAssertionSpecs.BeWithin.cs
@@ -18,11 +18,11 @@ public partial class DateTimeAssertionSpecs
 
             // Act
             Action act =
-                () => subject.Should().BeWithin(TimeSpan.FromHours(50)).Before(target, "{0} hours is enough", 50);
+                () => subject.Should().BeWithin(TimeSpan.FromHours(50)).Before(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <2010-04-08 09:59:59> to be within 2d and 2h before <2010-04-10 12:00:00> because 50 hours is enough, but it is behind by 2d, 2h and 1s.");
+                "Expected subject <2010-04-08 09:59:59> to be within 2d and 2h before <2010-04-10 12:00:00> because*failure message, but it is behind by 2d, 2h and 1s.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.Be.cs
@@ -62,7 +62,7 @@ public partial class DateTimeOffsetAssertionSpecs
             var otherDateTime = 11.March(2012).WithOffset(1.Hours());
 
             // Act
-            Action act = () => dateTime.Should().Be(otherDateTime, "because we want to test the failure {0}", "message");
+            Action act = () => dateTime.Should().Be(otherDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -77,7 +77,7 @@ public partial class DateTimeOffsetAssertionSpecs
             DateTimeOffset? otherDateTime = 11.March(2012).WithOffset(1.Hours());
 
             // Act
-            Action act = () => dateTime.Should().Be(otherDateTime, "because we want to test the failure {0}", "message");
+            Action act = () => dateTime.Should().Be(otherDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -130,7 +130,7 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action action = () =>
-                nullableDateTime.Should().Be(expectation, "because we want to test the failure {0}", "message");
+                nullableDateTime.Should().Be(expectation, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -147,7 +147,7 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action action = () =>
-                nullableDateTime.Should().Be(expectation, "because we want to test the failure {0}", "message");
+                nullableDateTime.Should().Be(expectation, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -204,7 +204,7 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action act =
-                () => dateTime.Should().NotBe(sameDateTime, "because we want to test the failure {0}", "message");
+                () => dateTime.Should().NotBe(sameDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -220,7 +220,7 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action act =
-                () => dateTime.Should().NotBe(sameDateTime, "because we want to test the failure {0}", "message");
+                () => dateTime.Should().NotBe(sameDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeAtLeast.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeAtLeast.cs
@@ -17,11 +17,11 @@ public partial class DateTimeOffsetAssertionSpecs
             DateTimeOffset subject = target - 23.Hours();
 
             // Act
-            Action act = () => subject.Should().BeAtLeast(TimeSpan.FromDays(1)).Before(target, "we like {0}", "that");
+            Action act = () => subject.Should().BeAtLeast(TimeSpan.FromDays(1)).Before(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <2009-10-01 01:00:00 +0h> to be at least 1d before <2009-10-02 +0h> because we like that, but it is behind by 23h.");
+                "Expected subject <2009-10-01 01:00:00 +0h> to be at least 1d before <2009-10-02 +0h> because*failure message, but it is behind by 23h.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeExactly.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeExactly.cs
@@ -40,7 +40,7 @@ public partial class DateTimeOffsetAssertionSpecs
             var otherDateTime = dateTime.ToUniversalTime();
 
             // Act
-            Action act = () => dateTime.Should().BeExactly(otherDateTime, "because we want to test the failure {0}", "message");
+            Action act = () => dateTime.Should().BeExactly(otherDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -55,7 +55,7 @@ public partial class DateTimeOffsetAssertionSpecs
             DateTimeOffset? otherDateTime = dateTime.ToUniversalTime();
 
             // Act
-            Action act = () => dateTime.Should().BeExactly(otherDateTime, "because we want to test the failure {0}", "message");
+            Action act = () => dateTime.Should().BeExactly(otherDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -108,7 +108,7 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action action = () =>
-                nullableDateTime.Should().BeExactly(expectation, "because we want to test the failure {0}", "message");
+                nullableDateTime.Should().BeExactly(expectation, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -150,7 +150,7 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action act =
-                () => dateTime.Should().NotBeExactly(sameDateTime, "because we want to test the failure {0}", "message");
+                () => dateTime.Should().NotBeExactly(sameDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -166,7 +166,7 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action act =
-                () => dateTime.Should().NotBeExactly(sameDateTime, "because we want to test the failure {0}", "message");
+                () => dateTime.Should().NotBeExactly(sameDateTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -182,11 +182,11 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action act =
-                () => subject.Should().BeExactly(TimeSpan.FromMinutes(20)).Before(target, "{0} minutes is enough", 20);
+                () => subject.Should().BeExactly(TimeSpan.FromMinutes(20)).Before(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <12:36:00 +0h> to be exactly 20m before <12:55:00 +0h> because 20 minutes is enough, but it is behind by 19m.");
+                "Expected subject <12:36:00 +0h> to be exactly 20m before <12:55:00 +0h> because*failure message, but it is behind by 19m.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeLessThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeLessThan.cs
@@ -18,11 +18,11 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action act =
-                () => subject.Should().BeLessThan(TimeSpan.FromSeconds(30)).After(target, "{0}s is the max", 30);
+                () => subject.Should().BeLessThan(TimeSpan.FromSeconds(30)).After(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <12:01:00 +1h> to be less than 30s after <12:00:30 +1h> because 30s is the max, but it is ahead by 30s.");
+                "Expected subject <12:01:00 +1h> to be less than 30s after <12:00:30 +1h> because*failure message, but it is ahead by 30s.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeMoreThan.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeMoreThan.cs
@@ -17,11 +17,11 @@ public partial class DateTimeOffsetAssertionSpecs
             DateTimeOffset subject = target - 1.Days();
 
             // Act
-            Action act = () => subject.Should().BeMoreThan(TimeSpan.FromDays(1)).Before(target, "we like {0}", "that");
+            Action act = () => subject.Should().BeMoreThan(TimeSpan.FromDays(1)).Before(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <2009-10-01 +0h> to be more than 1d before <2009-10-02 +0h> because we like that, but it is behind by 1d.");
+                "Expected subject <2009-10-01 +0h> to be more than 1d before <2009-10-02 +0h> because*failure message, but it is behind by 1d.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeOneOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeOneOf.cs
@@ -77,11 +77,11 @@ public partial class DateTimeOffsetAssertionSpecs
             DateTimeOffset value = 31.December(2016).WithOffset(1.Hours());
 
             // Act
-            Action action = () => value.Should().BeOneOf(new[] { value + 1.Days(), value + 2.Days() }, "because it's true");
+            Action action = () => value.Should().BeOneOf(new[] { value + 1.Days(), value + 2.Days() }, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
-                "Expected value to be one of {<2017-01-01 +1h>, <2017-01-02 +1h>} because it's true, but it was <2016-12-31 +1h>.");
+                "Expected value to be one of {<2017-01-01 +1h>, <2017-01-02 +1h>} because*failure message, but it was <2016-12-31 +1h>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeWithin.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.BeWithin.cs
@@ -18,11 +18,11 @@ public partial class DateTimeOffsetAssertionSpecs
 
             // Act
             Action act =
-                () => subject.Should().BeWithin(TimeSpan.FromHours(50)).Before(target, "{0} hours is enough", 50);
+                () => subject.Should().BeWithin(TimeSpan.FromHours(50)).Before(target, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <2010-04-08 09:59:59 +0h> to be within 2d and 2h before <2010-04-10 12:00:00 +0h> because 50 hours is enough, but it is behind by 2d, 2h and 1s.");
+                "Expected subject <2010-04-08 09:59:59 +0h> to be within 2d and 2h before <2010-04-10 12:00:00 +0h> because*failure message, but it is behind by 2d, 2h and 1s.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/EnumAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/EnumAssertionSpecs.cs
@@ -53,7 +53,7 @@ public class EnumAssertionSpecs
             TestEnum someObject = TestEnum.One | TestEnum.Two;
 
             // Act
-            Action act = () => someObject.Should().HaveFlag(TestEnum.Three, "we want to test the failure {0}", "message");
+            Action act = () => someObject.Should().HaveFlag(TestEnum.Three, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -81,7 +81,7 @@ public class EnumAssertionSpecs
             TestEnum someObject = TestEnum.One | TestEnum.Two;
 
             // Act
-            Action act = () => someObject.Should().NotHaveFlag(TestEnum.Two, "we want to test the failure {0}", "message");
+            Action act = () => someObject.Should().NotHaveFlag(TestEnum.Two, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -161,7 +161,7 @@ public class EnumAssertionSpecs
             MyEnum expected = MyEnum.Two;
 
             // Act
-            Action act = () => subject.Should().Be(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -175,7 +175,7 @@ public class EnumAssertionSpecs
         public void When_nullable_enums_are_equal_it_should_throw(MyEnum? subject, MyEnum? expected)
         {
             // Act
-            Action act = () => subject.Should().Be(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -225,7 +225,7 @@ public class EnumAssertionSpecs
             MyEnum expected = MyEnum.One;
 
             // Act
-            Action act = () => subject.Should().NotBe(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().NotBe(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -238,7 +238,7 @@ public class EnumAssertionSpecs
         public void When_nullable_enums_are_unequal_it_should_throw(MyEnum? subject, MyEnum? expected)
         {
             // Act
-            Action act = () => subject.Should().NotBe(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().NotBe(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -284,7 +284,7 @@ public class EnumAssertionSpecs
             TestEnum someObject = TestEnum.One;
 
             // Act
-            Action act = () => someObject.Should().HaveValue(3, "we want to test the failure {0}", "message");
+            Action act = () => someObject.Should().HaveValue(3, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -309,7 +309,7 @@ public class EnumAssertionSpecs
             MyEnum? subject = null;
 
             // Act
-            Action act = () => subject.Should().HaveValue("we want to test the failure {0}", "message");
+            Action act = () => subject.Should().HaveValue("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -336,7 +336,7 @@ public class EnumAssertionSpecs
             TestEnum someObject = TestEnum.One;
 
             // Act
-            Action act = () => someObject.Should().NotHaveValue(1, "we want to test the failure {0}", "message");
+            Action act = () => someObject.Should().NotHaveValue(1, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -370,7 +370,7 @@ public class EnumAssertionSpecs
             MyEnum? subject = MyEnum.One;
 
             // Act
-            Action act = () => subject.Should().NotHaveValue("we want to test the failure {0}", "message");
+            Action act = () => subject.Should().NotHaveValue("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -410,7 +410,7 @@ public class EnumAssertionSpecs
             MyEnumOtherName expected = MyEnumOtherName.OtherTwo;
 
             // Act
-            Action act = () => subject.Should().HaveSameValueAs(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().HaveSameValueAs(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -423,7 +423,7 @@ public class EnumAssertionSpecs
         public void When_nullable_enums_have_equal_values_it_should_throw(MyEnum? subject, MyEnumOtherName expected)
         {
             // Act
-            Action act = () => subject.Should().HaveSameValueAs(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().HaveSameValueAs(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -461,7 +461,7 @@ public class EnumAssertionSpecs
             MyEnumOtherName expected = MyEnumOtherName.OtherOne;
 
             // Act
-            Action act = () => subject.Should().NotHaveSameValueAs(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().NotHaveSameValueAs(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -476,7 +476,7 @@ public class EnumAssertionSpecs
             MyEnumOtherName expected = MyEnumOtherName.OtherOne;
 
             // Act
-            Action act = () => subject.Should().NotHaveSameValueAs(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().NotHaveSameValueAs(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -522,7 +522,7 @@ public class EnumAssertionSpecs
             MyEnumOtherValue expected = MyEnumOtherValue.Two;
 
             // Act
-            Action act = () => subject.Should().HaveSameNameAs(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().HaveSameNameAs(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -535,7 +535,7 @@ public class EnumAssertionSpecs
         public void When_nullable_enums_have_equal_names_it_should_throw(MyEnum? subject, MyEnumOtherValue expected)
         {
             // Act
-            Action act = () => subject.Should().HaveSameNameAs(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().HaveSameNameAs(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -573,7 +573,7 @@ public class EnumAssertionSpecs
             MyEnumOtherValue expected = MyEnumOtherValue.One;
 
             // Act
-            Action act = () => subject.Should().NotHaveSameNameAs(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().NotHaveSameNameAs(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -588,7 +588,7 @@ public class EnumAssertionSpecs
             MyEnumOtherValue expected = MyEnumOtherValue.One;
 
             // Act
-            Action act = () => subject.Should().NotHaveSameNameAs(expected, "we want to test the failure {0}", "message");
+            Action act = () => subject.Should().NotHaveSameNameAs(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -621,7 +621,7 @@ public class EnumAssertionSpecs
             MyEnum? subject = MyEnum.One;
 
             // Act
-            Action act = () => subject.Should().BeNull("we want to test the failure {0}", "message");
+            Action act = () => subject.Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -649,7 +649,7 @@ public class EnumAssertionSpecs
             MyEnum? subject = null;
 
             // Act
-            Action act = () => subject.Should().NotBeNull("we want to test the failure {0}", "message");
+            Action act = () => subject.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -676,10 +676,10 @@ public class EnumAssertionSpecs
             BindingFlags flags = BindingFlags.Public;
 
             // Act
-            Action act = () => flags.Should().Match(x => x == BindingFlags.Static, "that's what we need");
+            Action act = () => flags.Should().Match(x => x == BindingFlags.Static, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*Static*because that's what we need*found*Public*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*Static*because*failure message*found*Public*");
         }
 
         [Fact]
@@ -713,11 +713,11 @@ public class EnumAssertionSpecs
 
             // Act / Assert
             Action act = () =>
-                flags.Should().BeOneOf([BindingFlags.Public, BindingFlags.ExactBinding], "that's what we need");
+                flags.Should().BeOneOf([BindingFlags.Public, BindingFlags.ExactBinding], "we want to test the {0} message", "failure");
 
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected*Public*ExactBinding*because that's what we need*found*DeclaredOnly*");
+                .WithMessage("Expected*Public*ExactBinding*because*failure message*found*DeclaredOnly*");
         }
 
         [Fact]
@@ -728,11 +728,11 @@ public class EnumAssertionSpecs
 
             // Act / Assert
             Action act = () =>
-                flags.Should().BeOneOf([BindingFlags.Public, BindingFlags.ExactBinding], "failure {0}", "message");
+                flags.Should().BeOneOf([BindingFlags.Public, BindingFlags.ExactBinding], "we want to test the {0} message", "failure");
 
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected*Public*ExactBinding*because failure message*found*<null>*");
+                .WithMessage("Expected*Public*ExactBinding*because*failure message*found*<null>*");
         }
 
         [Fact]
@@ -745,12 +745,12 @@ public class EnumAssertionSpecs
             Action act = () =>
             {
                 using AssertionScope _ = new();
-                flags.Should().BeOneOf([BindingFlags.Public, BindingFlags.ExactBinding], "failure {0}", "message");
+                flags.Should().BeOneOf([BindingFlags.Public, BindingFlags.ExactBinding], "we want to test the {0} message", "failure");
             };
 
             act.Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected*Public*ExactBinding*because failure message*found*<null>*");
+                .WithMessage("Expected*Public*ExactBinding*because*failure message*found*<null>*");
         }
 
         [Fact]
@@ -801,7 +801,7 @@ public class EnumAssertionSpecs
             var dayOfWeek = (DayOfWeek)999;
 
             // Act
-            Action act = () => dayOfWeek.Should().BeDefined("we want to test the failure {0}", "message");
+            Action act = () => dayOfWeek.Should().BeDefined("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Primitives/GuidAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/GuidAssertionSpecs.cs
@@ -25,7 +25,7 @@ public class GuidAssertionSpecs
             var guid = new Guid("12345678-1234-1234-1234-123456789012");
 
             // Act
-            Action act = () => guid.Should().BeEmpty("because we want to test the failure {0}", "message");
+            Action act = () => guid.Should().BeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -49,7 +49,7 @@ public class GuidAssertionSpecs
         public void Should_fail_when_asserting_empty_guid_is_not_empty()
         {
             // Act
-            Action act = () => Guid.Empty.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+            Action act = () => Guid.Empty.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -88,7 +88,7 @@ public class GuidAssertionSpecs
             var differentGuid = new Guid("55555555-ffff-eeee-dddd-444444444444");
 
             // Act
-            Action act = () => guid.Should().Be(differentGuid, "because we want to test the failure {0}", "message");
+            Action act = () => guid.Should().Be(differentGuid, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -102,7 +102,7 @@ public class GuidAssertionSpecs
             var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
 
             // Act
-            Action act = () => guid.Should().Be(string.Empty, "we want to test the failure {0}", "message");
+            Action act = () => guid.Should().Be(string.Empty, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<ArgumentException>()
@@ -131,7 +131,7 @@ public class GuidAssertionSpecs
             var sameGuid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
 
             // Act
-            Action act = () => guid.Should().NotBe(sameGuid, "because we want to test the failure {0}", "message");
+            Action act = () => guid.Should().NotBe(sameGuid, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -145,7 +145,7 @@ public class GuidAssertionSpecs
             var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
 
             // Act
-            Action act = () => guid.Should().NotBe(string.Empty, "we want to test the failure {0}", "message");
+            Action act = () => guid.Should().NotBe(string.Empty, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<ArgumentException>()
@@ -170,7 +170,7 @@ public class GuidAssertionSpecs
 
             // Act
             Action act = () =>
-                guid.Should().NotBe("11111111-aaaa-bbbb-cccc-999999999999", "we want to test the failure {0}", "message");
+                guid.Should().NotBe("11111111-aaaa-bbbb-cccc-999999999999", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
@@ -60,7 +60,7 @@ public class NullableBooleanAssertionSpecs
         bool? nullableBoolean = null;
 
         // Act
-        Action act = () => nullableBoolean.Should().HaveValue("because we want to test the failure {0}", "message");
+        Action act = () => nullableBoolean.Should().HaveValue("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -74,7 +74,7 @@ public class NullableBooleanAssertionSpecs
         bool? nullableBoolean = null;
 
         // Act
-        Action act = () => nullableBoolean.Should().NotBeNull("because we want to test the failure {0}", "message");
+        Action act = () => nullableBoolean.Should().NotBeNull("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -135,7 +135,7 @@ public class NullableBooleanAssertionSpecs
         bool? nullableBoolean = true;
 
         // Act
-        Action act = () => nullableBoolean.Should().NotHaveValue("because we want to test the failure {0}", "message");
+        Action act = () => nullableBoolean.Should().NotHaveValue("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -149,7 +149,7 @@ public class NullableBooleanAssertionSpecs
         bool? nullableBoolean = true;
 
         // Act
-        Action act = () => nullableBoolean.Should().BeNull("because we want to test the failure {0}", "message");
+        Action act = () => nullableBoolean.Should().BeNull("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -164,7 +164,7 @@ public class NullableBooleanAssertionSpecs
 
         // Act
         Action action = () =>
-            nullableBoolean.Should().BeFalse("we want to test the failure {0}", "message");
+            nullableBoolean.Should().BeFalse("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
@@ -179,7 +179,7 @@ public class NullableBooleanAssertionSpecs
 
         // Act
         Action action = () =>
-            nullableBoolean.Should().BeTrue("we want to test the failure {0}", "message");
+            nullableBoolean.Should().BeTrue("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
@@ -195,7 +195,7 @@ public class NullableBooleanAssertionSpecs
 
         // Act
         Action action = () =>
-            nullableBoolean.Should().Be(differentNullableBoolean, "we want to test the failure {0}", "message");
+            nullableBoolean.Should().Be(differentNullableBoolean, "we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
@@ -211,7 +211,7 @@ public class NullableBooleanAssertionSpecs
 
         // Act
         Action action = () =>
-            nullableBoolean.Should().NotBe(differentNullableBoolean, "we want to test the failure {0}", "message");
+            nullableBoolean.Should().NotBe(differentNullableBoolean, "we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
@@ -269,7 +269,7 @@ public class NullableBooleanAssertionSpecs
 
         // Act
         Action action = () =>
-            falseBoolean.Should().NotBeFalse("we want to test the failure message");
+            falseBoolean.Should().NotBeFalse("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()
@@ -304,7 +304,7 @@ public class NullableBooleanAssertionSpecs
 
         // Act
         Action action = () =>
-            falseBoolean.Should().NotBeTrue("we want to test the failure message");
+            falseBoolean.Should().NotBeTrue("we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Primitives/NullableGuidAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/NullableGuidAssertionSpecs.cs
@@ -59,7 +59,7 @@ public class NullableGuidAssertionSpecs
         Guid? nullableGuid = null;
 
         // Act
-        Action act = () => nullableGuid.Should().HaveValue("because we want to test the failure {0}", "message");
+        Action act = () => nullableGuid.Should().HaveValue("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -73,7 +73,7 @@ public class NullableGuidAssertionSpecs
         Guid? nullableGuid = null;
 
         // Act
-        Action act = () => nullableGuid.Should().NotBeNull("because we want to test the failure {0}", "message");
+        Action act = () => nullableGuid.Should().NotBeNull("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -135,7 +135,7 @@ public class NullableGuidAssertionSpecs
 
         // Act
         Action act = () =>
-            guid.Should().Be(someGuid, "because we want to test the failure {0}", "message");
+            guid.Should().Be(someGuid, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -160,7 +160,7 @@ public class NullableGuidAssertionSpecs
         Guid? nullableGuid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
 
         // Act
-        Action act = () => nullableGuid.Should().NotHaveValue("because we want to test the failure {0}", "message");
+        Action act = () => nullableGuid.Should().NotHaveValue("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -175,7 +175,7 @@ public class NullableGuidAssertionSpecs
         Guid? nullableGuid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
 
         // Act
-        Action act = () => nullableGuid.Should().BeNull("because we want to test the failure {0}", "message");
+        Action act = () => nullableGuid.Should().BeNull("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -192,7 +192,7 @@ public class NullableGuidAssertionSpecs
 
         // Act
         Action act = () =>
-            nullableGuid.Should().Be(someGuid, "because we want to test the failure {0}", "message");
+            nullableGuid.Should().Be(someGuid, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/AwesomeAssertions.Specs/Primitives/NullableSimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/NullableSimpleTimeSpanAssertionSpecs.cs
@@ -47,7 +47,7 @@ public class NullableSimpleTimeSpanAssertionSpecs
         TimeSpan? nullableTimeSpan = null;
 
         // Act
-        Action act = () => nullableTimeSpan.Should().HaveValue("because we want to test the failure {0}", "message");
+        Action act = () => nullableTimeSpan.Should().HaveValue("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -61,7 +61,7 @@ public class NullableSimpleTimeSpanAssertionSpecs
         TimeSpan? nullableTimeSpan = null;
 
         // Act
-        Action act = () => nullableTimeSpan.Should().NotBeNull("because we want to test the failure {0}", "message");
+        Action act = () => nullableTimeSpan.Should().NotBeNull("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -121,7 +121,7 @@ public class NullableSimpleTimeSpanAssertionSpecs
         TimeSpan? nullableTimeSpan = 1.Seconds();
 
         // Act
-        Action act = () => nullableTimeSpan.Should().NotHaveValue("because we want to test the failure {0}", "message");
+        Action act = () => nullableTimeSpan.Should().NotHaveValue("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -135,7 +135,7 @@ public class NullableSimpleTimeSpanAssertionSpecs
         TimeSpan? nullableTimeSpan = 1.Seconds();
 
         // Act
-        Action act = () => nullableTimeSpan.Should().BeNull("because we want to test the failure {0}", "message");
+        Action act = () => nullableTimeSpan.Should().BeNull("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -169,7 +169,7 @@ public class NullableSimpleTimeSpanAssertionSpecs
         Action action =
             () =>
                 nullableTimeSpanA.Should()
-                    .Be(nullableTimeSpanB, "because we want to test the failure {0}", "message");
+                    .Be(nullableTimeSpanB, "we want to test the {0} message", "failure");
 
         // Assert
         action.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.Be.cs
@@ -68,12 +68,12 @@ public partial class ObjectAssertionSpecs
             var nonEqualObject = new ClassWithCustomEqualMethod(2);
 
             // Act
-            Action act = () => someObject.Should().Be(nonEqualObject, "because it should use the {0}", "reason");
+            Action act = () => someObject.Should().Be(nonEqualObject, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected someObject to be ClassWithCustomEqualMethod(2) because it should use the reason, but found ClassWithCustomEqualMethod(1).");
+                    "Expected someObject to be ClassWithCustomEqualMethod(2) because*failure message, but found ClassWithCustomEqualMethod(1).");
         }
 
         [Fact]
@@ -117,10 +117,10 @@ public partial class ObjectAssertionSpecs
             object value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().Be(new SomeClass(4), new SomeClassEqualityComparer(), "I said so");
+            Action act = () => value.Should().Be(new SomeClass(4), new SomeClassEqualityComparer(), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected value to be SomeClass(4)*I said so*found SomeClass(3).");
+            act.Should().Throw<XunitException>().WithMessage("Expected value to be SomeClass(4)*because*failure message*found SomeClass(3).");
         }
 
         [Fact]
@@ -130,10 +130,10 @@ public partial class ObjectAssertionSpecs
             var value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().Be(new SomeClass(4), new SomeClassEqualityComparer(), "I said so");
+            Action act = () => value.Should().Be(new SomeClass(4), new SomeClassEqualityComparer(), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected value to be SomeClass(4)*I said so*found SomeClass(3).");
+            act.Should().Throw<XunitException>().WithMessage("Expected value to be SomeClass(4)*because*failure message*found SomeClass(3).");
         }
 
         [Fact]
@@ -143,11 +143,11 @@ public partial class ObjectAssertionSpecs
             var value = new ClassWithCustomEqualMethod(3);
 
             // Act
-            Action act = () => value.Should().Be(new SomeClass(3), new SomeClassEqualityComparer(), "I said so");
+            Action act = () => value.Should().Be(new SomeClass(3), new SomeClassEqualityComparer(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be SomeClass(3)*I said so*found ClassWithCustomEqualMethod(3).");
+                .WithMessage("Expected value to be SomeClass(3)*because*failure message*found ClassWithCustomEqualMethod(3).");
         }
 
         [Fact]
@@ -235,7 +235,7 @@ public partial class ObjectAssertionSpecs
 
             // Act
             Action act = () =>
-                someObject.Should().NotBe(equalObject, "because we want to test the failure {0}", "message");
+                someObject.Should().NotBe(equalObject, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -270,10 +270,10 @@ public partial class ObjectAssertionSpecs
             object value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().NotBe(new SomeClass(3), new SomeClassEqualityComparer(), "I said so");
+            Action act = () => value.Should().NotBe(new SomeClass(3), new SomeClassEqualityComparer(), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Did not expect value to be equal to SomeClass(3)*I said so*");
+            act.Should().Throw<XunitException>().WithMessage("Did not expect value to be equal to SomeClass(3)*because*failure message*");
         }
 
         [Fact]
@@ -283,10 +283,10 @@ public partial class ObjectAssertionSpecs
             var value = new SomeClass(3);
 
             // Act
-            Action act = () => value.Should().NotBe(new SomeClass(3), new SomeClassEqualityComparer(), "I said so");
+            Action act = () => value.Should().NotBe(new SomeClass(3), new SomeClassEqualityComparer(), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Did not expect value to be equal to SomeClass(3)*I said so*");
+            act.Should().Throw<XunitException>().WithMessage("Did not expect value to be equal to SomeClass(3)*because*failure message*");
         }
 
         [Fact]
@@ -296,7 +296,7 @@ public partial class ObjectAssertionSpecs
             var value = new ClassWithCustomEqualMethod(3);
 
             // Act / Assert
-            value.Should().NotBe(new SomeClass(3), new SomeClassEqualityComparer(), "I said so");
+            value.Should().NotBe(new SomeClass(3), new SomeClassEqualityComparer());
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeAssignableTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeAssignableTo.cs
@@ -59,7 +59,7 @@ public partial class ObjectAssertionSpecs
         {
             // Arrange
             var someObject = new DummyImplementingClass();
-            Action act = () => someObject.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
+            Action act = () => someObject.Should().BeAssignableTo<DateTime>("we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -89,7 +89,7 @@ public partial class ObjectAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                someObject.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
+                someObject.Should().BeAssignableTo<DateTime>("we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -147,7 +147,7 @@ public partial class ObjectAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+                someObject.Should().BeAssignableTo(typeof(DateTime), "we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -162,7 +162,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new DummyImplementingClass();
 
             Action act = () =>
-                someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+                someObject.Should().BeAssignableTo(typeof(DateTime), "we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -176,7 +176,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new DummyImplementingClass();
 
             Action act = () =>
-                someObject.Should().BeAssignableTo(typeof(IList<>), "because we want to test the failure {0}", "message");
+                someObject.Should().BeAssignableTo(typeof(IList<>), "we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -227,7 +227,7 @@ public partial class ObjectAssertionSpecs
 
             Action act = () =>
                 someObject.Should()
-                    .NotBeAssignableTo<DummyImplementingClass>("because we want to test the failure {0}", "message");
+                    .NotBeAssignableTo<DummyImplementingClass>("we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -242,7 +242,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new DummyImplementingClass();
 
             Action act = () =>
-                someObject.Should().NotBeAssignableTo<DummyBaseClass>("because we want to test the failure {0}", "message");
+                someObject.Should().NotBeAssignableTo<DummyBaseClass>("we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -257,7 +257,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new DummyImplementingClass();
 
             Action act = () =>
-                someObject.Should().NotBeAssignableTo<IDisposable>("because we want to test the failure {0}", "message");
+                someObject.Should().NotBeAssignableTo<IDisposable>("we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -297,8 +297,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new DummyImplementingClass();
 
             Action act = () =>
-                someObject.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "because we want to test the failure {0}",
-                    "message");
+                someObject.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -314,7 +313,7 @@ public partial class ObjectAssertionSpecs
 
             Action act = () =>
                 someObject.Should()
-                    .NotBeAssignableTo(typeof(DummyBaseClass), "because we want to test the failure {0}", "message");
+                    .NotBeAssignableTo(typeof(DummyBaseClass), "we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -330,7 +329,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new DummyImplementingClass();
 
             Action act = () =>
-                someObject.Should().NotBeAssignableTo(typeof(IDisposable), "because we want to test the failure {0}", "message");
+                someObject.Should().NotBeAssignableTo(typeof(IDisposable), "we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -345,7 +344,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new List<string>();
 
             Action act = () =>
-                someObject.Should().NotBeAssignableTo(typeof(IList<>), "because we want to test the failure {0}", "message");
+                someObject.Should().NotBeAssignableTo(typeof(IList<>), "we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -362,7 +361,7 @@ public partial class ObjectAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                someObject.Should().NotBeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+                someObject.Should().NotBeAssignableTo(typeof(DateTime), "we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -377,7 +376,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new DummyImplementingClass();
 
             // Act / Assert
-            someObject.Should().NotBeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+            someObject.Should().NotBeAssignableTo(typeof(DateTime), "we want to test the {0} message", "failure");
         }
 
         [Fact]
@@ -387,7 +386,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new DummyImplementingClass();
 
             // Act / Assert
-            someObject.Should().NotBeAssignableTo(typeof(IList<>), "because we want to test the failure {0}", "message");
+            someObject.Should().NotBeAssignableTo(typeof(IList<>), "we want to test the {0} message", "failure");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeDataContractSerializable.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeDataContractSerializable.cs
@@ -32,12 +32,12 @@ public partial class ObjectAssertionSpecs
             var subject = new NonDataContractSerializableClass();
 
             // Act
-            Action act = () => subject.Should().BeDataContractSerializable("we need to store it on {0}", "disk");
+            Action act = () => subject.Should().BeDataContractSerializable("we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("*we need to store it on disk*EnumMemberAttribute*");
+                .WithMessage("*we want to test the failure message*EnumMemberAttribute*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeNull.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeNull.cs
@@ -38,7 +38,7 @@ public partial class ObjectAssertionSpecs
             var someObject = new object();
 
             // Act
-            Action act = () => someObject.Should().BeNull("because we want to test the failure {0}", "message");
+            Action act = () => someObject.Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -81,7 +81,7 @@ public partial class ObjectAssertionSpecs
             object someObject = null;
 
             // Act
-            Action act = () => someObject.Should().NotBeNull("because we want to test the failure {0}", "message");
+            Action act = () => someObject.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOfType.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOfType.cs
@@ -67,7 +67,7 @@ public partial class ObjectAssertionSpecs
 
             // Act
             Action act = () =>
-                valueTypeObject.Should().BeOfType(typeof(int), "because we want to test the failure {0}", "message");
+                valueTypeObject.Should().BeOfType(typeof(int), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -109,11 +109,11 @@ public partial class ObjectAssertionSpecs
             var someObject = new object();
 
             // Act
-            Action act = () => someObject.Should().BeOfType<int>("because they are {0} {1}", "of different", "type");
+            Action act = () => someObject.Should().BeOfType<int>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be int because they are of different type, but found object.");
+                "Expected type to be int because we want to test the failure message, but found object.");
         }
 
         [Fact]
@@ -218,7 +218,7 @@ public partial class ObjectAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                valueTypeObject.Should().NotBeOfType(typeof(int), "because we want to test the failure {0}", "message");
+                valueTypeObject.Should().NotBeOfType(typeof(int), "we want to test the {0} message", "failure");
             };
 
             // Assert

--- a/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOneOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeOneOf.cs
@@ -80,11 +80,11 @@ public partial class ObjectAssertionSpecs
 
             // Act
             Action act = () => value.Should().BeOneOf([new SomeClass(4), new SomeClass(5)],
-                new SomeClassEqualityComparer(), "I said so");
+                new SomeClassEqualityComparer(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-               .WithMessage("Expected value to be one of {SomeClass(4), SomeClass(5)}*I said so*SomeClass(3).");
+               .WithMessage("Expected value to be one of {SomeClass(4), SomeClass(5)}*failure message*SomeClass(3).");
         }
 
         [Fact]
@@ -108,11 +108,11 @@ public partial class ObjectAssertionSpecs
 
             // Act
             Action act = () => value.Should().BeOneOf([new SomeClass(4), new SomeClass(5)],
-                new SomeClassEqualityComparer(), "I said so");
+                new SomeClassEqualityComparer(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-               .WithMessage("Expected value to be one of {SomeClass(4), SomeClass(5)}*I said so*SomeClass(3).");
+               .WithMessage("Expected value to be one of {SomeClass(4), SomeClass(5)}*failure message*SomeClass(3).");
         }
 
         [Fact]
@@ -136,11 +136,11 @@ public partial class ObjectAssertionSpecs
 
             // Act
             Action act = () => value.Should().BeOneOf([new SomeClass(4), new SomeClass(5)],
-                new SomeClassEqualityComparer(), "I said so");
+                new SomeClassEqualityComparer(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-               .WithMessage("Expected value to be one of {SomeClass(4), SomeClass(5)}*I said so*ClassWithCustomEqualMethod(3).");
+               .WithMessage("Expected value to be one of {SomeClass(4), SomeClass(5)}*failure message*ClassWithCustomEqualMethod(3).");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeXmlSerializable.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/ObjectAssertionSpecs.BeXmlSerializable.cs
@@ -38,12 +38,12 @@ public partial class ObjectAssertionSpecs
             };
 
             // Act
-            Action act = () => subject.Should().BeXmlSerializable("we need to store it on {0}", "disk");
+            Action act = () => subject.Should().BeXmlSerializable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "*to be serializable because we need to store it on disk, but serialization failed with:*NonPublicClass*");
+                    "*to be serializable because*failure message, but serialization failed with:*NonPublicClass*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.Satisfy.cs
@@ -27,13 +27,13 @@ public partial class ReferenceTypeAssertionsSpecs
             var someObject = new object();
 
             // Act
-            Action act = () => someObject.Should().Satisfy<object>(o => o.Should().BeNull("it is not initialized yet"));
+            Action act = () => someObject.Should().Satisfy<object>(o => o.Should().BeNull("we want to test the {0} message", "failure"));
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 $"""
                  Expected {nameof(someObject)} to match inspector, but the inspector was not satisfied:
-                 *Expected o to be <null> because it is not initialized yet, but found System.Object*
+                 *Expected o to be <null> because*failure message*, but found System.Object*
                  """);
         }
 

--- a/Tests/AwesomeAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -36,7 +36,7 @@ public partial class ReferenceTypeAssertionsSpecs
         };
 
         // Act
-        Action act = () => subject.Should().BeSameAs(otherObject, "they are {0} {1}", "the", "same");
+        Action act = () => subject.Should().BeSameAs(otherObject, "we want to test the {0} message", "failure");
 
         // Assert
         act
@@ -46,7 +46,7 @@ public partial class ReferenceTypeAssertionsSpecs
             Expected subject to refer to
             {
                 UserName = "JohnDoe"
-            } because they are the same, but found
+            } because*failure message, but found
             {
                 Name = "John Doe"
             }.
@@ -90,11 +90,11 @@ public partial class ReferenceTypeAssertionsSpecs
         ClassWithCustomEqualMethod sameObject = someObject;
 
         // Act
-        Action act = () => someObject.Should().NotBeSameAs(sameObject, "they are {0} {1}", "the", "same");
+        Action act = () => someObject.Should().NotBeSameAs(sameObject, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Did not expect someObject to refer to*ClassWithCustomEqualMethod(1) because they are the same.");
+            .WithMessage("Did not expect someObject to refer to*ClassWithCustomEqualMethod(1) because*failure message.");
     }
 
     [Fact]
@@ -314,11 +314,11 @@ public partial class ReferenceTypeAssertionsSpecs
         var someObject = new object();
 
         // Act
-        Action act = () => someObject.Should().Match(o => o == null, "it is not initialized yet");
+        Action act = () => someObject.Should().Match(o => o == null, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("Expected someObject to match (o == null) because it is not initialized yet*");
+            .WithMessage("Expected someObject to match (o == null) because*failure message*");
     }
 
     [Fact]
@@ -333,11 +333,11 @@ public partial class ReferenceTypeAssertionsSpecs
         };
 
         // Act
-        Action act = () => someObject.Should().Match((SomeDto d) => d.Name.Length == 0, "it is not initialized yet");
+        Action act = () => someObject.Should().Match((SomeDto d) => d.Name.Length == 0, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
-            "Expected someObject to match (d.Name.Length == 0) because it is not initialized yet*");
+            "Expected someObject to match (d.Name.Length == 0) because*failure message*");
     }
 
     [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
@@ -52,7 +52,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan? nullTimeSpan = null;
 
         // Act
-        Action act = () => nullTimeSpan.Should().BePositive("because we want to test the failure {0}", "message");
+        Action act = () => nullTimeSpan.Should().BePositive("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -66,7 +66,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan timeSpan = 1.Seconds().Negate();
 
         // Act
-        Action act = () => timeSpan.Should().BePositive("because we want to test the failure {0}", "message");
+        Action act = () => timeSpan.Should().BePositive("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -116,7 +116,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan? nullTimeSpan = null;
 
         // Act
-        Action act = () => nullTimeSpan.Should().BeNegative("because we want to test the failure {0}", "message");
+        Action act = () => nullTimeSpan.Should().BeNegative("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -130,7 +130,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan timeSpan = 1.Seconds();
 
         // Act
-        Action act = () => timeSpan.Should().BeNegative("because we want to test the failure {0}", "message");
+        Action act = () => timeSpan.Should().BeNegative("we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -184,7 +184,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan expected = 1.Seconds();
 
         // Act
-        Action act = () => nullTimeSpan.Should().Be(expected, "because we want to test the failure {0}", "message");
+        Action act = () => nullTimeSpan.Should().Be(expected, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -198,7 +198,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan timeSpan = 1.Seconds();
 
         // Act
-        Action act = () => timeSpan.Should().Be(2.Seconds(), "because we want to test the failure {0}", "message");
+        Action act = () => timeSpan.Should().Be(2.Seconds(), "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -247,7 +247,7 @@ public class SimpleTimeSpanAssertionSpecs
         var oneSecond = 1.Seconds();
 
         // Act
-        Action act = () => oneSecond.Should().NotBe(oneSecond, "because we want to test the failure {0}", "message");
+        Action act = () => oneSecond.Should().NotBe(oneSecond, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
@@ -287,7 +287,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan expected = 1.Seconds();
 
         // Act
-        Action act = () => nullTimeSpan.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+        Action act = () => nullTimeSpan.Should().BeGreaterThan(expected, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -314,7 +314,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan actual = 1.Seconds();
 
         // Act
-        Action act = () => actual.Should().BeGreaterThan(2.Seconds(), "because we want to test the failure {0}", "message");
+        Action act = () => actual.Should().BeGreaterThan(2.Seconds(), "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -341,7 +341,7 @@ public class SimpleTimeSpanAssertionSpecs
 
         // Act
         Action act = () =>
-            nullTimeSpan.Should().BeGreaterThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
+            nullTimeSpan.Should().BeGreaterThanOrEqualTo(expected, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -390,7 +390,7 @@ public class SimpleTimeSpanAssertionSpecs
 
         // Act
         Action act = () =>
-            actual.Should().BeGreaterThanOrEqualTo(2.Seconds(), "because we want to test the failure {0}", "message");
+            actual.Should().BeGreaterThanOrEqualTo(2.Seconds(), "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -430,7 +430,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan expected = 1.Seconds();
 
         // Act
-        Action act = () => nullTimeSpan.Should().BeLessThan(expected, "because we want to test the failure {0}", "message");
+        Action act = () => nullTimeSpan.Should().BeLessThan(expected, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -457,7 +457,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan actual = 2.Seconds();
 
         // Act
-        Action act = () => actual.Should().BeLessThan(1.Seconds(), "because we want to test the failure {0}", "message");
+        Action act = () => actual.Should().BeLessThan(1.Seconds(), "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -495,7 +495,7 @@ public class SimpleTimeSpanAssertionSpecs
 
         // Act
         Action act = () =>
-            nullTimeSpan.Should().BeLessThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
+            nullTimeSpan.Should().BeLessThanOrEqualTo(expected, "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -533,7 +533,7 @@ public class SimpleTimeSpanAssertionSpecs
         TimeSpan actual = 2.Seconds();
 
         // Act
-        Action act = () => actual.Should().BeLessThanOrEqualTo(1.Seconds(), "because we want to test the failure {0}", "message");
+        Action act = () => actual.Should().BeLessThanOrEqualTo(1.Seconds(), "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>().WithMessage(
@@ -602,12 +602,12 @@ public class SimpleTimeSpanAssertionSpecs
         var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
         // Act
-        Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds(), "we want to test the error message");
+        Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds(), "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
             .WithMessage(
-                "Expected time to be within 20ms from 1d, 12h, 15m and 31s because we want to test the error message, but found 1d, 12h, 15m, 30s and 979ms.");
+                "Expected time to be within 20ms from 1d, 12h, 15m and 31s because*failure message, but found 1d, 12h, 15m, 30s and 979ms.");
     }
 
     [Fact]
@@ -618,12 +618,12 @@ public class SimpleTimeSpanAssertionSpecs
         var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
         // Act
-        Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds(), "we want to test the error message");
+        Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds(), "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
             .WithMessage(
-                "Expected time to be within 20ms from 1d, 12h, 15m and 31s because we want to test the error message, but found 1d, 12h, 15m, 31s and 21ms.");
+                "Expected time to be within 20ms from 1d, 12h, 15m and 31s because*failure message, but found 1d, 12h, 15m, 31s and 21ms.");
     }
 
     [Fact]
@@ -661,12 +661,12 @@ public class SimpleTimeSpanAssertionSpecs
 
         // Act
         Action act = () =>
-            time.Should().BeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(20), "we want to test the error message");
+            time.Should().BeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(20), "we want to test the {0} message", "failure");
 
         // Assert
         act.Should().Throw<XunitException>()
             .WithMessage(
-                "Expected time to be within 20ms from 1d, 12h, 15m and 31s because we want to test the error message, but found 1d, 12h, 15m, 30s and 979ms.");
+                "Expected time to be within 20ms from 1d, 12h, 15m and 31s because*failure message, but found 1d, 12h, 15m, 30s and 979ms.");
     }
 
     #endregion

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Be.cs
@@ -33,12 +33,13 @@ public partial class StringAssertionSpecs
         public void When_two_strings_differ_unexpectedly_it_should_throw()
         {
             // Act
-            Action act = () => "ADC".Should().Be("ABC", "because we {0}", "do");
+            Action act = () => "ADC".Should().Be("ABC", "we want to test the {0} message", "failure");
 
             // Assert
             // we want one assertion with the full message.
-            act.Should().Throw<XunitException>().Which.Message.Should().Be("""
-                Expected string to be the same string because we do, but they differ at index 1:
+            act.Should().Throw<XunitException>().Which.Message.Should().Be(
+                """
+                Expected string to be the same string because we want to test the failure message, but they differ at index 1:
                     ↓ (actual)
                   "ADC"
                   "ABC"
@@ -139,11 +140,11 @@ public partial class StringAssertionSpecs
         public void When_string_is_expected_to_be_null_it_should_throw()
         {
             // Act
-            Action act = () => "AB".Should().BeNull("we like {0}", "null");
+            Action act = () => "AB".Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected string to be <null> because we like null, but found \"AB\".");
+                "Expected string to be <null> because we want to test the failure message, but found \"AB\".");
         }
 
         [Fact]
@@ -162,12 +163,12 @@ public partial class StringAssertionSpecs
         public void When_the_expected_string_is_the_same_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
         {
             // Act
-            Action act = () => "ABC".Should().Be("ABC ", "because I say {0}", "so");
+            Action act = () => "ABC".Should().Be("ABC ", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 """
-                *index 3*
+                *because we want to test the failure message*index 3*
                       ↓ (actual)
                   "ABC"
                   "ABC "
@@ -181,12 +182,12 @@ public partial class StringAssertionSpecs
             When_the_actual_string_is_the_same_as_the_expected_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
         {
             // Act
-            Action act = () => "ABC ".Should().Be("ABC", "because I say {0}", "so");
+            Action act = () => "ABC ".Should().Be("ABC", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 """
-                *index 3*
+                *because we want to test the failure message*index 3*
                       ↓ (actual)
                   "ABC "
                   "ABC"
@@ -228,7 +229,8 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void When_two_strings_differ_and_contain_white_spaces_to_escape_these_are_shown_in_the_message_and_respected_in_the_index()
+        public void
+            When_two_strings_differ_and_contain_white_spaces_to_escape_these_are_shown_in_the_message_and_respected_in_the_index()
         {
             string subject = "\t\r\nand now some longer text, parts of which get truncated, and \t\r\ndiff\r\n\t";
             string expected = "\t\r\nand now some longer text, parts of which get truncated, and \t\r\nDIFF\r\n\t";
@@ -253,11 +255,12 @@ public partial class StringAssertionSpecs
             const string expected = "this is a long text which differs in between two words";
 
             // Act
-            Action act = () => subject.Should().Be(expected, "because we use arrows now");
+            Action act = () => subject.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("""
-                Expected subject to be the same string because we use arrows now, but they differ at index 20:
+            act.Should().Throw<XunitException>().WithMessage(
+                """
+                Expected subject to be the same string because we want to test the failure message, but they differ at index 20:
                                    ↓ (actual)
                   "…is a long text that differs in between two words"
                   "…is a long text which differs in between two words"
@@ -272,11 +275,12 @@ public partial class StringAssertionSpecs
             const string expected = "this was too short";
 
             // Act
-            Action act = () => subject.Should().Be(expected, "because we use arrows now");
+            Action act = () => subject.Should().Be(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("""
-                Expected subject to be the same string because we use arrows now, but they differ at index 5:
+            act.Should().Throw<XunitException>().WithMessage(
+                """
+                Expected subject to be the same string because we want to test the failure message, but they differ at index 5:
                         ↓ (actual)
                   "this is a long text that has more than 60 characters so it…"
                   "this was too short"
@@ -287,7 +291,9 @@ public partial class StringAssertionSpecs
         [Theory]
         [InlineData("ThisIsUsedTo Check a difference after 5 characters")]
         [InlineData("ThisIsUsedTo CheckADifferenc e after 15 characters")]
-        public void Will_look_for_a_word_boundary_between_5_and_15_characters_before_the_mismatching_index_to_highlight_the_mismatch(string expected)
+        public void
+            Will_look_for_a_word_boundary_between_5_and_15_characters_before_the_mismatching_index_to_highlight_the_mismatch(
+                string expected)
         {
             const string subject = "ThisIsUsedTo CheckADifferenceInThe WordBoundaryAlgorithm";
 
@@ -302,7 +308,7 @@ public partial class StringAssertionSpecs
         [InlineData("ThisIsUsedTo Chec k a difference after 4 characters", "\"…sedTo CheckADifferen")]
         [InlineData("ThisIsUsedTo CheckADifference after 16 characters", "\"…Difference")]
         public void Will_fallback_to_10_characters_if_no_word_boundary_can_be_found_before_the_mismatching_index(
-                string expected, string expectedMessagePart)
+            string expected, string expectedMessagePart)
         {
             const string subject = "ThisIsUsedTo CheckADifferenceInThe WordBoundaryAlgorithm";
 
@@ -316,9 +322,12 @@ public partial class StringAssertionSpecs
         [Theory]
         [InlineData("This Is A LongTextWithMoreThan60CharactersWhichIs after 10 + 35 characters")]
         [InlineData("This Is A LongTextWithMoreThan60Ch after 10 + 50 characters")]
-        public void Will_look_for_a_word_boundary_between_45_and_60_characters_after_the_mismatching_index_to_highlight_the_mismatch(string expected)
+        public void
+            Will_look_for_a_word_boundary_between_45_and_60_characters_after_the_mismatching_index_to_highlight_the_mismatch(
+                string expected)
         {
-            const string subject = "This Is A LongTextWithMoreThan60CharactersWhichIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
+            const string subject =
+                "This Is A LongTextWithMoreThan60CharactersWhichIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
 
             // Act
             Action act = () => subject.Should().Be(expected);
@@ -348,12 +357,15 @@ public partial class StringAssertionSpecs
         }
 
         [Theory]
-        [InlineData("This Is A LongTextWithMoreThan60C that differs with 60 characters remaining", "oreThan60CharactersWhichIsUsedToCheckADifferenceAt…\"")]
-        [InlineData("This Is A LongTextWithMoreThan60Ch IsALongTextIsUsedToCheckADiffere after 10 + 16 characters", "reThan60CharactersWhichIsUsedToCheckADifferenceAtTheEndOfThe…\"")]
+        [InlineData("This Is A LongTextWithMoreThan60C that differs with 60 characters remaining",
+            "oreThan60CharactersWhichIsUsedToCheckADifferenceAt…\"")]
+        [InlineData("This Is A LongTextWithMoreThan60Ch IsALongTextIsUsedToCheckADiffere after 10 + 16 characters",
+            "reThan60CharactersWhichIsUsedToCheckADifferenceAtTheEndOfThe…\"")]
         public void Will_fallback_to_50_characters_if_no_word_boundary_can_be_found_after_the_mismatching_index(
-                string expected, string expectedMessagePart)
+            string expected, string expectedMessagePart)
         {
-            const string subject = "This Is A LongTextWithMoreThan60CharactersWhichIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
+            const string subject =
+                "This Is A LongTextWithMoreThan60CharactersWhichIsUsedToCheckADifferenceAtTheEndOfThe WordBoundaryAlgorithm";
 
             // Act
             Action act = () => subject.Should().Be(expected);
@@ -368,30 +380,31 @@ public partial class StringAssertionSpecs
             var expectedIndex = 100 + (4 * Environment.NewLine.Length);
 
             var subject = """
-            @startuml
-            Alice -> Bob : Authentication Request
-            Bob --> Alice : Authentication Response
+                @startuml
+                Alice -> Bob : Authentication Request
+                Bob --> Alice : Authentication Response
 
-            Alice -> Bob : Another authentication Request
-            Alice <-- Bob : Another authentication Response
-            @enduml
-            """;
+                Alice -> Bob : Another authentication Request
+                Alice <-- Bob : Another authentication Response
+                @enduml
+                """;
 
             var expected = """
-            @startuml
-            Alice -> Bob : Authentication Request
-            Bob --> Alice : Authentication Response
+                @startuml
+                Alice -> Bob : Authentication Request
+                Bob --> Alice : Authentication Response
 
-            Alice -> Bob : Invalid authentication Request
-            Alice <-- Bob : Another authentication Response
-            @enduml
-            """;
+                Alice -> Bob : Invalid authentication Request
+                Alice <-- Bob : Another authentication Response
+                @enduml
+                """;
 
             // Act
             Action act = () => subject.Should().Be(expected);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage($"""
+            act.Should().Throw<XunitException>().WithMessage(
+                $"""
                 Expected subject to be the same string, but they differ on line 5 and column 16 (index {expectedIndex}):
                              ↓ (actual)
                   "…-> Bob : Another authentication Request*\nAlice <-- Bob :…"
@@ -418,12 +431,12 @@ public partial class StringAssertionSpecs
             Action act = () => "public class Foo { }".Should().Be("public class Foo { };");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .Which.Message.Should().Match("""
-                     *"…class Foo { }"
-                     *"…class Foo { };"
-                     *(expected).
-                     """);
+            act.Should().Throw<XunitException>().Which.Message.Should().Match(
+                """
+                *"…class Foo { }"
+                *"…class Foo { };"
+                *(expected).
+                """);
         }
 
         [Fact]
@@ -467,11 +480,11 @@ public partial class StringAssertionSpecs
         public void When_equal_strings_are_expected_to_differ_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().NotBe("ABC", "because we don't like {0}", "ABC");
+            Action act = () => "ABC".Should().NotBe("ABC", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected string not to be \"ABC\" because we don't like ABC.");
+                "Expected string not to be \"ABC\" because we want to test the failure message.");
         }
 
         [Fact]
@@ -528,11 +541,11 @@ public partial class StringAssertionSpecs
         {
             // Act
             string someString = null;
-            Action act = () => someString.Should().NotBeNull("we don't like {0}", "null");
+            Action act = () => someString.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someString not to be <null> because we don't like null.");
+                "Expected someString not to be <null> because we want to test the failure message.");
         }
 
         [Fact]
@@ -543,11 +556,10 @@ public partial class StringAssertionSpecs
             string expectedString = null;
 
             // Act
-            Action act = () => actualString.Should().NotBe(expectedString, "failure {0}", "message");
+            Action act = () => actualString.Should().NotBe(expectedString, "we want to test the {0} message", "failure");
 
             // Act / Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*not to be <null>*failure message*");
+            act.Should().Throw<XunitException>().WithMessage("*not to be <null>*because*failure message*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeEmpty.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeEmpty.cs
@@ -41,7 +41,7 @@ public partial class StringAssertionSpecs
             string actual = "ABC";
 
             // Act
-            Action act = () => actual.Should().BeEmpty("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().BeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -55,11 +55,11 @@ public partial class StringAssertionSpecs
             string nullString = null;
 
             // Act
-            Action act = () => nullString.Should().BeEmpty("because strings should never be {0}", "null");
+            Action act = () => nullString.Should().BeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected nullString to be empty because strings should never be null, but found <null>.");
+                "Expected nullString to be empty because we want to test the failure message, but found <null>.");
         }
     }
 
@@ -105,7 +105,7 @@ public partial class StringAssertionSpecs
             string actual = "";
 
             // Act
-            Action act = () => actual.Should().NotBeEmpty("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeEquivalentTo.cs
@@ -124,11 +124,11 @@ public partial class StringAssertionSpecs
         public void When_strings_differ_other_than_by_case_it_should_throw()
         {
             // Act
-            Action act = () => "ADC".Should().BeEquivalentTo("abc", "we will test {0} + {1}", 1, 2);
+            Action act = () => "ADC".Should().BeEquivalentTo("abc", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected string to be equivalent *because we will test 1 + 2, but*index 1*\"ADC\"*\"abc\"*.");
+                "Expected string to be equivalent *because we want to test the failure message, but*index 1*\"ADC\"*\"abc\"*.");
         }
 
         [Fact]
@@ -171,11 +171,11 @@ public partial class StringAssertionSpecs
         {
             // Act
             string someString = null;
-            Action act = () => someString.Should().BeEquivalentTo("abc", "we will test {0} + {1}", 1, 2);
+            Action act = () => someString.Should().BeEquivalentTo("abc", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected someString to be equivalent to \"abc\" because we will test 1 + 2, but found <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected someString to be equivalent to \"abc\" because we want to test the failure message, but found <null>.");
         }
 
         [Fact]
@@ -183,7 +183,7 @@ public partial class StringAssertionSpecs
             When_the_expected_string_is_equivalent_to_the_actual_string_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
         {
             // Act
-            Action act = () => "ABC".Should().BeEquivalentTo("abc ", "because I say {0}", "so");
+            Action act = () => "ABC".Should().BeEquivalentTo("abc ", "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -191,7 +191,7 @@ public partial class StringAssertionSpecs
                 .Throw<XunitException>()
                 .WithMessage(
                     """
-                    *index 3*
+                    *because*failure message*index 3*
                           ↓ (actual)
                       "ABC"
                       "abc "
@@ -204,7 +204,7 @@ public partial class StringAssertionSpecs
             When_the_actual_string_equivalent_to_the_expected_but_with_trailing_spaces_it_should_throw_with_clear_error_message()
         {
             // Act
-            Action act = () => "ABC ".Should().BeEquivalentTo("abc", "because I say {0}", "so");
+            Action act = () => "ABC ".Should().BeEquivalentTo("abc", "we want to test the {0} message", "failure");
 
             // Assert
             act
@@ -212,7 +212,7 @@ public partial class StringAssertionSpecs
                 .Throw<XunitException>()
                 .WithMessage(
                     """
-                    *index 3*
+                    *because*failure message*index 3*
                           ↓ (actual)
                       "ABC "
                       "abc"
@@ -314,11 +314,11 @@ public partial class StringAssertionSpecs
             string unexpected = "abc";
 
             // Act
-            Action action = () => actual.Should().NotBeEquivalentTo(unexpected, "because I say {0}", "so");
+            Action action = () => actual.Should().NotBeEquivalentTo(unexpected, "we want to test the {0} message", "failure");
 
             // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected actual not to be equivalent to \"abc\" because I say so, but they are.");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected actual not to be equivalent to \"abc\" because we want to test the failure message, but they are.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
@@ -84,7 +84,7 @@ public partial class StringAssertionSpecs
             string actual = "ABC";
 
             // Act
-            Action act = () => actual.Should().BeLowerCased("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().BeLowerCased("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -98,11 +98,11 @@ public partial class StringAssertionSpecs
             string nullString = null;
 
             // Act
-            Action act = () => nullString.Should().BeLowerCased("because strings should never be {0}", "null");
+            Action act = () => nullString.Should().BeLowerCased("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected all alphabetic characters in nullString to be lower cased because strings should never be null, but found <null>.");
+                "Expected all alphabetic characters in nullString to be lower cased because we want to test the failure message, but found <null>.");
         }
     }
 
@@ -191,7 +191,7 @@ public partial class StringAssertionSpecs
             string actual = "abc";
 
             // Act
-            Action act = () => actual.Should().NotBeLowerCased("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().NotBeLowerCased("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeNullOrEmpty.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeNullOrEmpty.cs
@@ -38,11 +38,11 @@ public partial class StringAssertionSpecs
             string str = "hello";
 
             // Act
-            Action act = () => str.Should().BeNullOrEmpty("it was not initialized {0}", "yet");
+            Action act = () => str.Should().BeNullOrEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected str to be <null> or empty because it was not initialized yet, but found \"hello\".");
+                "Expected str to be <null> or empty because we want to test the failure message, but found \"hello\".");
         }
     }
 
@@ -65,11 +65,11 @@ public partial class StringAssertionSpecs
             string str = "";
 
             // Act
-            Action act = () => str.Should().NotBeNullOrEmpty("a valid string is expected for {0}", "str");
+            Action act = () => str.Should().NotBeNullOrEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected str not to be <null> or empty because a valid string is expected for str, but found \"\".");
+                "Expected str not to be <null> or empty because we want to test the failure message, but found \"\".");
         }
 
         [Fact]
@@ -79,11 +79,11 @@ public partial class StringAssertionSpecs
             string str = null;
 
             // Act
-            Action act = () => str.Should().NotBeNullOrEmpty("a valid string is expected for {0}", "str");
+            Action act = () => str.Should().NotBeNullOrEmpty("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected str not to be <null> or empty because a valid string is expected for str, but found <null>.");
+                "Expected str not to be <null> or empty because we want to test the failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeOneOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeOneOf.cs
@@ -32,12 +32,12 @@ public partial class StringAssertionSpecs
             string value = "abc";
 
             // Act
-            Action action = () => value.Should().BeOneOf(["def", "xyz"], "because those are the valid values");
+            Action action = () => value.Should().BeOneOf(["def", "xyz"], "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to be one of {\"def\", \"xyz\"} because those are the valid values, but found \"abc\".");
+                    "Expected value to be one of {\"def\", \"xyz\"} because we want to test the failure message, but found \"abc\".");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
@@ -71,7 +71,7 @@ public partial class StringAssertionSpecs
             string actual = "abc";
 
             // Act
-            Action act = () => actual.Should().BeUpperCased("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().BeUpperCased("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -85,11 +85,11 @@ public partial class StringAssertionSpecs
             string nullString = null;
 
             // Act
-            Action act = () => nullString.Should().BeUpperCased("because strings should never be {0}", "null");
+            Action act = () => nullString.Should().BeUpperCased("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected all alphabetic characters in nullString to be upper-case because strings should never be null, but found <null>.");
+                "Expected all alphabetic characters in nullString to be upper-case because we want to test the failure message, but found <null>.");
         }
     }
 
@@ -178,7 +178,7 @@ public partial class StringAssertionSpecs
             string actual = "ABC";
 
             // Act
-            Action act = () => actual.Should().NotBeUpperCased("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().NotBeUpperCased("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Contain.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Contain.cs
@@ -29,11 +29,11 @@ public partial class StringAssertionSpecs
         public void When_string_does_not_contain_an_expected_string_it_should_throw()
         {
             // Act
-            Action act = () => "ABCDEF".Should().Contain("XYZ", "that is {0}", "required");
+            Action act = () => "ABCDEF".Should().Contain("XYZ", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected string \"ABCDEF\" to contain \"XYZ\" because that is required.");
+                "Expected string \"ABCDEF\" to contain \"XYZ\" because we want to test the failure message.");
         }
 
         [Fact]
@@ -67,11 +67,11 @@ public partial class StringAssertionSpecs
         {
             // Act
             string someString = null;
-            Action act = () => someString.Should().Contain("XYZ", "that is {0}", "required");
+            Action act = () => someString.Should().Contain("XYZ", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someString <null> to contain \"XYZ\" because that is required.");
+                "Expected someString <null> to contain \"XYZ\" because we want to test the failure message.");
         }
 
         public class ContainExactly
@@ -85,12 +85,12 @@ public partial class StringAssertionSpecs
                 string expectedSubstring = "XYS";
 
                 // Act
-                Action act = () => actual.Should().Contain(expectedSubstring, Exactly.Once(), "that is {0}", "required");
+                Action act = () =>
+                    actual.Should().Contain(expectedSubstring, Exactly.Once(), "we want to test the {0} message", "failure");
 
                 // Assert
-                act.Should().Throw<XunitException>()
-                    .WithMessage(
-                        "Expected * \"ABCDEF\" to contain \"XYS\" exactly 1 time because that is required, but found it 0 times.");
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected * \"ABCDEF\" to contain \"XYS\" exactly 1 time because we want to test the failure message, but found it 0 times.");
             }
 
             [Fact]
@@ -415,11 +415,11 @@ public partial class StringAssertionSpecs
         public void When_string_contains_unexpected_fragment_it_should_throw()
         {
             // Act
-            Action act = () => "abcd".Should().NotContain("bc", "it was not expected {0}", "today");
+            Action act = () => "abcd".Should().NotContain("bc", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect string \"abcd\" to contain \"bc\" because it was not expected today.");
+                .WithMessage("Did not expect string \"abcd\" to contain \"bc\" because we want to test the failure message.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainAll.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainAll.cs
@@ -100,12 +100,12 @@ public partial class StringAssertionSpecs
             var testString = $"{red} {green}";
 
             // Act
-            Action act = () => testString.Should().ContainAll([yellow, blue], "some {0} reason", "special");
+            Action act = () => testString.Should().ContainAll([yellow, blue], "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"*{testString}*contain*{yellow}*{blue}*because some special reason*");
+                .WithMessage($"*{testString}*contain*{yellow}*{blue}*because we want to test the failure message*");
         }
 
         [Fact]
@@ -184,12 +184,13 @@ public partial class StringAssertionSpecs
             var testString = $"{red} {green} {yellow}";
 
             // Act
-            Action act = () => testString.Should().NotContainAll([red, green, yellow], "some {0} reason", "special");
+            Action act = () =>
+                testString.Should().NotContainAll([red, green, yellow], "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"*not*{testString}*contain all*{red}*{green}*{yellow}*because*some special reason*");
+                .WithMessage($"*not*{testString}*contain all*{red}*{green}*{yellow}*because*failure message*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainAny.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainAny.cs
@@ -115,12 +115,11 @@ public partial class StringAssertionSpecs
             var testString = $"{red} {green}";
 
             // Act
-            Action act = () => testString.Should().ContainAny([blue, purple], "some {0} reason", "special");
+            Action act = () => testString.Should().ContainAny([blue, purple], "we want to test the {0} message", "failure");
 
             // Assert
-            act
-                .Should().Throw<XunitException>()
-                .WithMessage($"*{testString}*contain at least one of*{blue}*{purple}*because some special reason*");
+            act.Should().Throw<XunitException>().WithMessage(
+                $"*{testString}*contain at least one of*{blue}*{purple}*because we want to test the failure message*");
         }
     }
 
@@ -198,12 +197,12 @@ public partial class StringAssertionSpecs
             var testString = $"{red} {green} {yellow}";
 
             // Act
-            Action act = () => testString.Should().NotContainAny([red], "some {0} reason", "special");
+            Action act = () => testString.Should().NotContainAny([red], "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"*not*{testString}*contain any*{red}*because*some special reason*");
+                .WithMessage($"*not*{testString}*contain any*{red}*because*we want to test the failure message*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.ContainEquivalentOf.cs
@@ -96,11 +96,11 @@ public partial class StringAssertionSpecs
         {
             // Act
             Action act = () =>
-                "a".Should().ContainEquivalentOf("aa", "failure {0}", "message");
+                "a".Should().ContainEquivalentOf("aa", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected string \"a\" to contain the equivalent of \"aa\" at least 1 time because failure message, but found it 0 times.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected string \"a\" to contain the equivalent of \"aa\" at least 1 time because*failure message, but found it 0 times.");
         }
 
         [Fact]
@@ -157,12 +157,12 @@ public partial class StringAssertionSpecs
 
                 // Act
                 Action act = () =>
-                    actual.Should().ContainEquivalentOf(expectedSubstring, Exactly.Once(), "that is {0}", "required");
+                    actual.Should().ContainEquivalentOf(expectedSubstring, Exactly.Once(), "we want to test the {0} message",
+                        "failure");
 
                 // Assert
-                act.Should().Throw<XunitException>()
-                    .WithMessage(
-                        "Expected * <null> to contain the equivalent of \"XyZ\" exactly 1 time because that is required, but found it 0 times.");
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected * <null> to contain the equivalent of \"XyZ\" exactly 1 time because*failure message, but found it 0 times.");
             }
 
             [Fact]
@@ -189,9 +189,8 @@ public partial class StringAssertionSpecs
                 Action act = () => actual.Should().ContainEquivalentOf(expectedSubstring, Exactly.Times(3));
 
                 // Assert
-                act.Should().Throw<XunitException>()
-                    .WithMessage(
-                        "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" exactly 3 times, but found it 2 times.");
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" exactly 3 times, but found it 2 times.");
             }
 
             [Fact]
@@ -206,8 +205,8 @@ public partial class StringAssertionSpecs
                 Action act = () => actual.Should().ContainEquivalentOf(expectedSubstring, Exactly.Once());
 
                 // Assert
-                act.Should().Throw<XunitException>()
-                    .WithMessage("Expected * \"abCDEf\" to contain the equivalent of \"xyS\" exactly 1 time, but found it 0 times.");
+                act.Should().Throw<XunitException>().WithMessage(
+                    "Expected * \"abCDEf\" to contain the equivalent of \"xyS\" exactly 1 time, but found it 0 times.");
             }
 
             [Fact]
@@ -254,8 +253,8 @@ public partial class StringAssertionSpecs
             Action act = () => actual.Should().ContainEquivalentOf(expectedSubstring, AtLeast.Times(3));
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" at least 3 times, but found it 2 times.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" at least 3 times, but found it 2 times.");
         }
 
         [Fact]
@@ -317,9 +316,8 @@ public partial class StringAssertionSpecs
             Action act = () => actual.Should().ContainEquivalentOf(expectedSubstring, MoreThan.Times(2));
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" more than 2 times, but found it 2 times.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" more than 2 times, but found it 2 times.");
         }
 
         [Fact]
@@ -334,8 +332,8 @@ public partial class StringAssertionSpecs
             Action act = () => actual.Should().ContainEquivalentOf(expectedSubstring, MoreThan.Once());
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected * \"abCDEf\" to contain the equivalent of \"xyS\" more than 1 time, but found it 0 times.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected * \"abCDEf\" to contain the equivalent of \"xyS\" more than 1 time, but found it 0 times.");
         }
 
         [Fact]
@@ -381,8 +379,8 @@ public partial class StringAssertionSpecs
             Action act = () => actual.Should().ContainEquivalentOf(expectedSubstring, AtMost.Times(1));
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" at most 1 time, but found it 2 times.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" at most 1 time, but found it 2 times.");
         }
 
         [Fact]
@@ -436,9 +434,8 @@ public partial class StringAssertionSpecs
             Action act = () => actual.Should().ContainEquivalentOf(expectedSubstring, LessThan.Times(2));
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" less than 2 times, but found it 2 times.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected * \"abCDEBcDF\" to contain the equivalent of \"Bcd\" less than 2 times, but found it 2 times.");
         }
 
         [Fact]
@@ -601,11 +598,11 @@ public partial class StringAssertionSpecs
             string subject = null;
 
             // Act
-            Action act = () => subject.Should().NotContainEquivalentOf("ANY", "failure {0}", "message");
+            Action act = () => subject.Should().NotContainEquivalentOf("ANY", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .Which.Message.Should().Be("Did not expect subject to contain the equivalent of \"ANY\" because failure message, but found <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect subject to contain the equivalent of \"ANY\" because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.EndWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.EndWith.cs
@@ -42,13 +42,13 @@ public partial class StringAssertionSpecs
             Action act = () =>
             {
                 using var a = new AssertionScope();
-                "ABC".Should().EndWith("AB", "it should");
+                "ABC".Should().EndWith("AB", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 """
-                Expected string to end with the same string because it should, but they differ before index 3:
+                Expected string to end with the same string because*failure message, but they differ before index 3:
                      ↓ (actual)
                   "ABC"
                    "AB"
@@ -216,8 +216,10 @@ public partial class StringAssertionSpecs
         public void When_expected_becomes_longer_than_actual_after_truncation_strings_are_right_aligned()
         {
             // Arrange
-            const string subject = "from cancel this waver was coming from this is a long text pat thaT differs in between two words";
-            const string expected = "such and when to this the other they should and sad rhino whicH differs in between two words";
+            const string subject =
+                "from cancel this waver was coming from this is a long text pat thaT differs in between two words";
+            const string expected =
+                "such and when to this the other they should and sad rhino whicH differs in between two words";
 
             // Act
             Action act = () => subject.Should().EndWith(expected);
@@ -262,9 +264,11 @@ public partial class StringAssertionSpecs
         public void When_both_strings_are_truncated_from_both_ends_arrows_are_aligned()
         {
             // Arrange
-            var subject = "this is a very long text. it is very long text that12345 differs in between two words. it is very lengthy.";
+            var subject =
+                "this is a very long text. it is very long text that12345 differs in between two words. it is very lengthy.";
 
-            var expected = "this is a very long text. it is very long text that1264 differs in between two words. it is very lengthy.";
+            var expected =
+                "this is a very long text. it is very long text that1264 differs in between two words. it is very lengthy.";
 
             // Act
             Action act = () => subject.Should().EndWith(expected);
@@ -445,11 +449,11 @@ public partial class StringAssertionSpecs
 
             // Act
             Action action = () =>
-                value.Should().NotEndWith("BC", "because of some {0}", "reason");
+                value.Should().NotEndWith("BC", "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
-                "Expected value not to end with \"BC\" because of some reason, but found \"ABC\".");
+                "Expected value not to end with \"BC\" because*failure message, but found \"ABC\".");
         }
 
         [Fact]
@@ -492,12 +496,12 @@ public partial class StringAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                someString.Should().NotEndWith("ABC", "some {0}", "reason");
+                someString.Should().NotEndWith("ABC", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someString not to end with \"ABC\"*some reason*, but found <null>.");
+                "Expected someString not to end with \"ABC\" because*failure message*, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.EndWithEquivalentOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.EndWithEquivalentOf.cs
@@ -109,11 +109,11 @@ public partial class StringAssertionSpecs
         public void When_end_of_string_does_not_meet_equivalent_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().EndWithEquivalentOf("ab", "because it should end");
+            Action act = () => "ABC".Should().EndWithEquivalentOf("ab", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected string*it should*index 3*ABC*ab*");
+                "Expected string*because*failure message*index 3*ABC*ab*");
         }
 
         [Fact]
@@ -275,11 +275,11 @@ public partial class StringAssertionSpecs
 
             // Act
             Action action = () =>
-                value.Should().NotEndWithEquivalentOf("Bc", "because of some {0}", "reason");
+                value.Should().NotEndWithEquivalentOf("Bc", "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
-                "Expected value not to end with equivalent of \"Bc\" because of some reason, but found \"ABC\".");
+                "Expected value not to end with equivalent of \"Bc\" because*failure message*, but found \"ABC\".");
         }
 
         [Fact]
@@ -322,12 +322,12 @@ public partial class StringAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                someString.Should().NotEndWithEquivalentOf("Abc", "some {0}", "reason");
+                someString.Should().NotEndWithEquivalentOf("Abc", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someString not to end with equivalent of \"Abc\"*some reason*, but found <null>.");
+                "Expected someString not to end with equivalent of \"Abc\" because*failure message*, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.HaveLength.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.HaveLength.cs
@@ -32,12 +32,12 @@ public partial class StringAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                actual.Should().HaveLength(0, "we want to test the failure {0}", "message");
+                actual.Should().HaveLength(0, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected actual with length 0 *failure message*, but found <null>.");
+                .WithMessage("Expected actual with length 0 because*failure message*, but found <null>.");
         }
 
         [Fact]
@@ -50,12 +50,12 @@ public partial class StringAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                actual.Should().HaveLength(1, "we want to test the failure {0}", "message");
+                actual.Should().HaveLength(1, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected actual with length 1 *failure message*, but found string \"ABC\" with length 3.");
+                .WithMessage("Expected actual with length 1 because*failure message*, but found string \"ABC\" with length 3.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Match.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Match.cs
@@ -18,12 +18,12 @@ public partial class StringAssertionSpecs
             string subject = "hello world!";
 
             // Act
-            Action act = () => subject.Should().Match("h*earth!", "failure {0}", "message");
+            Action act = () => subject.Should().Match("h*earth!", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected subject to match*\"h*earth!\" because failure message, but*\"hello world!\" does not.");
+                    "Expected subject to match*\"h*earth!\" because*failure message, but*\"hello world!\" does not.");
         }
 
         [Fact]
@@ -129,12 +129,12 @@ public partial class StringAssertionSpecs
             string subject = "hello world";
 
             // Act
-            Action act = () => subject.Should().NotMatch("*world*", "because that's illegal");
+            Action act = () => subject.Should().NotMatch("*world*", "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>().WithMessage(
-                    "Did not expect subject to match*\"*world*\" because that's illegal, but*\"hello world\" matches.");
+                    "Did not expect subject to match*\"*world*\" because*failure message, but*\"hello world\" matches.");
         }
 
         [Fact]
@@ -175,12 +175,11 @@ public partial class StringAssertionSpecs
             string subject = null;
 
             // Act
-            Action act = () => subject.Should().NotMatch("*", "failure {0}", "message");
+            Action act = () => subject.Should().NotMatch("*", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .Which.Message.Should().Be(
-                    "Did not expect subject to match \"*\" because failure message, but found <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect subject to match \"*\" because*failure message, but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.MatchEquivalentOf.cs
@@ -62,12 +62,12 @@ public partial class StringAssertionSpecs
             string subject = "hello world!";
 
             // Act
-            Action act = () => subject.Should().MatchEquivalentOf("h*earth!", "that's the universal greeting");
+            Action act = () => subject.Should().MatchEquivalentOf("h*earth!", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected subject to match the equivalent of*\"h*earth!\" " +
-                "because that's the universal greeting, but*\"hello world!\" does not.");
+                "because*failure message, but*\"hello world!\" does not.");
         }
 
         [Fact]
@@ -211,12 +211,12 @@ public partial class StringAssertionSpecs
             string subject = "hello WORLD";
 
             // Act
-            Action act = () => subject.Should().NotMatchEquivalentOf("*world*", "because that's illegal");
+            Action act = () => subject.Should().NotMatchEquivalentOf("*world*", "we want to test the {0} message", "failure");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Did not expect subject to match the equivalent of*\"*world*\" because that's illegal, " +
+                .WithMessage("Did not expect subject to match the equivalent of*\"*world*\" because*failure message, " +
                     "but*\"hello WORLD\" matches.");
         }
 
@@ -284,12 +284,13 @@ public partial class StringAssertionSpecs
             string subject = null;
 
             // Act
-            Action act = () => subject.Should().NotMatchEquivalentOf("*", "failure {0}", "message");
+            Action act = () => subject.Should().NotMatchEquivalentOf("*", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .Which.Message.Should().Be(// use `Be` because we cannot match a literal * in `WithMessage`
-                    "Did not expect subject to match the equivalent of \"*\" because failure message, but found <null>.");
+                    "Did not expect subject to match the equivalent of \"*\" because we want to test the failure message,"
+                    + " but found <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.MatchRegex.cs
@@ -33,12 +33,12 @@ public partial class StringAssertionSpecs
             string subject = "hello world!";
 
             // Act
-            Action act = () => subject.Should().MatchRegex("h.*\\sworld?$", "that's the universal greeting");
+            Action act = () => subject.Should().MatchRegex("h.*\\sworld?$", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected subject to match regex*\"h.*\\sworld?$\" because that's the universal greeting, but*\"hello world!\" does not match.");
+                    "Expected subject to match regex*\"h.*\\sworld?$\" because*failure message, but*\"hello world!\" does not match.");
         }
 
         [Fact]
@@ -48,11 +48,11 @@ public partial class StringAssertionSpecs
             string subject = null;
 
             // Act
-            Action act = () => subject.Should().MatchRegex(".*", "because it should be a string");
+            Action act = () => subject.Should().MatchRegex(".*", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
+                .WithMessage("Expected subject to match regex*\".*\" because*failure message, but it was <null>.");
         }
 
         [Fact]
@@ -139,12 +139,13 @@ public partial class StringAssertionSpecs
             string subject = "hello world!";
 
             // Act
-            Action act = () => subject.Should().MatchRegex(new Regex("h.*\\sworld?$"), "that's the universal greeting");
+            Action act = () =>
+                subject.Should().MatchRegex(new Regex("h.*\\sworld?$"), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected subject to match regex*\"h.*\\sworld?$\" because that's the universal greeting, but*\"hello world!\" does not match.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected subject to match regex*\"h.*\\sworld?$\" because*failure message,"
+                + " but*\"hello world!\" does not match.");
         }
 
         [Fact]
@@ -157,12 +158,12 @@ public partial class StringAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                subject.Should().MatchRegex(new Regex(".*"), "because it should be a string");
+                subject.Should().MatchRegex(new Regex(".*"), "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
+                .WithMessage("Expected subject to match regex*\".*\" because*failure message, but it was <null>.");
         }
 
         [Fact]
@@ -255,12 +256,12 @@ public partial class StringAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                subject.Should().MatchRegex(".*", Exactly.Times(0), "because it should be a string");
+                subject.Should().MatchRegex(".*", Exactly.Times(0), "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().ThrowExactly<XunitException>()
-                .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
+                .WithMessage("Expected subject to match regex*\".*\" because*failure message, but it was <null>.");
         }
 
         [Fact]
@@ -358,12 +359,12 @@ public partial class StringAssertionSpecs
             string subject = "hello world!";
 
             // Act
-            Action act = () => subject.Should().NotMatchRegex(".*world.*", "because that's illegal");
+            Action act = () => subject.Should().NotMatchRegex(".*world.*", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Did not expect subject to match regex*\".*world.*\" because that's illegal, but*\"hello world!\" matches.");
+                    "Did not expect subject to match regex*\".*world.*\" because*failure message, but*\"hello world!\" matches.");
         }
 
         [Fact]
@@ -373,11 +374,11 @@ public partial class StringAssertionSpecs
             string subject = null;
 
             // Act
-            Action act = () => subject.Should().NotMatchRegex(".*", "because it should not be a string");
+            Action act = () => subject.Should().NotMatchRegex(".*", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to not match regex*\".*\" because it should not be a string, but it was <null>.");
+                .WithMessage("Expected subject to not match regex*\".*\" because*failure message, but it was <null>.");
         }
 
         [Fact]
@@ -440,8 +441,7 @@ public partial class StringAssertionSpecs
             Action act = () => subject.Should().NotMatchRegex(string.Empty);
 
             // Assert
-            act.Should().ThrowExactly<ArgumentException>()
-                .WithMessage(
+            act.Should().ThrowExactly<ArgumentException>().WithMessage(
                     "Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.*")
                 .WithParameterName("regularExpression");
         }
@@ -463,12 +463,12 @@ public partial class StringAssertionSpecs
             string subject = "hello world!";
 
             // Act
-            Action act = () => subject.Should().NotMatchRegex(new Regex(".*world.*"), "because that's illegal");
+            Action act = () =>
+                subject.Should().NotMatchRegex(new Regex(".*world.*"), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Did not expect subject to match regex*\".*world.*\" because that's illegal, but*\"hello world!\" matches.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect subject to match regex*\".*world.*\" because*failure message, but*\"hello world!\" matches.");
         }
 
         [Fact]
@@ -481,12 +481,12 @@ public partial class StringAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                subject.Should().NotMatchRegex(new Regex(".*"), "because it should not be a string");
+                subject.Should().NotMatchRegex(new Regex(".*"), "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to not match regex*\".*\" because it should not be a string, but it was <null>.");
+                .WithMessage("Expected subject to not match regex*\".*\" because*failure message, but it was <null>.");
         }
 
         [Fact]
@@ -514,8 +514,7 @@ public partial class StringAssertionSpecs
             Action act = () => subject.Should().NotMatchRegex(new Regex(string.Empty));
 
             // Assert
-            act.Should().ThrowExactly<ArgumentException>()
-                .WithMessage(
+            act.Should().ThrowExactly<ArgumentException>().WithMessage(
                     "Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.*")
                 .WithParameterName("regularExpression");
         }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Parsable.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.Parsable.cs
@@ -17,7 +17,7 @@ public partial class StringAssertionSpecs
             string sut = "aaa";
 
             // Act
-            Action act = () => sut.Should().BeParsableInto<int>("we want to test the {0}", "failure message")
+            Action act = () => sut.Should().BeParsableInto<int>("we want to test the {0} message", "failure")
                 .Which.Should().Be(0);
 
             // Assert
@@ -88,7 +88,7 @@ public partial class StringAssertionSpecs
             string sut = "1";
 
             // Act
-            Action act = () => sut.Should().NotBeParsableInto<int>("we want to test the {0}", "failure message");
+            Action act = () => sut.Should().NotBeParsableInto<int>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*1*int*we want*failure message*could*");

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.StartWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.StartWith.cs
@@ -37,12 +37,12 @@ public partial class StringAssertionSpecs
         public void When_string_does_not_start_with_expected_phrase_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().StartWith("ABB", "it should {0}", "start");
+            Action act = () => "ABC".Should().StartWith("ABB", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 """
-                Expected string to start with the same string because it should start, but they differ at index 2:
+                Expected string to start with the same string because*failure message, but they differ at index 2:
                      ↓ (actual)
                   "ABC"
                   "ABB"
@@ -56,12 +56,12 @@ public partial class StringAssertionSpecs
             When_string_does_not_start_with_expected_phrase_and_one_of_them_is_long_it_should_display_both_strings_on_separate_line()
         {
             // Act
-            Action act = () => "ABCDEFGHI".Should().StartWith("ABCDDFGHI", "it should {0}", "start");
+            Action act = () => "ABCDEFGHI".Should().StartWith("ABCDDFGHI", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 """
-                Expected string to start with the same string because it should start, but they differ at index 4:
+                Expected string to start with the same string because*failure message, but they differ at index 4:
                        ↓ (actual)
                   "ABCDEFGHI"
                   "ABCDDFGHI"
@@ -192,11 +192,11 @@ public partial class StringAssertionSpecs
 
             // Act
             Action action = () =>
-                value.Should().NotStartWith("AB", "because of some reason");
+                value.Should().NotStartWith("AB", "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
-                "Expected value not to start with \"AB\" because of some reason, but found \"ABC\".");
+                "Expected value not to start with \"AB\" because*failure message, but found \"ABC\".");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.StartWithEquivalentOf.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.StartWithEquivalentOf.cs
@@ -99,10 +99,10 @@ public partial class StringAssertionSpecs
         public void When_start_of_string_does_not_meet_equivalent_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().StartWithEquivalentOf("bc", "because it should start");
+            Action act = () => "ABC".Should().StartWithEquivalentOf("bc", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected string to start with*ABC*bc*");
+            act.Should().Throw<XunitException>().WithMessage("Expected string to start with*because*failure message*ABC*bc*");
         }
 
         [Fact]
@@ -111,12 +111,12 @@ public partial class StringAssertionSpecs
             When_start_of_string_does_not_meet_equivalent_and_one_of_them_is_long_it_should_display_both_strings_on_separate_line()
         {
             // Act
-            Action act = () => "ABCDEFGHI".Should().StartWithEquivalentOf("abcddfghi", "it should {0}", "start");
+            Action act = () => "ABCDEFGHI".Should().StartWithEquivalentOf("abcddfghi", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 """
-                Expected string to start with equivalent of the same string because it should start, but they differ at index 4:
+                Expected string to start with equivalent of the same string because*failure message, but they differ at index 4:
                        ↓ (actual)
                   "ABCDEFGHI"
                   "abcddfghi"
@@ -277,11 +277,11 @@ public partial class StringAssertionSpecs
 
             // Act
             Action action = () =>
-                value.Should().NotStartWithEquivalentOf("aB", "because of some reason");
+                value.Should().NotStartWithEquivalentOf("aB", "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
-                "Expected value not to start with equivalent of \"aB\" because of some reason, but found \"ABC\".");
+                "Expected value not to start with equivalent of \"aB\" because*failure message, but found \"ABC\".");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Primitives/TimeOnlyAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/TimeOnlyAssertionSpecs.Be.cs
@@ -61,11 +61,11 @@ public partial class TimeOnlyAssertionSpecs
             var otherTimeOnly = new TimeOnly(15, 03, 11);
 
             // Act
-            Action act = () => timeOnly.Should().Be(otherTimeOnly, "because we want to test the failure {0}", "message");
+            Action act = () => timeOnly.Should().Be(otherTimeOnly, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected timeOnly to be <15:03:11.000>*failure message, but found <15:03:10.000>.");
+                .WithMessage("Expected timeOnly to be <15:03:11.000>*because*failure message, but found <15:03:10.000>.");
         }
 
         [Fact]
@@ -76,11 +76,11 @@ public partial class TimeOnlyAssertionSpecs
             var otherTimeOnly = new TimeOnly(15, 03, 10, 175);
 
             // Act
-            Action act = () => timeOnly.Should().Be(otherTimeOnly, "because we want to test the failure {0}", "message");
+            Action act = () => timeOnly.Should().Be(otherTimeOnly, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected timeOnly to be <15:03:10.175>*failure message, but found <15:03:10.556>.");
+                .WithMessage("Expected timeOnly to be <15:03:10.175>*because*failure message, but found <15:03:10.556>.");
         }
 
         [Fact]
@@ -128,8 +128,7 @@ public partial class TimeOnlyAssertionSpecs
 
             // Act
             Action action = () =>
-                nullableTimeOnly.Should().Be(new TimeOnly(15, 06, 04), "because we want to test the failure {0}",
-                    "message");
+                nullableTimeOnly.Should().Be(new TimeOnly(15, 06, 04), "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -181,8 +180,7 @@ public partial class TimeOnlyAssertionSpecs
             TimeOnly sameTime = new(19, 06, 04);
 
             // Act
-            Action act =
-                () => time.Should().NotBe(sameTime, "because we want to test the failure {0}", "message");
+            Action act = () => time.Should().NotBe(sameTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -198,8 +196,7 @@ public partial class TimeOnlyAssertionSpecs
             TimeOnly? sameTime = new(19, 06, 04);
 
             // Act
-            Action act =
-                () => time.Should().NotBe(sameTime, "because we want to test the failure {0}", "message");
+            Action act = () => time.Should().NotBe(sameTime, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -57,12 +57,11 @@ public class AssemblyAssertionSpecs
             Assembly assemblyB = FindAssembly.Containing<ClassB>();
 
             // Act
-            Action act = () => assemblyA.Should().NotReference(assemblyB, "we want to test the failure {0}", "message");
+            Action act = () => assemblyA.Should().NotReference(assemblyB, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected assembly not to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected assembly not to reference assembly \"AssemblyB\" because*failure message*, but assemblyA is <null>.");
         }
 
         [Fact]
@@ -127,12 +126,11 @@ public class AssemblyAssertionSpecs
             Assembly assemblyB = FindAssembly.Containing<ClassB>();
 
             // Act
-            Action act = () => assemblyA.Should().Reference(assemblyB, "we want to test the failure {0}", "message");
+            Action act = () => assemblyA.Should().Reference(assemblyB, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected assembly to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected assembly to reference assembly \"AssemblyB\" because*failure message*, but assemblyA is <null>.");
         }
 
         [Fact]
@@ -188,8 +186,8 @@ public class AssemblyAssertionSpecs
             var thisAssembly = GetType().Assembly;
 
             // Act
-            Action act = () => thisAssembly.Should().DefineType("FakeNamespace", "FakeName",
-                "because we want to test the failure {0}", "message");
+            Action act = () =>
+                thisAssembly.Should().DefineType("FakeNamespace", "FakeName", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -205,15 +203,13 @@ public class AssemblyAssertionSpecs
             Assembly thisAssembly = null;
 
             // Act
-            Action act = () =>
-                thisAssembly.Should().DefineType(GetType().Namespace, "WellKnownClassWithAttribute",
-                    "we want to test the failure {0}", "message");
+            Action act = () => thisAssembly.Should().DefineType(GetType().Namespace, "WellKnownClassWithAttribute",
+                "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected assembly to define type *.\"WellKnownClassWithAttribute\" *failure message*" +
-                    ", but thisAssembly is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected assembly to define type *.\"WellKnownClassWithAttribute\" because*failure message*" +
+                ", but thisAssembly is <null>.");
         }
 
         [Fact]
@@ -280,11 +276,11 @@ public class AssemblyAssertionSpecs
             var signedAssembly = FindAssembly.Stub("0123456789ABCEF007");
 
             // Act
-            Action act = () => signedAssembly.Should().BeUnsigned("this assembly is never shipped");
+            Action act = () => signedAssembly.Should().BeUnsigned("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect the assembly * to be signed because this assembly is never shipped, but it is.");
+                .WithMessage("Did not expect the assembly * to be signed because*failure message, but it is.");
         }
 
         [Fact]
@@ -336,11 +332,12 @@ public class AssemblyAssertionSpecs
             var unsignedAssembly = FindAssembly.Stub(noKey);
 
             // Act
-            Action act = () => unsignedAssembly.Should().BeSignedWithPublicKey("1234", "signing is part of the contract");
+            Action act = () =>
+                unsignedAssembly.Should().BeSignedWithPublicKey("1234", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected assembly * to have public key \"1234\" because signing is part of the contract, but it is unsigned.");
+                .WithMessage("Expected assembly * to have public key \"1234\" because*failure message, but it is unsigned.");
         }
 
         [Fact]
@@ -350,11 +347,12 @@ public class AssemblyAssertionSpecs
             var signedAssembly = FindAssembly.Stub("0123456789ABCEF007");
 
             // Act
-            Action act = () => signedAssembly.Should().BeSignedWithPublicKey("1234", "signing is part of the contract");
+            Action act = () =>
+                signedAssembly.Should().BeSignedWithPublicKey("1234", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected assembly * to have public key \"1234\" because signing is part of the contract, but it has * instead.");
+                .WithMessage("Expected assembly * to have public key \"1234\" because*failure message, but it has * instead.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -21,12 +21,13 @@ public class ExecutionTimeAssertionsSpecs
             var subject = new SleepingClass();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessThanOrEqualTo(500.Milliseconds(),
-                "we like speed");
+            Action act = () =>
+                subject.ExecutionTimeOf(s => s.Sleep(610)).Should()
+                    .BeLessThanOrEqualTo(500.Milliseconds(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(610)) should be less than or equal to 500ms because we like speed, but it required*");
+                "*(s.Sleep(610)) should be less than or equal to 500ms because*failure message, but it required*");
         }
 
         [Fact]
@@ -119,12 +120,13 @@ public class ExecutionTimeAssertionsSpecs
             var subject = new SleepingClass();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessThan(500.Milliseconds(),
-                "we like speed");
+            Action act = () =>
+                subject.ExecutionTimeOf(s => s.Sleep(610)).Should()
+                    .BeLessThan(500.Milliseconds(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(610)) should be less than 500ms because we like speed, but it required*");
+                "*(s.Sleep(610)) should be less than 500ms because*failure message, but it required*");
         }
 
         [Fact]
@@ -228,12 +230,13 @@ public class ExecutionTimeAssertionsSpecs
             var subject = new SleepingClass();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThanOrEqualTo(1.Seconds(),
-                "we like speed");
+            Action act = () =>
+                subject.ExecutionTimeOf(s => s.Sleep(100)).Should()
+                    .BeGreaterThanOrEqualTo(1.Seconds(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(100)) should be greater than or equal to 1s because we like speed, but it required*");
+                "*(s.Sleep(100)) should be greater than or equal to 1s because*failure message, but it required*");
         }
 
         [Fact]
@@ -325,12 +328,13 @@ public class ExecutionTimeAssertionsSpecs
             var subject = new SleepingClass();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThan(1.Seconds(),
-                "we like speed");
+            Action act = () =>
+                subject.ExecutionTimeOf(s => s.Sleep(100)).Should()
+                    .BeGreaterThan(1.Seconds(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(100)) should be greater than 1s because we like speed, but it required*");
+                "*(s.Sleep(100)) should be greater than 1s because*failure message, but it required*");
         }
 
         [Fact]
@@ -426,12 +430,11 @@ public class ExecutionTimeAssertionsSpecs
 
             // Act
             Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeCloseTo(100.Milliseconds(),
-                50.Milliseconds(),
-                "we like speed");
+                50.Milliseconds(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(200)) should be within 50ms from 100ms because we like speed, but it required*");
+                "*(s.Sleep(200)) should be within 50ms from 100ms because*failure message, but it required*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -69,8 +69,8 @@ public static class TaskAssertionSpecs
             Func<Task> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().CompleteWithinAsync(
-                timeSpan, "because we want to test the failure {0}", "message");
+            Func<Task> testAction = () =>
+                action.Should().CompleteWithinAsync(timeSpan, "we want to test the {0} message", "failure");
 
             // Assert
             await testAction.Should().ThrowAsync<XunitException>()
@@ -188,8 +188,8 @@ public static class TaskAssertionSpecs
             Func<Task> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().NotCompleteWithinAsync(
-                timeSpan, "because we want to test the failure {0}", "message");
+            Func<Task> testAction = () =>
+                action.Should().NotCompleteWithinAsync(timeSpan, "we want to test the {0} message", "failure");
 
             // Assert
             await testAction.Should().ThrowAsync<XunitException>()
@@ -306,8 +306,8 @@ public static class TaskAssertionSpecs
             Func<Task> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().ThrowAsync<InvalidOperationException>(
-                "because we want to test the failure {0}", "message");
+            Func<Task> testAction = () =>
+                action.Should().ThrowAsync<InvalidOperationException>("we want to test the {0} message", "failure");
 
             // Assert
             await testAction.Should().ThrowAsync<XunitException>()
@@ -325,8 +325,7 @@ public static class TaskAssertionSpecs
             {
                 using var _ = new AssertionScope();
 
-                await action.Should().ThrowAsync<InvalidOperationException>(
-                    "because we want to test the failure {0}", "message");
+                await action.Should().ThrowAsync<InvalidOperationException>("we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -393,7 +392,7 @@ public static class TaskAssertionSpecs
 
             // Act
             Func<Task> testAction = () => action.Should().ThrowWithinAsync<InvalidOperationException>(
-                100.Milliseconds(), "because we want to test the failure {0}", "message");
+                100.Milliseconds(), "we want to test the {0} message", "failure");
 
             // Assert
             await testAction.Should().ThrowAsync<XunitException>()
@@ -412,7 +411,7 @@ public static class TaskAssertionSpecs
                 using var _ = new AssertionScope();
 
                 await action.Should().ThrowWithinAsync<InvalidOperationException>(
-                    100.Milliseconds(), "because we want to test the failure {0}", "message");
+                    100.Milliseconds(), "we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -501,7 +500,7 @@ public static class TaskAssertionSpecs
                 return taskFactory
                     .Awaiting(t => (Task)t.Task)
                     .Should(timer).ThrowWithinAsync<InvalidOperationException>(
-                        100.Ticks(), "because we want to test the failure {0}", "message");
+                        100.Ticks(), "we want to test the {0} message", "failure");
             };
 
             timer.Delay(101.Ticks());

--- a/Tests/AwesomeAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -35,12 +35,13 @@ public class TaskCompletionSourceAssertionSpecs
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () =>
+                subject.Should(timer).CompleteWithinAsync(1.Seconds(), "we want to test the {0} message", "failure");
             timer.Complete();
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Expected subject to complete within 1s because test testArg.");
+                .WithMessage("Expected subject to complete within 1s because we want to test the failure message.");
         }
 
         [Fact]
@@ -65,12 +66,14 @@ public class TaskCompletionSourceAssertionSpecs
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () =>
+                subject.Should(timer).NotCompleteWithinAsync(1.Seconds(), "we want to test the {0} message", "failure");
             subject.SetResult();
             timer.Complete();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*to not complete within*because test testArg*");
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("*to not complete within*because we want to test the failure message*");
         }
 
         [Fact]
@@ -127,11 +130,12 @@ public class TaskCompletionSourceAssertionSpecs
             TaskCompletionSource subject = null;
 
             // Act
-            Func<Task> action = () => subject.Should().NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () =>
+                subject.Should().NotCompleteWithinAsync(1.Seconds(), "we want to test the {0} message", "failure");
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Expected subject to not complete within 1s because test testArg, but found <null>.");
+                .WithMessage("Expected subject to not complete within 1s because*failure message, but found <null>.");
         }
 
         [Fact]
@@ -308,12 +312,13 @@ public class TaskCompletionSourceAssertionSpecs
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () =>
+                subject.Should(timer).CompleteWithinAsync(1.Seconds(), "we want to test the {0} message", "failure");
             timer.Complete();
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Expected subject to complete within 1s because test testArg.");
+                .WithMessage("Expected subject to complete within 1s because we want to test the failure message.");
         }
 
         [Fact]
@@ -338,13 +343,14 @@ public class TaskCompletionSourceAssertionSpecs
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () =>
+                subject.Should(timer).NotCompleteWithinAsync(1.Seconds(), "we want to test the {0} message", "failure");
             subject.SetResult(true);
             timer.Complete();
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect*to complete within*because test testArg*");
+                .WithMessage("Did not expect*to complete within*because we want to test the failure message*");
         }
 
         [Fact]
@@ -401,11 +407,12 @@ public class TaskCompletionSourceAssertionSpecs
             TaskCompletionSource<bool> subject = null;
 
             // Act
-            Func<Task> action = () => subject.Should().NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () =>
+                subject.Should().NotCompleteWithinAsync(1.Seconds(), "we want to test the {0} message", "failure");
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect subject to complete within 1s because test testArg, but found <null>.");
+                .WithMessage("Did not expect subject to complete within 1s because*failure message, but found <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -24,8 +24,8 @@ public static class TaskOfTAssertionSpecs
             Func<Task<int>> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().CompleteWithinAsync(
-                timeSpan, "because we want to test the failure {0}", "message");
+            Func<Task> testAction = () =>
+                action.Should().CompleteWithinAsync(timeSpan, "we want to test the {0} message", "failure");
 
             // Assert
             await testAction.Should().ThrowAsync<XunitException>()
@@ -44,8 +44,7 @@ public static class TaskOfTAssertionSpecs
             {
                 using var _ = new AssertionScope();
 
-                await action.Should().CompleteWithinAsync(
-                    timeSpan, "because we want to test the failure {0}", "message");
+                await action.Should().CompleteWithinAsync(timeSpan, "we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -294,7 +293,7 @@ public static class TaskOfTAssertionSpecs
             Func<Task> testAction = async () =>
             {
                 using var _ = new AssertionScope();
-                await action.Should().NotThrowAsync("because we want to test the failure {0}", "message");
+                await action.Should().NotThrowAsync("we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -428,8 +427,7 @@ public static class TaskOfTAssertionSpecs
             {
                 using var _ = new AssertionScope();
 
-                await action.Should().NotThrowAfterAsync(waitTime, pollInterval,
-                    "because we want to test the failure {0}", "message");
+                await action.Should().NotThrowAfterAsync(waitTime, pollInterval, "we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -500,11 +498,11 @@ public static class TaskOfTAssertionSpecs
 
             // Act
             Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                .NotThrowAfterAsync(waitTime, pollInterval, "we want to test the {0} message", "failure");
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+                .WithMessage("Did not expect any exceptions after 2s because we want to test the failure message*");
         }
 
         [Fact]
@@ -567,11 +565,11 @@ public static class TaskOfTAssertionSpecs
 
             // Act
             Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                .NotThrowAfterAsync(waitTime, pollInterval, "we want to test the {0} message", "failure");
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+                .WithMessage("Did not expect any exceptions after 2s because we want to test the failure message*");
         }
 
         [UIFact]

--- a/Tests/AwesomeAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
@@ -28,12 +28,11 @@ public class BufferedStreamAssertionSpecs
             using var stream = new BufferedStream(new MemoryStream(), 1);
 
             // Act
-            Action act = () =>
-                stream.Should().HaveBufferSize(10, "we want to test the failure {0}", "message");
+            Action act = () => stream.Should().HaveBufferSize(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the buffer size of stream to be 10 *failure message*, but it was 1.");
+                .WithMessage("Expected the buffer size of stream to be 10 because*failure message*, but it was 1.");
         }
 
         [Fact]
@@ -46,12 +45,12 @@ public class BufferedStreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().HaveBufferSize(10, "we want to test the failure {0}", "message");
+                stream.Should().HaveBufferSize(10, "we want to test the {0} message", "failure");
             };
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the buffer size of stream to be 10 *failure message*, but found a <null> reference.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the buffer size of stream to be 10 because*failure message*, but found a <null> reference.");
         }
     }
 
@@ -74,12 +73,11 @@ public class BufferedStreamAssertionSpecs
             using var stream = new BufferedStream(new MemoryStream(), 10);
 
             // Act
-            Action act = () =>
-                stream.Should().NotHaveBufferSize(10, "we want to test the failure {0}", "message");
+            Action act = () => stream.Should().NotHaveBufferSize(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but it was.");
+                .WithMessage("Expected the buffer size of stream not to be 10 because*failure message*, but it was.");
         }
 
         [Fact]
@@ -92,12 +90,12 @@ public class BufferedStreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().NotHaveBufferSize(10, "we want to test the failure {0}", "message");
+                stream.Should().NotHaveBufferSize(10, "we want to test the {0} message", "failure");
             };
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but found a <null> reference.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the buffer size of stream not to be 10 because*failure message*, but found a <null> reference.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Streams/StreamAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Streams/StreamAssertionSpecs.cs
@@ -27,12 +27,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Writable = false };
 
             // Act
-            Action act = () =>
-                stream.Should().BeWritable("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().BeWritable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be writable *failure message*, but it was not.");
+                .WithMessage("Expected stream to be writable because*failure message*, but it was not.");
         }
 
         [Fact]
@@ -45,12 +44,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().BeWritable("we want to test the failure {0}", "message");
+                stream.Should().BeWritable("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be writable *failure message*, but found a <null> reference.");
+                .WithMessage("Expected stream to be writable because*failure message*, but found a <null> reference.");
         }
     }
 
@@ -74,11 +73,11 @@ public class StreamAssertionSpecs
 
             // Act
             Action act = () =>
-                stream.Should().NotBeWritable("we want to test the failure {0}", "message");
+                stream.Should().NotBeWritable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be writable *failure message*, but it was.");
+                .WithMessage("Expected stream not to be writable because*failure message*, but it was.");
         }
 
         [Fact]
@@ -91,12 +90,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().NotBeWritable("we want to test the failure {0}", "message");
+                stream.Should().NotBeWritable("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be writable *failure message*, but found a <null> reference.");
+                .WithMessage("Expected stream not to be writable because*failure message*, but found a <null> reference.");
         }
     }
 
@@ -119,12 +118,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Seekable = false };
 
             // Act
-            Action act = () =>
-                stream.Should().BeSeekable("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().BeSeekable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be seekable *failure message*, but it was not.");
+                .WithMessage("Expected stream to be seekable because*failure message*, but it was not.");
         }
 
         [Fact]
@@ -137,12 +135,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().BeSeekable("we want to test the failure {0}", "message");
+                stream.Should().BeSeekable("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be seekable *failure message*, but found a <null> reference.");
+                .WithMessage("Expected stream to be seekable because*failure message*, but found a <null> reference.");
         }
     }
 
@@ -165,12 +163,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Seekable = true };
 
             // Act
-            Action act = () =>
-                stream.Should().NotBeSeekable("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().NotBeSeekable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be seekable *failure message*, but it was.");
+                .WithMessage("Expected stream not to be seekable because*failure message*, but it was.");
         }
 
         [Fact]
@@ -183,12 +180,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().NotBeSeekable("we want to test the failure {0}", "message");
+                stream.Should().NotBeSeekable("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be seekable *failure message*, but found a <null> reference.");
+                .WithMessage("Expected stream not to be seekable because*failure message*, but found a <null> reference.");
         }
     }
 
@@ -211,12 +208,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Readable = false };
 
             // Act
-            Action act = () =>
-                stream.Should().BeReadable("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().BeReadable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be readable *failure message*, but it was not.");
+                .WithMessage("Expected stream to be readable because*failure message*, but it was not.");
         }
 
         [Fact]
@@ -257,12 +253,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Readable = true };
 
             // Act
-            Action act = () =>
-                stream.Should().NotBeReadable("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().NotBeReadable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be readable *failure message*, but it was.");
+                .WithMessage("Expected stream not to be readable because*failure message*, but it was.");
         }
 
         [Fact]
@@ -275,12 +270,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().NotBeReadable("we want to test the failure {0}", "message");
+                stream.Should().NotBeReadable("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be readable *failure message*, but found a <null> reference.");
+                .WithMessage("Expected stream not to be readable because*failure message*, but found a <null> reference.");
         }
     }
 
@@ -304,11 +299,11 @@ public class StreamAssertionSpecs
 
             // Act
             Action act = () =>
-                stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+                stream.Should().HavePosition(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream to be 10* *failure message*, but it was 1*.");
+                .WithMessage("Expected the position of stream to be 10L because*failure message*, but it was 1*.");
         }
 
         [Fact]
@@ -321,12 +316,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+                stream.Should().HavePosition(10, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream to be 10* *failure message*, but found a <null> reference.");
+                .WithMessage("Expected the position of stream to be 10L because*failure message*, but found a <null> reference.");
         }
 
         [Theory]
@@ -337,12 +332,11 @@ public class StreamAssertionSpecs
             using var stream = new ExceptingStream(exception);
 
             // Act
-            Action act = () =>
-                stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+            Action act = () => stream.Should().HavePosition(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream to be 10* *failure message*, " +
+                .WithMessage("Expected the position of stream to be 10L because*failure message*, " +
                     "but it failed with*GetPositionExceptionMessage*");
         }
     }
@@ -367,11 +361,11 @@ public class StreamAssertionSpecs
 
             // Act
             Action act = () =>
-                stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+                stream.Should().NotHavePosition(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream not to be 10* *failure message*, but it was.");
+                .WithMessage("Expected the position of stream not to be 10L because*failure message*, but it was.");
         }
 
         [Fact]
@@ -384,12 +378,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+                stream.Should().NotHavePosition(10, "we want to test the {0} message", "failure");
             };
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream not to be 10* *failure message*, but found a <null> reference.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the position of stream not to be 10L because*failure message*, but found a <null> reference.");
         }
 
         [Theory]
@@ -401,11 +395,11 @@ public class StreamAssertionSpecs
 
             // Act
             Action act = () =>
-                stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+                stream.Should().NotHavePosition(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream not to be 10* *failure message*, " +
+                .WithMessage("Expected the position of stream not to be 10L because*failure message*, " +
                     "but it failed with*GetPositionExceptionMessage*");
         }
     }
@@ -437,12 +431,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Seekable = true, WithLength = 1 };
 
             // Act
-            Action act = () =>
-                stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+            Action act = () => stream.Should().HaveLength(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream to be 10* *failure message*, but it was 1*.");
+                .WithMessage("Expected the length of stream to be 10L because*failure message*, but it was 1*.");
         }
 
         [Fact]
@@ -455,12 +448,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+                stream.Should().HaveLength(10, "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream to be 10* *failure message*, but found a <null> reference.");
+                .WithMessage("Expected the length of stream to be 10L because*failure message*, but found a <null> reference.");
         }
 
         [Theory]
@@ -471,12 +464,11 @@ public class StreamAssertionSpecs
             using var stream = new ExceptingStream(exception);
 
             // Act
-            Action act = () =>
-                stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+            Action act = () => stream.Should().HaveLength(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream to be 10* *failure message*, " +
+                .WithMessage("Expected the length of stream to be 10L because*failure message*, " +
                     "but it failed with*GetLengthExceptionMessage*");
         }
     }
@@ -500,12 +492,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Seekable = true, WithLength = 10 };
 
             // Act
-            Action act = () =>
-                stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+            Action act = () => stream.Should().NotHaveLength(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream not to be 10* *failure message*, but it was.");
+                .WithMessage("Expected the length of stream not to be 10L because*failure message*, but it was.");
         }
 
         [Fact]
@@ -518,12 +509,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+                stream.Should().NotHaveLength(10, "we want to test the {0} message", "failure");
             };
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream not to be 10* *failure message*, but found a <null> reference.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the length of stream not to be 10L because*failure message*, but found a <null> reference.");
         }
 
         [Theory]
@@ -534,12 +525,11 @@ public class StreamAssertionSpecs
             using var stream = new ExceptingStream(exception);
 
             // Act
-            Action act = () =>
-                stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+            Action act = () => stream.Should().NotHaveLength(10, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream not to be 10* *failure message*, " +
+                .WithMessage("Expected the length of stream not to be 10L because*failure message*, " +
                     "but it failed with*GetLengthExceptionMessage*");
         }
     }
@@ -571,12 +561,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Readable = true, Writable = true };
 
             // Act
-            Action act = () =>
-                stream.Should().BeReadOnly("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().BeReadOnly("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be read-only *failure message*, but it was writable or not readable.");
+                .WithMessage("Expected stream to be read-only because*failure message*, but it was writable or not readable.");
         }
 
         [Fact]
@@ -586,12 +575,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Readable = false, Writable = false };
 
             // Act
-            Action act = () =>
-                stream.Should().BeReadOnly("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().BeReadOnly("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be read-only *failure message*, but it was writable or not readable.");
+                .WithMessage("Expected stream to be read-only because*failure message*, but it was writable or not readable.");
         }
 
         [Fact]
@@ -604,12 +592,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().BeReadOnly("we want to test the failure {0}", "message");
+                stream.Should().BeReadOnly("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be read-only *failure message*, but found a <null> reference.");
+                .WithMessage("Expected stream to be read-only because*failure message*, but found a <null> reference.");
         }
     }
 
@@ -642,12 +630,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Readable = true, Writable = false };
 
             // Act
-            Action act = () =>
-                stream.Should().NotBeReadOnly("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().NotBeReadOnly("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be read-only *failure message*, but it was.");
+                .WithMessage("Expected stream not to be read-only because*failure message*, but it was.");
         }
 
         [Fact]
@@ -660,12 +647,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().NotBeReadOnly("we want to test the failure {0}", "message");
+                stream.Should().NotBeReadOnly("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be read-only *failure message*, but found a <null> reference.");
+                .WithMessage("Expected stream not to be read-only because*failure message*, but found a <null> reference.");
         }
     }
 
@@ -688,12 +675,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Readable = true, Writable = true };
 
             // Act
-            Action act = () =>
-                stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().BeWriteOnly("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be write-only *failure message*, but it was readable or not writable.");
+                .WithMessage("Expected stream to be write-only because*failure message*, but it was readable or not writable.");
         }
 
         [Fact]
@@ -703,12 +689,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Readable = false, Writable = false };
 
             // Act
-            Action act = () =>
-                stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().BeWriteOnly("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be write-only *failure message*, but it was readable or not writable.");
+                .WithMessage("Expected stream to be write-only because*failure message*, but it was readable or not writable.");
         }
 
         [Fact]
@@ -721,12 +706,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+                stream.Should().BeWriteOnly("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be write-only *failure message*, but found a <null> reference.");
+                .WithMessage("Expected stream to be write-only because*failure message*, but found a <null> reference.");
         }
     }
 
@@ -759,12 +744,11 @@ public class StreamAssertionSpecs
             using var stream = new TestStream { Readable = false, Writable = true };
 
             // Act
-            Action act = () =>
-                stream.Should().NotBeWriteOnly("we want to test the failure {0}", "message");
+            Action act = () => stream.Should().NotBeWriteOnly("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be write-only *failure message*, but it was.");
+                .WithMessage("Expected stream not to be write-only because*failure message*, but it was.");
         }
 
         [Fact]
@@ -777,12 +761,12 @@ public class StreamAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                stream.Should().NotBeWriteOnly("we want to test the failure {0}", "message");
+                stream.Should().NotBeWriteOnly("we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be write-only *failure message*, but found a <null> reference.");
+                .WithMessage("Expected stream not to be write-only because*failure message*, but found a <null> reference.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
@@ -27,13 +27,12 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().Return(typeof(string), "we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().Return(typeof(string), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method IntMethod to be string because we want to test the " +
-                    "error message, but it is int.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the return type of method IntMethod to be string"
+                + " because we want to test the failure message, but it is int.");
         }
 
         [Fact]
@@ -43,13 +42,12 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("VoidMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().Return(typeof(string), "we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().Return(typeof(string), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method VoidMethod to be string because we want to test the " +
-                    "error message, but it is void.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the return type of method VoidMethod to be string"
+                + " because we want to test the failure message, but it is void.");
         }
 
         [Fact]
@@ -59,13 +57,11 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = null;
 
             // Act
-            Action act = () =>
-                methodInfo.Should().Return(typeof(string), "we want to test the failure {0}", "message");
+            Action act = () => methodInfo.Should().Return(typeof(string), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the return type of method to be string *failure message*, but methodInfo is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the return type of method to be string because*failure message*, but methodInfo is <null>.");
         }
 
         [Fact]
@@ -103,13 +99,11 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn(typeof(int), "we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().NotReturn(typeof(int), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of*IntMethod*not to be int*because we want to test the " +
-                    "error message, but it is.");
+                .WithMessage("Expected the return type of*IntMethod*not to be int*because*failure message, but it is.");
         }
 
         [Fact]
@@ -120,12 +114,12 @@ public class MethodBaseAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().NotReturn(typeof(string), "we want to test the failure {0}", "message");
+                methodInfo.Should().NotReturn(typeof(string), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected the return type of method not to be string *failure message*, but methodInfo is <null>.");
+                    "Expected the return type of method not to be string because*failure message, but methodInfo is <null>.");
         }
 
         [Fact]
@@ -163,13 +157,11 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().Return<string>("we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().Return<string>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method IntMethod to be string because we want to test the " +
-                    "error message, but it is int.");
+                .WithMessage("Expected the return type of method IntMethod to be string because*failure message, but it is int.");
         }
 
         [Fact]
@@ -180,11 +172,11 @@ public class MethodBaseAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().Return<string>("we want to test the failure {0}", "message");
+                methodInfo.Should().Return<string>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method to be string *failure message*, but methodInfo is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the return type of method to be string because*failure message*, but methodInfo is <null>.");
         }
     }
 
@@ -207,13 +199,12 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn<int>("we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().NotReturn<int>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of*IntMethod*not to be int*because we want to test the " +
-                    "error message, but it is.");
+                    "failure message, but it is.");
         }
 
         [Fact]
@@ -223,13 +214,11 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = null;
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotReturn<string>("we want to test the failure {0}", "message");
+            Action act = () => methodInfo.Should().NotReturn<string>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the return type of method not to be string *failure message*, but methodInfo is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the return type of method not to be string because*failure message*, but methodInfo is <null>.");
         }
     }
 
@@ -252,14 +241,11 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().ReturnVoid("because we want to test the error message {0}", "message");
+            Action act = () => methodInfo.Should().ReturnVoid("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the return type of method IntMethod to be void because we want to test the error message " +
-                    "message, but it is int.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the return type of method IntMethod to be void because*failure message, but it is int.");
         }
 
         [Fact]
@@ -270,11 +256,11 @@ public class MethodBaseAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().ReturnVoid("we want to test the failure {0}", "message");
+                methodInfo.Should().ReturnVoid("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method to be void *failure message*, but methodInfo is <null>.");
+                .WithMessage("Expected the return type of method to be void because*failure message*, but methodInfo is <null>.");
         }
     }
 
@@ -297,12 +283,11 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("VoidMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotReturnVoid("because we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().NotReturnVoid("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of*VoidMethod*not to be void*because we want to test the error message*");
+                .WithMessage("Expected the return type of*VoidMethod*not to be void because*failure message*");
         }
 
         [Fact]
@@ -312,12 +297,12 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = null;
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotReturnVoid("we want to test the failure {0}", "message");
+            Action act = () => methodInfo.Should().NotReturnVoid("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the return type of method not to be void *failure message*, but methodInfo is <null>.");
+                .WithMessage(
+                    "Expected the return type of method not to be void because*failure message*, but methodInfo is <null>.");
         }
     }
 
@@ -352,12 +337,12 @@ public class MethodBaseAssertionSpecs
             // Act
             Action act = () =>
                 methodInfo.Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the error {0}", "message");
+                    .HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method TestClass.PrivateMethod to be Protected because we want to test the error message" +
+                    "Expected method TestClass.PrivateMethod to be Protected because we want to test the failure message" +
                     ", but it is Private.");
         }
 
@@ -385,12 +370,12 @@ public class MethodBaseAssertionSpecs
             Action act = () =>
                 setMethod
                     .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+                    .HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method TestClass.set_ProtectedSetProperty to be Public because we want to test the error message" +
+                    "Expected method TestClass.set_ProtectedSetProperty to be Public because we want to test the failure message" +
                     ", but it is Protected.");
         }
 
@@ -418,13 +403,13 @@ public class MethodBaseAssertionSpecs
             Action act = () =>
                 getMethod
                     .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the error {0}", "message");
+                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method TestClass.get_PublicGetProperty to be Internal because we want to test the error message, but it" +
-                    " is Public.");
+                    "Expected method TestClass.get_PublicGetProperty to be Internal because we want to test the failure message," +
+                    " but it is Public.");
         }
 
         [Fact]
@@ -444,15 +429,13 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "because we want to test the" +
-                    " error {0}", "message");
+            Action act = () => methodInfo.Should().HaveAccessModifier(
+                CSharpAccessModifier.ProtectedInternal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method TestClass.InternalMethod to be ProtectedInternal because we want to test the error message, but" +
-                    " it is Internal.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method TestClass.InternalMethod to be ProtectedInternal because we want to test the failure message," +
+                " but it is Internal.");
         }
 
         [Fact]
@@ -473,13 +456,13 @@ public class MethodBaseAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
+                methodInfo.Should()
+                    .HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method TestClass.ProtectedInternalMethod to be Private because we want to test the error message, but it is " +
-                    "ProtectedInternal.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method TestClass.ProtectedInternalMethod to be Private because we want to test the failure message," +
+                " but it is ProtectedInternal.");
         }
 
         [Fact]
@@ -490,11 +473,11 @@ public class MethodBaseAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method to be Public *failure message*, but methodInfo is <null>.");
+                .WithMessage("Expected method to be Public because*failure message*, but methodInfo is <null>.");
         }
 
         [Fact]
@@ -544,11 +527,11 @@ public class MethodBaseAssertionSpecs
             // Act
             Action act = () =>
                 methodInfo.Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
+                    .NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method TestClass.PrivateMethod not to be Private*because we want to test the error message*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method TestClass.PrivateMethod not to be Private because*failure message*");
         }
 
         [Fact]
@@ -573,12 +556,11 @@ public class MethodBaseAssertionSpecs
             Action act = () =>
                 setMethod
                     .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the error {0}", "message");
+                    .NotHaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method TestClass.set_ProtectedSetProperty not to be Protected*because we want to test the error message*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method TestClass.set_ProtectedSetProperty not to be Protected because*failure message*");
         }
 
         [Fact]
@@ -611,14 +593,12 @@ public class MethodBaseAssertionSpecs
             MethodInfo getMethod = propertyInfo.GetMethod;
 
             // Act
-            Action act = () =>
-                getMethod
-                    .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+            Action act = () => getMethod.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method TestClass.get_PublicGetProperty not to be Public*because we want to test the error message*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method TestClass.get_PublicGetProperty not to be Public because*failure message*");
         }
 
         [Fact]
@@ -638,13 +618,12 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("InternalMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "because we want to test the" +
-                    " error {0}", "message");
+            Action act = () => methodInfo.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.Internal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method TestClass.InternalMethod not to be Internal*because we want to test the error message*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method TestClass.InternalMethod not to be Internal*because we want to test the failure message*");
         }
 
         [Fact]
@@ -664,14 +643,12 @@ public class MethodBaseAssertionSpecs
             MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("ProtectedInternalMethod");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the error {0}",
-                    "message");
+            Action act = () => methodInfo.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.ProtectedInternal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method TestClass.ProtectedInternalMethod not to be ProtectedInternal*because we want to test the error message*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method TestClass.ProtectedInternalMethod not to be ProtectedInternal because*failure message*");
         }
 
         [Fact]
@@ -683,11 +660,11 @@ public class MethodBaseAssertionSpecs
             // Act
             Action act = () =>
                 methodInfo.Should().NotHaveAccessModifier(
-                    CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+                    CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method not to be Public *failure message*, but methodInfo is <null>.");
+                .WithMessage("Expected method not to be Public because*failure message*, but methodInfo is <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
@@ -29,13 +29,12 @@ public class MethodInfoAssertionSpecs
             MethodInfo methodInfo = typeof(ClassWithNonVirtualPublicMethods).GetParameterlessMethod("PublicDoNothing");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().BeVirtual("we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().BeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected method void AwesomeAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing" +
-                    " to be virtual because we want to test the error message," +
+                    " to be virtual because we want to test the failure message," +
                     " but it is not virtual.");
         }
 
@@ -46,12 +45,11 @@ public class MethodInfoAssertionSpecs
             MethodInfo methodInfo = null;
 
             // Act
-            Action act = () =>
-                methodInfo.Should().BeVirtual("we want to test the failure {0}", "message");
+            Action act = () => methodInfo.Should().BeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method to be virtual *failure message*, but methodInfo is <null>.");
+                .WithMessage("Expected method to be virtual because*failure message*, but methodInfo is <null>.");
         }
     }
 
@@ -74,13 +72,12 @@ public class MethodInfoAssertionSpecs
             MethodInfo methodInfo = typeof(ClassWithAllMethodsVirtual).GetParameterlessMethod("PublicVirtualDoNothing");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotBeVirtual("we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().NotBeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected method *ClassWithAllMethodsVirtual.PublicVirtualDoNothing" +
-                    " not to be virtual because we want to test the error message," +
+                    " not to be virtual because we want to test the failure message," +
                     " but it is.");
         }
 
@@ -91,8 +88,7 @@ public class MethodInfoAssertionSpecs
             MethodInfo methodInfo = null;
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+            Action act = () => methodInfo.Should().NotBeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -243,13 +239,13 @@ public class MethodInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method void AwesomeAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                    "AwesomeAssertions*DummyMethodAttribute because we want to test the error message," +
+                    "AwesomeAssertions*DummyMethodAttribute because we want to test the failure message," +
                     " but that attribute was not found.");
         }
 
@@ -298,15 +294,14 @@ public class MethodInfoAssertionSpecs
                 typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
-            Action act = () =>
-                methodInfo.Should()
-                    .BeDecoratedWith<DummyMethodAttribute>(d => !d.Filter, "because we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should()
+                .BeDecoratedWith<DummyMethodAttribute>(d => !d.Filter, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method void AwesomeAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                    "AwesomeAssertions*DummyMethodAttribute because we want to test the error message," +
+                    "AwesomeAssertions*DummyMethodAttribute because we want to test the failure message," +
                     " but that attribute was not found.");
         }
 
@@ -357,12 +352,11 @@ public class MethodInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>("we want to test the failure {0}", "message");
+                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method to be decorated with *.DummyMethodAttribute *failure message*, but methodInfo is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method to be decorated with *.DummyMethodAttribute because*failure message*, but methodInfo is <null>.");
         }
     }
 
@@ -428,13 +422,13 @@ public class MethodInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method void AwesomeAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
-                    "AwesomeAssertions*DummyMethodAttribute because we want to test the error message," +
+                    "AwesomeAssertions*DummyMethodAttribute because we want to test the failure message," +
                     " but that attribute was found.");
         }
 
@@ -490,15 +484,14 @@ public class MethodInfoAssertionSpecs
                 typeof(ClassWithAllMethodsDecoratedWithDummyAttribute).GetParameterlessMethod("PublicDoNothing");
 
             // Act
-            Action act = () =>
-                methodInfo.Should()
-                    .NotBeDecoratedWith<DummyMethodAttribute>(d => d.Filter, "because we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should()
+                .NotBeDecoratedWith<DummyMethodAttribute>(d => d.Filter, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected method void AwesomeAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
-                    "AwesomeAssertions*DummyMethodAttribute because we want to test the error message," +
+                    "AwesomeAssertions*DummyMethodAttribute because we want to test the failure message," +
                     " but that attribute was found.");
         }
 
@@ -510,7 +503,7 @@ public class MethodInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>("we want to test the failure {0}", "message");
+                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -539,13 +532,12 @@ public class MethodInfoAssertionSpecs
             MethodInfo methodInfo = typeof(ClassWithNonAsyncMethods).GetParameterlessMethod("PublicDoNothing");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().BeAsync("we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().BeAsync("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected method Task AwesomeAssertions*ClassWithNonAsyncMethods.PublicDoNothing" +
-                    " to be async because we want to test the error message," +
+                    " to be async because we want to test the failure message," +
                     " but it is not.");
         }
 
@@ -556,8 +548,7 @@ public class MethodInfoAssertionSpecs
             MethodInfo methodInfo = null;
 
             // Act
-            Action act = () =>
-                methodInfo.Should().BeAsync("we want to test the failure {0}", "message");
+            Action act = () => methodInfo.Should().BeAsync("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -584,13 +575,12 @@ public class MethodInfoAssertionSpecs
             MethodInfo methodInfo = typeof(ClassWithAllMethodsAsync).GetParameterlessMethod("PublicAsyncDoNothing");
 
             // Act
-            Action act = () =>
-                methodInfo.Should().NotBeAsync("we want to test the error {0}", "message");
+            Action act = () => methodInfo.Should().NotBeAsync("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("*ClassWithAllMethodsAsync.PublicAsyncDoNothing*" +
-                    "not to be async*because we want to test the error message*");
+                    "not to be async*because we want to test the failure message*");
         }
 
         [Fact]
@@ -601,11 +591,11 @@ public class MethodInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                methodInfo.Should().NotBeAsync("we want to test the failure {0}", "message");
+                methodInfo.Should().NotBeAsync("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method not to be async *failure message*, but methodInfo is <null>.");
+                .WithMessage("Expected method not to be async because*failure message*, but methodInfo is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
@@ -42,13 +42,12 @@ public class MethodInfoSelectorAssertionSpecs
             var methodSelector = new MethodInfoSelector(typeof(ClassWithNonVirtualPublicMethods));
 
             // Act
-            Action act = () =>
-                methodSelector.Should().BeVirtual("we want to test the error {0}", "message");
+            Action act = () => methodSelector.Should().BeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods" +
-                    " to be virtual because we want to test the error message," +
+                    " to be virtual because we want to test the failure message," +
                     " but the following methods are not virtual:*" +
                     "Void AwesomeAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing*" +
                     "Void AwesomeAssertions*ClassWithNonVirtualPublicMethods.InternalDoNothing*" +
@@ -90,13 +89,12 @@ public class MethodInfoSelectorAssertionSpecs
             var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsVirtual));
 
             // Act
-            Action act = () =>
-                methodSelector.Should().NotBeVirtual("we want to test the error {0}", "message");
+            Action act = () => methodSelector.Should().NotBeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods" +
-                    " not to be virtual because we want to test the error message," +
+                    " not to be virtual because we want to test the failure message," +
                     " but the following methods are virtual" +
                     "*ClassWithAllMethodsVirtual.PublicVirtualDoNothing" +
                     "*ClassWithAllMethodsVirtual.InternalVirtualDoNothing" +
@@ -156,12 +154,12 @@ public class MethodInfoSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+                methodSelector.Should().BeDecoratedWith<DummyMethodAttribute>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to be decorated with" +
-                    " AwesomeAssertions*DummyMethodAttribute because we want to test the error message," +
+                    " AwesomeAssertions*DummyMethodAttribute because we want to test the failure message," +
                     " but the following methods are not:*" +
                     "Void AwesomeAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing*" +
                     "Void AwesomeAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing*" +
@@ -221,12 +219,12 @@ public class MethodInfoSelectorAssertionSpecs
 
             // Act
             Action act = () => methodSelector.Should()
-                    .NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+                .NotBeDecoratedWith<DummyMethodAttribute>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected all selected methods to not be decorated*DummyMethodAttribute*because we want to test the error message" +
+                    "Expected all selected methods to not be decorated*DummyMethodAttribute*because we want to test the failure message" +
                     "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing*" +
                     "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice*" +
                     "*ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing*" +
@@ -273,12 +271,12 @@ public class MethodInfoSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                methodSelector.Should().Be(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+                methodSelector.Should().Be(CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to be Public" +
-                    " because we want to test the error message" +
+                    " because we want to test the failure message" +
                     ", but the following methods are not:*" +
                     "Void AwesomeAssertions*.GenericClassWithNonPublicMethods<int>.PublicDoNothing*" +
                     "Void AwesomeAssertions*.GenericClassWithNonPublicMethods<int>.DoNothingWithParameter*" +
@@ -323,12 +321,12 @@ public class MethodInfoSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                methodSelector.Should().NotBe(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+                methodSelector.Should().NotBe(CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to not be Public" +
-                    " because we want to test the error message" +
+                    " because we want to test the failure message" +
                     ", but the following methods are:*" +
                     "Void AwesomeAssertions*ClassWithPublicMethods.PublicDoNothing*");
         }
@@ -353,13 +351,13 @@ public class MethodInfoSelectorAssertionSpecs
             var methodSelector = new MethodInfoSelector(typeof(ClassWithNonAsyncMethods));
 
             // Act
-            Action act = () => methodSelector.Should().BeAsync("we want to test the error {0}", "message");
+            Action act = () => methodSelector.Should().BeAsync("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     """
-                    Expected all selected methods to be async because we want to test the error message, but the following methods are not:
+                    Expected all selected methods to be async because we want to test the failure message, but the following methods are not:
                     Task AwesomeAssertions.Specs.Types.ClassWithNonAsyncMethods.PublicDoNothing
                     Task AwesomeAssertions.Specs.Types.ClassWithNonAsyncMethods.InternalDoNothing
                     Task AwesomeAssertions.Specs.Types.ClassWithNonAsyncMethods.ProtectedDoNothing
@@ -386,12 +384,12 @@ public class MethodInfoSelectorAssertionSpecs
             var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsAsync));
 
             // Act
-            Action act = () => methodSelector.Should().NotBeAsync("we want to test the error {0}", "message");
+            Action act = () => methodSelector.Should().NotBeAsync("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("""
-                    Expected all selected methods not to be async because we want to test the error message, but the following methods are:
+                    Expected all selected methods not to be async because we want to test the failure message, but the following methods are:
                     Task AwesomeAssertions.Specs.Types.ClassWithAllMethodsAsync.PublicAsyncDoNothing
                     Task AwesomeAssertions.Specs.Types.ClassWithAllMethodsAsync.InternalAsyncDoNothing
                     Task AwesomeAssertions.Specs.Types.ClassWithAllMethodsAsync.ProtectedAsyncDoNothing

--- a/Tests/AwesomeAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -30,13 +30,13 @@ public class PropertyInfoAssertionSpecs
                 typeof(ClassWithNonVirtualPublicProperties).GetRuntimeProperty("PublicNonVirtualProperty");
 
             // Act
-            Action act = () => propertyInfo.Should().BeVirtual("we want to test the error {0}", "message");
+            Action act = () => propertyInfo.Should().BeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected property ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty" +
-                    " to be virtual because we want to test the error message," +
+                    " to be virtual because we want to test the failure message," +
                     " but it is not.");
         }
 
@@ -47,12 +47,11 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = null;
 
             // Act
-            Action act = () =>
-                propertyInfo.Should().BeVirtual("we want to test the failure {0}", "message");
+            Action act = () => propertyInfo.Should().BeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to be virtual *failure message*, but propertyInfo is <null>.");
+                .WithMessage("Expected property to be virtual because*failure message*, but propertyInfo is <null>.");
         }
     }
 
@@ -76,14 +75,13 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesVirtual).GetRuntimeProperty("PublicVirtualProperty");
 
             // Act
-            Action act = () =>
-                propertyInfo.Should().NotBeVirtual("we want to test the error {0}", "message");
+            Action act = () => propertyInfo.Should().NotBeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected property *ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
-                    " not to be virtual because we want to test the error message," +
+                    " not to be virtual because we want to test the failure message," +
                     " but it is.");
         }
 
@@ -94,12 +92,11 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = null;
 
             // Act
-            Action act = () =>
-                propertyInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+            Action act = () => propertyInfo.Should().NotBeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected property not to be virtual *failure message*, but propertyInfo is <null>.");
+                .WithMessage("Expected property not to be virtual because*failure message*, but propertyInfo is <null>.");
         }
     }
 
@@ -137,7 +134,7 @@ public class PropertyInfoAssertionSpecs
         {
             // Arrange
             PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty(
-                    "PublicPropertyWithSameAttributeTwice");
+                "PublicPropertyWithSameAttributeTwice");
 
             // Act
             Action act = () =>
@@ -156,13 +153,13 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>("because we want to test the error message");
+                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected property " +
                     "ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
-                    "AwesomeAssertions*DummyPropertyAttribute because we want to test the error message, but that attribute was not found.");
+                    "AwesomeAssertions*DummyPropertyAttribute because we want to test the failure message, but that attribute was not found.");
         }
 
         [Fact]
@@ -176,13 +173,13 @@ public class PropertyInfoAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>(d => d.Value == "NotARealValue",
-                    "because we want to test the error {0}", "message");
+                    "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected property ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
-                    "AwesomeAssertions*DummyPropertyAttribute because we want to test the error message," +
+                    "AwesomeAssertions*DummyPropertyAttribute because we want to test the failure message," +
                     " but that attribute was not found.");
         }
 
@@ -205,12 +202,11 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>("we want to test the failure {0}", "message");
+                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected property to be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected property to be decorated with *.DummyPropertyAttribute because*failure message*, but propertyInfo is <null>.");
         }
 
         [Fact]
@@ -240,12 +236,11 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().NotBeDecoratedWith<DummyPropertyAttribute>("we want to test the failure {0}", "message");
+                propertyInfo.Should().NotBeDecoratedWith<DummyPropertyAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected property to not be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected property to not be decorated with *.DummyPropertyAttribute because*failure message*, but propertyInfo is <null>.");
         }
 
         [Fact]
@@ -273,13 +268,12 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("ReadOnlyProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().BeWritable("we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().BeWritable("we want to test the {0} message", "failure");
 
             // Assert
             action
-                .Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected property ClassWithProperties.ReadOnlyProperty to have a setter because we want to test the error message.");
+                .Should().Throw<XunitException>().WithMessage(
+                    "Expected property ClassWithProperties.ReadOnlyProperty to have a setter because*failure message.");
         }
 
         [Fact]
@@ -310,11 +304,11 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().BeWritable("we want to test the failure {0}", "message");
+                propertyInfo.Should().BeWritable("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to have a setter *failure message*, but propertyInfo is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected property to have a setter because*failure message*, but propertyInfo is <null>.");
         }
     }
 
@@ -347,13 +341,12 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().BeReadable("we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().BeReadable("we want to test the {0} message", "failure");
 
             // Assert
             action
-                .Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected property *WriteOnlyProperty to have a getter because we want to test the error message, but it does not.");
+                .Should().Throw<XunitException>().WithMessage(
+                    "Expected property *WriteOnlyProperty to have a getter because*failure message, but it does not.");
         }
 
         [Fact]
@@ -364,11 +357,11 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().BeReadable("we want to test the failure {0}", "message");
+                propertyInfo.Should().BeReadable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected property to have a getter *failure message*, but propertyInfo is <null>.");
+                .WithMessage("Expected property to have a getter because*failure message*, but propertyInfo is <null>.");
         }
     }
 
@@ -391,13 +384,13 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadWriteProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().NotBeWritable("we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().NotBeWritable("we want to test the {0} message", "failure");
 
             // Assert
             action
                 .Should().Throw<XunitException>()
                 .WithMessage("Did not expect property ClassWithReadOnlyProperties.ReadWriteProperty" +
-                    " to have a setter because we want to test the error message.");
+                    " to have a setter because we want to test the failure message.");
         }
 
         [Fact]
@@ -407,13 +400,13 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("WriteOnlyProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().NotBeWritable("we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().NotBeWritable("we want to test the {0} message", "failure");
 
             // Assert
             action
                 .Should().Throw<XunitException>()
                 .WithMessage("Did not expect property ClassWithProperties.WriteOnlyProperty" +
-                    " to have a setter because we want to test the error message.");
+                    " to have a setter because we want to test the failure message.");
         }
 
         [Fact]
@@ -424,11 +417,11 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().NotBeWritable("we want to test the failure {0}", "message");
+                propertyInfo.Should().NotBeWritable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo not to have a setter *failure message*, but it is <null>.");
+                .WithMessage("Expected propertyInfo not to have a setter because*failure message*, but it is <null>.");
         }
     }
 
@@ -441,13 +434,13 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadOnlyProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().NotBeReadable("we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().NotBeReadable("we want to test the {0} message", "failure");
 
             // Assert
             action
                 .Should().Throw<XunitException>()
                 .WithMessage("Did not expect property ClassWithReadOnlyProperties.ReadOnlyProperty " +
-                    "to have a getter because we want to test the error message.");
+                    "to have a getter because we want to test the failure message.");
         }
 
         [Fact]
@@ -457,13 +450,13 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithReadOnlyProperties).GetRuntimeProperty("ReadWriteProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().NotBeReadable("we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().NotBeReadable("we want to test the {0} message", "failure");
 
             // Assert
             action
                 .Should().Throw<XunitException>()
                 .WithMessage("Did not expect property ClassWithReadOnlyProperties.ReadWriteProperty " +
-                    "to have a getter because we want to test the error message.");
+                    "to have a getter because we want to test the failure message.");
         }
 
         [Fact]
@@ -484,11 +477,11 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().NotBeReadable("we want to test the failure {0}", "message");
+                propertyInfo.Should().NotBeReadable("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected property not to have a getter *failure message*, but propertyInfo is <null>.");
+                .WithMessage("Expected property not to have a getter because*failure message*, but propertyInfo is <null>.");
         }
     }
 
@@ -512,12 +505,12 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action action = () =>
-                propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+                propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected getter of property ClassWithProperties.WritePrivateReadProperty " +
-                    "to be Public because we want to test the error message, but it is Private*");
+                    "to be Public because we want to test the failure message, but it is Private*");
         }
 
         [Fact]
@@ -546,11 +539,11 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+                propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo to be Public *failure message*, but it is <null>.");
+                .WithMessage("Expected propertyInfo to be Public because*failure message*, but it is <null>.");
         }
 
         [Fact]
@@ -589,12 +582,12 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action action = () =>
-                propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+                propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected setter of property ClassWithProperties.ReadPrivateWriteProperty " +
-                    "to be Public because we want to test the error message, but it is Private.");
+                    "to be Public because we want to test the failure message, but it is Private.");
         }
 
         [Fact]
@@ -623,11 +616,11 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+                propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected propertyInfo to be Public *failure message*, but it is <null>.");
+                .WithMessage("Expected propertyInfo to be Public because*failure message*, but it is <null>.");
         }
 
         [Fact]
@@ -665,12 +658,12 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().Return(typeof(int), "we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().Return(typeof(int), "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected type of property ClassWithProperties.StringProperty" +
-                    " to be int because we want to test the error message, but it is string.");
+                    " to be int because we want to test the failure message, but it is string.");
         }
 
         [Fact]
@@ -681,11 +674,11 @@ public class PropertyInfoAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfo.Should().Return(typeof(int), "we want to test the failure {0}", "message");
+                propertyInfo.Should().Return(typeof(int), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type of property to be int *failure message*, but propertyInfo is <null>.");
+                .WithMessage("Expected type of property to be int because*failure message*, but propertyInfo is <null>.");
         }
 
         [Fact]
@@ -723,12 +716,11 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().Return<int>("we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().Return<int>("we want to test the {0} message", "failure");
 
             // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected type of property ClassWithProperties.StringProperty to be int because we want to test the error " +
-                    "message, but it is string.");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected type of property ClassWithProperties.StringProperty to be int because*failure message, but it is string.");
         }
     }
 
@@ -751,12 +743,12 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().NotReturn(typeof(string), "we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().NotReturn(typeof(string), "we want to test the {0} message", "failure");
 
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected type of property ClassWithProperties.StringProperty" +
-                    " not to be string because we want to test the error message, but it is.");
+                    " not to be string because we want to test the failure message, but it is.");
         }
 
         [Fact]
@@ -766,12 +758,11 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = null;
 
             // Act
-            Action act = () =>
-                propertyInfo.Should().NotReturn(typeof(int), "we want to test the failure {0}", "message");
+            Action act = () => propertyInfo.Should().NotReturn(typeof(int), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type of property not to be int *failure message*, but propertyInfo is <null>.");
+                .WithMessage("Expected type of property not to be int because*failure message*, but propertyInfo is <null>.");
         }
 
         [Fact]
@@ -809,12 +800,11 @@ public class PropertyInfoAssertionSpecs
             PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
 
             // Act
-            Action action = () => propertyInfo.Should().NotReturn<string>("we want to test the error {0}", "message");
+            Action action = () => propertyInfo.Should().NotReturn<string>("we want to test the {0} message", "failure");
 
             // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected type of property ClassWithProperties.StringProperty not to be*String*because we want to test the error " +
-                    "message, but it is.");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected type of property ClassWithProperties.StringProperty not to be*String*because*failure message, but it is.");
         }
     }
 

--- a/Tests/AwesomeAssertions.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
@@ -43,12 +43,12 @@ public class PropertyInfoSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfoSelector.Should().BeVirtual("we want to test the error {0}", "message");
+                propertyInfoSelector.Should().BeVirtual("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected properties" +
-                    " to be virtual because we want to test the error message," +
+                    " to be virtual because we want to test the failure message," +
                     " but the following properties are not virtual:*" +
                     "ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty*" +
                     "ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty*" +
@@ -91,16 +91,16 @@ public class PropertyInfoSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                propertyInfoSelector.Should().NotBeVirtual("we want to test the error {0}", "message");
+                propertyInfoSelector.Should().NotBeVirtual("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected properties" +
-                    " not to be virtual because we want to test the error message," +
-                    " but the following properties are virtual*" +
-                    "*ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
-                    "*ClassWithAllPropertiesVirtual.InternalVirtualProperty" +
-                    "*ClassWithAllPropertiesVirtual.ProtectedVirtualProperty");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all selected properties" +
+                " not to be virtual because we want to test the failure message," +
+                " but the following properties are virtual*" +
+                "*ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
+                "*ClassWithAllPropertiesVirtual.InternalVirtualProperty" +
+                "*ClassWithAllPropertiesVirtual.ProtectedVirtualProperty");
         }
     }
 
@@ -141,16 +141,16 @@ public class PropertyInfoSelectorAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfoSelector.Should()
-                    .BeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
+                    .BeDecoratedWith<DummyPropertyAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected properties to be decorated with" +
-                    " AwesomeAssertions*DummyPropertyAttribute because we want to test the error message," +
-                    " but the following properties are not:*" +
-                    "ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty*" +
-                    "ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty*" +
-                    "ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all selected properties to be decorated with" +
+                " AwesomeAssertions*DummyPropertyAttribute because we want to test the failure message," +
+                " but the following properties are not:*" +
+                "ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty*" +
+                "ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty*" +
+                "ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
         }
     }
 
@@ -191,16 +191,16 @@ public class PropertyInfoSelectorAssertionSpecs
             // Act
             Action act = () =>
                 propertyInfoSelector.Should()
-                    .NotBeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
+                    .NotBeDecoratedWith<DummyPropertyAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all selected properties not to be decorated*" +
-                    "DummyPropertyAttribute*" +
-                    "because we want to test the error message*" +
-                    "ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicProperty*" +
-                    "ClassWithAllPropertiesDecoratedWithDummyAttribute.InternalProperty*" +
-                    "ClassWithAllPropertiesDecoratedWithDummyAttribute.ProtectedProperty*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all selected properties not to be decorated*" +
+                "DummyPropertyAttribute*" +
+                "because we want to test the failure message*" +
+                "ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicProperty*" +
+                "ClassWithAllPropertiesDecoratedWithDummyAttribute.InternalProperty*" +
+                "ClassWithAllPropertiesDecoratedWithDummyAttribute.ProtectedProperty*");
         }
     }
 
@@ -213,13 +213,12 @@ public class PropertyInfoSelectorAssertionSpecs
             var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithReadOnlyProperties));
 
             // Act
-            Action action = () => propertyInfoSelector.Should().BeWritable("because we want to test the error {0}", "message");
+            Action action = () => propertyInfoSelector.Should().BeWritable("we want to test the {0} message", "failure");
 
             // Assert
             action
-                .Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all selected properties to have a setter because we want to test the error message, " +
+                .Should().Throw<XunitException>().WithMessage(
+                    "Expected all selected properties to have a setter because we want to test the failure message, " +
                     "but the following properties do not:*" +
                     "ClassWithReadOnlyProperties.ReadOnlyProperty*" +
                     "ClassWithReadOnlyProperties.ReadOnlyProperty2");
@@ -245,13 +244,12 @@ public class PropertyInfoSelectorAssertionSpecs
             var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithWritableProperties));
 
             // Act
-            Action action = () => propertyInfoSelector.Should().NotBeWritable("because we want to test the error {0}", "message");
+            Action action = () => propertyInfoSelector.Should().NotBeWritable("we want to test the {0} message", "failure");
 
             // Assert
             action
-                .Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected selected properties to not have a setter because we want to test the error message, " +
+                .Should().Throw<XunitException>().WithMessage(
+                    "Expected selected properties to not have a setter because we want to test the failure message, " +
                     "but the following properties do:*" +
                     "ClassWithWritableProperties.ReadWriteProperty*" +
                     "ClassWithWritableProperties.ReadWriteProperty2");
@@ -291,14 +289,13 @@ public class PropertyInfoSelectorAssertionSpecs
             var propertyInfoSelector = new PropertyInfoSelector(typeof(GenericClassWithOnlyReadOnlyProperties<object>));
 
             // Act
-            Action action = () => propertyInfoSelector.Should().BeWritable("because we want to test the error {0}", "message");
+            Action action = () => propertyInfoSelector.Should().BeWritable("we want to test the {0} message", "failure");
 
             // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all selected properties to have a setter because we want to test the error message, " +
-                    "but the following properties do not:*" +
-                    "GenericClassWithOnlyReadOnlyProperties<object>.ReadOnlyProperty");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected all selected properties to have a setter because we want to test the failure message, " +
+                "but the following properties do not:*" +
+                "GenericClassWithOnlyReadOnlyProperties<object>.ReadOnlyProperty");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.Be.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.Be.cs
@@ -32,12 +32,11 @@ public partial class TypeAssertionSpecs
             Type differentType = typeof(ClassWithoutAttribute);
 
             // Act
-            Action act = () =>
-                type.Should().Be(differentType, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().Be(differentType, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be *.ClassWithoutAttribute *failure message*, but found *.ClassWithAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be *.ClassWithoutAttribute because*failure message*, but found *.ClassWithAttribute.");
         }
 
         [Fact]
@@ -60,11 +59,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                nullType.Should().Be(someType, "we want to test the failure {0}", "message");
+                nullType.Should().Be(someType, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be *.ClassWithAttribute *failure message*, but found <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be *.ClassWithAttribute because*failure message*, but found <null>.");
         }
 
         [Fact]
@@ -76,11 +75,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                someType.Should().Be(nullType, "we want to test the failure {0}", "message");
+                someType.Should().Be(nullType, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be <null> *failure message*, but found *.ClassWithAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be <null> because*failure message*, but found *.ClassWithAttribute.");
         }
 
         [Fact]
@@ -98,12 +97,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                typeFromThisAssembly.Should().Be(typeFromOtherAssembly, "we want to test the failure {0}", "message");
+                typeFromThisAssembly.Should().Be(typeFromOtherAssembly, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to be [AssemblyB.ClassC, AssemblyB*] *failure message*, but found [AssemblyB.ClassC, AwesomeAssertions.Specs*].");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be [AssemblyB.ClassC, AssemblyB*] because*failure message*, but found [AssemblyB.ClassC, AwesomeAssertions.Specs*].");
         }
 
         [Fact]
@@ -124,11 +122,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().Be<ClassWithoutAttribute>("we want to test the failure {0}", "message");
+                type.Should().Be<ClassWithoutAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be *.ClassWithoutAttribute *failure message*, but found *.ClassWithAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be *.ClassWithoutAttribute because*failure message*, but found *.ClassWithAttribute.");
         }
     }
 
@@ -153,12 +151,11 @@ public partial class TypeAssertionSpecs
             Type sameType = typeof(ClassWithAttribute);
 
             // Act
-            Action act = () =>
-                type.Should().NotBe(sameType, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotBe(sameType, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be [*.ClassWithAttribute*] *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type not to be [*.ClassWithAttribute*] because*failure message*, but it is.");
         }
 
         [Fact]
@@ -194,11 +191,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBe<ClassWithAttribute>("we want to test the failure {0}", "message");
+                type.Should().NotBe<ClassWithAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be [*.ClassWithAttribute*] *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type not to be [*.ClassWithAttribute*] because*failure message*, but it is.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeAbstract.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeAbstract.cs
@@ -39,11 +39,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithoutMembers);
 
             // Act
-            Action act = () => type.Should().BeAbstract("we want to test the failure {0}", "message");
+            Action act = () => type.Should().BeAbstract("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithoutMembers to be abstract *failure message*.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithoutMembers to be abstract because*failure message*.");
         }
 
         [Theory]
@@ -68,11 +68,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().BeAbstract("we want to test the failure {0}", "message");
+                type.Should().BeAbstract("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be abstract *failure message*, but type is <null>.");
+                .WithMessage("Expected type to be abstract because*failure message*, but type is <null>.");
         }
     }
 
@@ -109,11 +109,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(Abstract);
 
             // Act
-            Action act = () => type.Should().NotBeAbstract("we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotBeAbstract("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.Abstract not to be abstract *failure message*.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.Abstract not to be abstract because*failure message*.");
         }
 
         [Theory]
@@ -138,11 +138,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeAbstract("we want to test the failure {0}", "message");
+                type.Should().NotBeAbstract("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be abstract *failure message*, but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type not to be abstract because*failure message*, but type is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeAssignableTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeAssignableTo.cs
@@ -38,13 +38,12 @@ public partial class TypeAssertionSpecs
         {
             // Arrange
             Type someType = typeof(DummyImplementingClass);
-            Action act = () => someType.Should().BeAssignableTo<DateTime>("we want to test the failure {0}", "message");
+            Action act = () => someType.Should().BeAssignableTo<DateTime>("we want to test the {0} message", "failure");
 
             // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected someType *.DummyImplementingClass to be assignable to *.DateTime *failure message*" +
-                    ", but it is not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected someType *.DummyImplementingClass to be assignable to *.DateTime because*failure message*" +
+                ", but it is not.");
         }
 
         [Fact]
@@ -76,11 +75,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                someType.Should().BeAssignableTo(typeof(DateTime), "we want to test the failure {0}", "message");
+                someType.Should().BeAssignableTo(typeof(DateTime), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*.DummyImplementingClass to be assignable to *.DateTime *failure message*");
+                .WithMessage("*.DummyImplementingClass to be assignable to *.DateTime because*failure message*");
         }
 
         [Fact]
@@ -112,13 +111,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                someType.Should().BeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+                someType.Should().BeAssignableTo(typeof(IDummyInterface<>), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected someType *.IDummyInterface to be assignable to *.IDummyInterface<T> *failure message*" +
-                    ", but it is not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected someType *.IDummyInterface to be assignable to *.IDummyInterface<T> because*failure message*" +
+                ", but it is not.");
         }
 
         [Fact]
@@ -128,11 +126,11 @@ public partial class TypeAssertionSpecs
             Type someType = typeof(ClassWithAttribute);
 
             Action act = () =>
-                someType.Should().BeAssignableTo(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
+                someType.Should().BeAssignableTo(typeof(DummyBaseType<>), "we want to test the {0} message", "failure");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*.ClassWithAttribute to be assignable to *.DummyBaseType* *failure message*");
+                .WithMessage("*.ClassWithAttribute to be assignable to *.DummyBaseType* because*failure message*");
         }
 
         [Fact]
@@ -168,12 +166,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeAssignableTo<DummyImplementingClass>("we want to test the failure {0}", "message");
+                type.Should().NotBeAssignableTo<DummyImplementingClass>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass because*failure message*");
         }
 
         [Fact]
@@ -184,13 +181,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeAssignableTo<DummyBaseClass>("we want to test the failure {0}", "message");
+                type.Should().NotBeAssignableTo<DummyBaseClass>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*" +
-                    ", but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass because*failure message*" +
+                ", but it is.");
         }
 
         [Fact]
@@ -201,12 +197,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeAssignableTo<IDisposable>("we want to test the failure {0}", "message");
+                type.Should().NotBeAssignableTo<IDisposable>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable because*failure message*, but it is.");
         }
 
         [Fact]
@@ -224,13 +219,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "we want to test the failure {0}", "message");
+                type.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "we want to test the {0} message", "failure");
 
             // Act / Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*" +
-                    ", but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass because*failure message*" +
+                ", but it is.");
         }
 
         [Fact]
@@ -241,13 +235,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
+                type.Should().NotBeAssignableTo(typeof(DummyBaseClass), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*" +
-                    ", but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass because*failure message*" +
+                ", but it is.");
         }
 
         [Fact]
@@ -258,12 +251,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(IDisposable), "we want to test the failure {0}", "message");
+                type.Should().NotBeAssignableTo(typeof(IDisposable), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable because*failure message*, but it is.");
         }
 
         [Fact]
@@ -295,13 +287,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+                type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface<T> *failure message*" +
-                    ", but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface<T> because*failure message*" +
+                ", but it is.");
         }
 
         [Fact]
@@ -312,13 +303,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+                type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface<T> *failure message*" +
-                    ", but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface<T> because*failure message*" +
+                ", but it is.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWith.cs
@@ -40,13 +40,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                typeWithoutAttribute.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+                typeWithoutAttribute.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithoutAttribute to be decorated with *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was not found.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithoutAttribute to be decorated with *.DummyClassAttribute because*failure message*" +
+                ", but the attribute was not found.");
         }
 
         [Fact]
@@ -126,13 +125,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute* *failure message*" +
-                    ", but the attribute was found.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute because*failure message*" +
+                ", but the attribute was found.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWithOrInherit.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWithOrInherit.cs
@@ -40,13 +40,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+                type.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithoutAttribute to be decorated with or inherit *.DummyClassAttribute " +
-                    "*failure message*, but the attribute was not found.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithoutAttribute to be decorated with or inherit *.DummyClassAttribute because*failure message*" +
+                ", but the attribute was not found.");
         }
 
         [Fact]
@@ -127,13 +126,12 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 typeWithAttribute.Should()
-                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute " +
-                    "*failure message* attribute was found.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute because*failure message*" +
+                ", but the attribute was found.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeDerivedFrom.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeDerivedFrom.cs
@@ -30,12 +30,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().BeDerivedFrom(typeof(ClassWithMembers), "we want to test the failure {0}", "message");
+                type.Should().BeDerivedFrom(typeof(ClassWithMembers), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyBaseClass to be derived from *.ClassWithMembers *failure message*, but it is not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.DummyBaseClass to be derived from *.ClassWithMembers because*failure message*" +
+                ", but it is not.");
         }
 
         [Fact]
@@ -46,13 +46,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().BeDerivedFrom(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+                type.Should().BeDerivedFrom(typeof(IDummyInterface), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatImplementsInterface to be derived from *.IDummyInterface *failure message*" +
-                    ", but *.IDummyInterface is an interface.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassThatImplementsInterface to be derived from *.IDummyInterface because*failure message*" +
+                ", but *.IDummyInterface is an interface.");
         }
 
         [Fact]
@@ -83,12 +82,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().BeDerivedFrom(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
+                type.Should().BeDerivedFrom(typeof(DummyBaseType<>), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassWithMembers to be derived from *.DummyBaseType<T>* *failure message*, but it is not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithMembers to be derived from *.DummyBaseType<T> because*failure message*" +
+                ", but it is not.");
         }
 
         [Fact]
@@ -140,13 +139,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
+                type.Should().NotBeDerivedFrom(typeof(DummyBaseClass), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyImplementingClass not to be derived from *.DummyBaseClass *failure message*" +
-                    ", but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.DummyImplementingClass not to be derived from *.DummyBaseClass because*failure message*" +
+                ", but it is.");
         }
 
         [Fact]
@@ -157,13 +155,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+                type.Should().NotBeDerivedFrom(typeof(IDummyInterface), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatImplementsInterface not to be derived from *.IDummyInterface *failure message*" +
-                    ", but *.IDummyInterface is an interface.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassThatImplementsInterface not to be derived from *.IDummyInterface because*failure message*" +
+                ", but *.IDummyInterface is an interface.");
         }
 
         [Fact]
@@ -194,13 +191,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
+                type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.DummyBaseType<*.ClassWithGenericBaseType> not to be derived from *.DummyBaseType<T> " +
-                    "*failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.DummyBaseType<*.ClassWithGenericBaseType> not to be derived from *.DummyBaseType<T> " +
+                "because*failure message*, but it is.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeSealed.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeSealed.cs
@@ -39,11 +39,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithoutMembers);
 
             // Act
-            Action act = () => type.Should().BeSealed("we want to test the failure {0}", "message");
+            Action act = () => type.Should().BeSealed("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithoutMembers to be sealed *failure message*.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithoutMembers to be sealed because*failure message*.");
         }
 
         [Theory]
@@ -67,12 +67,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().BeSealed("we want to test the failure {0}", "message");
+            Action act = () => type.Should().BeSealed("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be sealed *failure message*, but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be sealed because*failure message*, but type is <null>.");
         }
     }
 
@@ -109,11 +108,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(Sealed);
 
             // Act
-            Action act = () => type.Should().NotBeSealed("we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotBeSealed("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.Sealed not to be sealed *failure message*.");
+                .WithMessage("Expected type *.Sealed not to be sealed because*failure message*.");
         }
 
         [Theory]
@@ -137,12 +136,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotBeSealed("we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotBeSealed("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be sealed *failure message*, but type is <null>.");
+                .WithMessage("Expected type not to be sealed because*failure message*, but type is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeStatic.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.BeStatic.cs
@@ -39,11 +39,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithoutMembers);
 
             // Act
-            Action act = () => type.Should().BeStatic("we want to test the failure {0}", "message");
+            Action act = () => type.Should().BeStatic("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithoutMembers to be static *failure message*.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassWithoutMembers to be static because*failure message*.");
         }
 
         [Theory]
@@ -67,12 +67,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().BeStatic("we want to test the failure {0}", "message");
+            Action act = () => type.Should().BeStatic("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be static *failure message*, but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be static because*failure message*, but type is <null>.");
         }
     }
 
@@ -109,11 +108,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(Static);
 
             // Act
-            Action act = () => type.Should().NotBeStatic("we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotBeStatic("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.Static not to be static *failure message*.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.Static not to be static because*failure message*.");
         }
 
         [Theory]
@@ -137,12 +136,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotBeStatic("we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotBeStatic("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be static *failure message*, but type is <null>.");
+                .WithMessage("Expected type not to be static because*failure message*, but type is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveAccessModifier.cs
@@ -33,11 +33,12 @@ public partial class TypeAssertionSpecs
             Action act = () =>
                 type
                     .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
+                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.IPublicInterface to be Internal *failure message*, but it is Public.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.IPublicInterface to be Internal because*failure message*"
+                + ", but it is Public.");
         }
 
         [Fact]
@@ -89,11 +90,12 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+                    CSharpAccessModifier.ProtectedInternal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.InternalClass to be ProtectedInternal because*failure message*"
+                + ", but it is Internal.");
         }
 
         [Fact]
@@ -105,11 +107,12 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveAccessModifier(
-                    CSharpAccessModifier.Private, "we want to test the failure {0}", "message");
+                    CSharpAccessModifier.Private, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.GenericClass<int> to be Private *failure message*, but it is Internal.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.GenericClass<int> to be Private because*failure message*"
+                + ", but it is Internal.");
         }
 
         [Fact]
@@ -121,12 +124,12 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+                    CSharpAccessModifier.ProtectedInternal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type AwesomeAssertions.Specs.Types.IInternalInterface to be ProtectedInternal *failure message*, but it is Internal.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.IInternalInterface to be ProtectedInternal because*failure message*"
+                + ", but it is Internal.");
         }
 
         [Fact]
@@ -138,11 +141,12 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+                    CSharpAccessModifier.ProtectedInternal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.InternalStruct to be ProtectedInternal *failure message*, but it is Internal.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.InternalStruct to be ProtectedInternal because*failure message*"
+                + ", but it is Internal.");
         }
 
         [Fact]
@@ -154,11 +158,12 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+                    CSharpAccessModifier.ProtectedInternal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.InternalEnum to be ProtectedInternal *failure message*, but it is Internal.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.InternalEnum to be ProtectedInternal because*failure message*"
+                + ", but it is Internal.");
         }
 
         [Fact]
@@ -179,12 +184,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the failure {0}",
-                    "message");
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.Nested+PrivateClass to be Protected *failure message*, but it is Private.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.Nested+PrivateClass to be Protected because*failure message*"
+                + ", but it is Private.");
         }
 
         [Fact]
@@ -209,7 +214,8 @@ public partial class TypeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.Nested+ProtectedEnum to be Public, but it is Protected.");
+                .WithMessage(
+                    "Expected type AwesomeAssertions.Specs.Types.Nested+ProtectedEnum to be Public, but it is Protected.");
         }
 
         [Fact]
@@ -229,14 +235,13 @@ public partial class TypeAssertionSpecs
             Type type = typeof(Nested.IPublicInterface);
 
             // Act
-            Action act = () =>
-                type
-                    .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveAccessModifier(
+                CSharpAccessModifier.Internal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.Nested+IPublicInterface to be Internal *failure message*, but it is Public.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.Nested+IPublicInterface to be Internal because*failure message*"
+                + ", but it is Public.");
         }
 
         [Fact]
@@ -256,13 +261,13 @@ public partial class TypeAssertionSpecs
             Type type = typeof(Nested.InternalClass);
 
             // Act
-            Action act = () =>
-                type.Should().HaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveAccessModifier(
+                CSharpAccessModifier.ProtectedInternal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.Nested+InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.Nested+InternalClass to be ProtectedInternal because*failure message*"
+                + ", but it is Internal.");
         }
 
         [Fact]
@@ -283,12 +288,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}", "message");
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type AwesomeAssertions.Specs.Types.Nested+IProtectedInternalInterface to be Private *failure message*, but it is ProtectedInternal.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.Nested+IProtectedInternalInterface to be Private because*failure message*"
+                + ", but it is ProtectedInternal.");
         }
 
         [Fact]
@@ -299,11 +304,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to be Public *failure message*, but type is <null>.");
+                .WithMessage("Expected type to be Public because*failure message*, but type is <null>.");
         }
 
         [Fact]
@@ -341,14 +346,13 @@ public partial class TypeAssertionSpecs
             Type type = typeof(IPublicInterface);
 
             // Act
-            Action act = () =>
-                type
-                    .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.IPublicInterface not to be Public *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.IPublicInterface not to be Public because*failure message*"
+                + ", but it is.");
         }
 
         [Fact]
@@ -368,13 +372,12 @@ public partial class TypeAssertionSpecs
             Type type = typeof(InternalClass);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}",
-                    "message");
+            Action act = () => type.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.Internal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.InternalClass not to be Internal *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.InternalClass not to be Internal because*failure message*, but it is.");
         }
 
         [Fact]
@@ -394,13 +397,13 @@ public partial class TypeAssertionSpecs
             Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}",
-                    "message");
+            Action act = () => type.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.Private, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.Nested+PrivateClass not to be Private *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.Nested+PrivateClass not to be Private because*failure message*"
+                + ", but it is.");
         }
 
         [Fact]
@@ -445,14 +448,13 @@ public partial class TypeAssertionSpecs
             Type type = typeof(Nested.IPublicInterface);
 
             // Act
-            Action act = () =>
-                type
-                    .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.Nested+IPublicInterface not to be Public *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.Nested+IPublicInterface not to be Public because*failure message*"
+                + ", but it is.");
         }
 
         [Fact]
@@ -472,13 +474,13 @@ public partial class TypeAssertionSpecs
             Type type = typeof(Nested.InternalClass);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}",
-                    "message");
+            Action act = () => type.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.Internal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type AwesomeAssertions.Specs.Types.Nested+InternalClass not to be Internal *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.Nested+InternalClass not to be Internal because*failure message*"
+                + ", but it is.");
         }
 
         [Fact]
@@ -498,14 +500,13 @@ public partial class TypeAssertionSpecs
             Type type = typeof(Nested.IProtectedInternalInterface);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(
-                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.ProtectedInternal, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type AwesomeAssertions.Specs.Types.Nested+IProtectedInternalInterface not to be ProtectedInternal *failure message*, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type AwesomeAssertions.Specs.Types.Nested+IProtectedInternalInterface not to be ProtectedInternal"
+                + " because*failure message*, but it is.");
         }
 
         [Fact]
@@ -515,13 +516,12 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}",
-                    "message");
+            Action act = () => type.Should().NotHaveAccessModifier(
+                CSharpAccessModifier.Public, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be Public *failure message*, but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type not to be Public because*failure message*, but type is <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveConstructor.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveConstructor.cs
@@ -32,13 +32,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveConstructor([typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
+                type.Should().HaveConstructor([typeof(int), typeof(Type)], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor *ClassWithNoMembers(int, System.Type) to exist *failure message*" +
-                    ", but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected constructor *ClassWithNoMembers(int, System.Type) to exist because*failure message*" +
+                ", but it does not.");
         }
 
         [Fact]
@@ -48,12 +47,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveConstructor([typeof(string)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveConstructor([typeof(string)], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor type(string) to exist *failure message*, but type is <null>.");
+                .WithMessage("Expected constructor type(string) to exist because*failure message*, but type is <null>.");
         }
 
         [Fact]
@@ -92,13 +90,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithMembers);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveConstructor([typeof(string)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveConstructor([typeof(string)], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor *.ClassWithMembers(string) not to exist *failure message*, but it does.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected constructor *.ClassWithMembers(string) not to exist because*failure message*, but it does.");
         }
 
         [Fact]
@@ -108,12 +104,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveConstructor([typeof(string)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveConstructor([typeof(string)], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor type(string) not to exist *failure message*, but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected constructor type(string) not to exist because*failure message*, but type is <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveDefaultConstructor.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveDefaultConstructor.cs
@@ -58,14 +58,12 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithCctorAndNonDefaultConstructor);
 
             // Act
-            Action act = () =>
-                type.Should().HaveDefaultConstructor("we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveDefaultConstructor("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor *ClassWithCctorAndNonDefaultConstructor() to exist *failure message*" +
-                    ", but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected constructor *ClassWithCctorAndNonDefaultConstructor() to exist because*failure message*" +
+                ", but it does not.");
         }
 
         [Fact]
@@ -75,12 +73,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveDefaultConstructor("we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveDefaultConstructor("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor type() to exist *failure message*, but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected constructor type() to exist because*failure message*, but type is <null>.");
         }
     }
 
@@ -104,13 +101,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithMembers);
 
             // Act
-            Action act = () =>
-                type.Should()
-                    .NotHaveDefaultConstructor("we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveDefaultConstructor("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor *.ClassWithMembers() not to exist *failure message*, but it does.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected constructor *.ClassWithMembers() not to exist because*failure message*, but it does.");
         }
 
         [Fact]
@@ -120,12 +115,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithCctor);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveDefaultConstructor("we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveDefaultConstructor("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor *ClassWithCctor*() not to exist *failure message*, but it does.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected constructor *ClassWithCctor*() not to exist because*failure message*, but it does.");
         }
 
         [Fact]
@@ -145,12 +139,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveDefaultConstructor("we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveDefaultConstructor("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor type() not to exist *failure message*, but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected constructor type() not to exist because*failure message*, but type is <null>.");
         }
     }
 

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitConversionOperator.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitConversionOperator.cs
@@ -57,13 +57,12 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveExplicitConversionOperator(
-                    sourceType, targetType, "we want to test the failure {0}", "message");
+                    sourceType, targetType, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit string(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static explicit string(*.TypeWithConversionOperators) to exist because*failure message*" +
+                ", but it does not.");
         }
 
         [Fact]
@@ -75,13 +74,12 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().HaveExplicitConversionOperator(
-                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit string(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static explicit string(*.TypeWithConversionOperators) to exist because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]
@@ -137,15 +135,13 @@ public partial class TypeAssertionSpecs
             var type = typeof(TypeWithConversionOperators);
 
             // Act
-            Action act = () =>
-                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
+                "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit string(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static explicit string(*.TypeWithConversionOperators) to exist because*failure message*" +
+                ", but it does not.");
         }
 
         [Fact]
@@ -155,15 +151,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
+                "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit string(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static explicit string(*.TypeWithConversionOperators) to exist because*failure message*" +
+                ", but type is <null>.");
         }
     }
 
@@ -191,15 +185,13 @@ public partial class TypeAssertionSpecs
             var targetType = typeof(byte);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(
-                    sourceType, targetType, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveExplicitConversionOperator(
+                sourceType, targetType, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit byte(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but it does.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static explicit byte(*.TypeWithConversionOperators) to not exist because*failure message*" +
+                ", but it does.");
         }
 
         [Fact]
@@ -209,15 +201,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(
-                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveExplicitConversionOperator(
+                typeof(TypeWithConversionOperators), typeof(string), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit string(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static explicit string(*.TypeWithConversionOperators) to not exist because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]
@@ -271,15 +261,13 @@ public partial class TypeAssertionSpecs
             var type = typeof(TypeWithConversionOperators);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator<TypeWithConversionOperators, byte>(
-                    "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveExplicitConversionOperator<TypeWithConversionOperators, byte>(
+                "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit byte(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but it does.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static explicit byte(*.TypeWithConversionOperators) to not exist because*failure message*" +
+                ", but it does.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitMethod.cs
@@ -106,15 +106,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod(
-                    typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveExplicitMethod(
+                typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]
@@ -211,15 +209,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveExplicitMethod<IExplicitInterface>(
-                    "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveExplicitMethod<IExplicitInterface>(
+                "ExplicitMethod", new Type[0], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]
@@ -364,15 +360,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod(
-                    typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveExplicitMethod(
+                typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]
@@ -478,15 +472,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitMethod<IExplicitInterface>(
-                    "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveExplicitMethod<IExplicitInterface>(
+                "ExplicitMethod", new Type[0], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveExplicitProperty.cs
@@ -106,15 +106,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveExplicitProperty(
-                    typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveExplicitProperty(
+                typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]
@@ -226,15 +224,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveExplicitProperty<IExplicitInterface>(
-                    "ExplicitStringProperty", "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveExplicitProperty<IExplicitInterface>(
+                "ExplicitStringProperty", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty because*failure message*" +
+                ", but type is <null>.");
         }
     }
 
@@ -334,15 +330,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveExplicitProperty(
-                    typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveExplicitProperty(
+                typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to not explicitly implement *IExplicitInterface.ExplicitStringProperty *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to not explicitly implement *IExplicitInterface.ExplicitStringProperty because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]
@@ -435,13 +429,12 @@ public partial class TypeAssertionSpecs
             // Act
             Action act = () =>
                 type.Should().NotHaveExplicitProperty<IExplicitInterface>(
-                    "ExplicitStringProperty", "we want to test the failure {0}", "message");
+                    "ExplicitStringProperty", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to not explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to not explicitly implement *.IExplicitInterface.ExplicitStringProperty because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveImplicitConversionOperator.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveImplicitConversionOperator.cs
@@ -36,15 +36,13 @@ public partial class TypeAssertionSpecs
             var targetType = typeof(string);
 
             // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator(
-                    sourceType, targetType, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveImplicitConversionOperator(
+                sourceType, targetType, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit string(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static implicit string(*.TypeWithConversionOperators) to exist because*failure message*" +
+                ", but it does not.");
         }
 
         [Fact]
@@ -54,15 +52,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator(
-                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveImplicitConversionOperator(
+                typeof(TypeWithConversionOperators), typeof(string), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit string(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static implicit string(*.TypeWithConversionOperators) to exist because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]
@@ -126,7 +122,8 @@ public partial class TypeAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method implicit operator int(TypeWithConversionOperators) to be Internal, but it is Public.");
+                .WithMessage(
+                    "Expected method implicit operator int(TypeWithConversionOperators) to be Internal, but it is Public.");
         }
 
         [Fact]
@@ -136,15 +133,13 @@ public partial class TypeAssertionSpecs
             var type = typeof(TypeWithConversionOperators);
 
             // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
+                "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit string(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static implicit string(*.TypeWithConversionOperators) to exist because*failure message*" +
+                ", but it does not.");
         }
 
         [Fact]
@@ -154,15 +149,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
+                "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit string(*.TypeWithConversionOperators) to exist *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static implicit string(*.TypeWithConversionOperators) to exist because*failure message*" +
+                ", but type is <null>.");
         }
     }
 
@@ -190,15 +183,13 @@ public partial class TypeAssertionSpecs
             var targetType = typeof(int);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(
-                    sourceType, targetType, "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveImplicitConversionOperator(
+                sourceType, targetType, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit int(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but it does.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static implicit int(*.TypeWithConversionOperators) to not exist because*failure message*" +
+                ", but it does.");
         }
 
         [Fact]
@@ -208,15 +199,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(
-                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveImplicitConversionOperator(
+                typeof(TypeWithConversionOperators), typeof(string), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit string(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static implicit string(*.TypeWithConversionOperators) to not exist because*failure message*" +
+                ", but type is <null>.");
         }
 
         [Fact]
@@ -270,15 +259,13 @@ public partial class TypeAssertionSpecs
             var type = typeof(TypeWithConversionOperators);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, int>(
-                    "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, int>(
+                "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit int(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but it does.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static implicit int(*.TypeWithConversionOperators) to not exist because*failure message*" +
+                ", but it does.");
         }
 
         [Fact]
@@ -288,15 +275,13 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>(
-                    "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>(
+                "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit string(*.TypeWithConversionOperators) to not exist *failure message*" +
-                    ", but type is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected public static implicit string(*.TypeWithConversionOperators) to not exist because*failure message*" +
+                ", but type is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveIndexer.cs
@@ -33,15 +33,13 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithNoMembers);
 
             // Act
-            Action act = () =>
-                type.Should().HaveIndexer(
-                    typeof(string), [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveIndexer(
+                typeof(string), [typeof(int), typeof(Type)], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected string *ClassWithNoMembers[int, System.Type] to exist *failure message*" +
-                    ", but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected string *ClassWithNoMembers[int, System.Type] to exist because*failure message*" +
+                ", but it does not.");
         }
 
         [Fact]
@@ -51,14 +49,12 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithMembers);
 
             // Act
-            Action act = () =>
-                type.Should().HaveIndexer(
-                    typeof(string), [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveIndexer(
+                typeof(string), [typeof(int), typeof(Type)], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected string *.ClassWithMembers[int, System.Type] to exist *failure message*, but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected string *.ClassWithMembers[int, System.Type] to exist because*failure message*, but it does not.");
         }
 
         [Fact]
@@ -69,11 +65,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveIndexer(typeof(string), [typeof(string)], "we want to test the failure {0}", "message");
+                type.Should().HaveIndexer(typeof(string), [typeof(string)], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected string type[string] to exist *failure message*, but type is <null>.");
+                .WithMessage("Expected string type[string] to exist because*failure message*, but type is <null>.");
         }
 
         [Fact]
@@ -126,12 +122,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithMembers);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveIndexer([typeof(string)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveIndexer([typeof(string)], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected indexer *.ClassWithMembers[string] to not exist *failure message*, but it does.");
+                .WithMessage("Expected indexer *.ClassWithMembers[string] to not exist because*failure message*, but it does.");
         }
 
         [Fact]
@@ -141,12 +136,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveIndexer([typeof(string)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveIndexer([typeof(string)], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected indexer type[string] to not exist *failure message*, but type is <null>.");
+                .WithMessage("Expected indexer type[string] to not exist because*failure message*, but type is <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveMethod.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveMethod.cs
@@ -33,15 +33,13 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithNoMembers);
 
             // Act
-            Action act = () =>
-                type.Should().HaveMethod(
-                    "NonExistentMethod", [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveMethod(
+                "NonExistentMethod", [typeof(int), typeof(Type)], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method *ClassWithNoMembers.NonExistentMethod(int, System.Type) to exist *failure message*" +
-                    ", but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method *ClassWithNoMembers.NonExistentMethod(int, System.Type) to exist because*failure message*" +
+                ", but it does not.");
         }
 
         [Fact]
@@ -51,15 +49,13 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithMembers);
 
             // Act
-            Action act = () =>
-                type.Should().HaveMethod(
-                    "VoidMethod", [typeof(int), typeof(Type)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveMethod(
+                "VoidMethod", [typeof(int), typeof(Type)], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method *.ClassWithMembers.VoidMethod(int, System.Type) to exist *failure message*" +
-                    ", but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method *.ClassWithMembers.VoidMethod(int, System.Type) to exist because*failure message*" +
+                ", but it does not.");
         }
 
         [Fact]
@@ -69,12 +65,11 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveMethod("Name", [typeof(string)], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveMethod("Name", [typeof(string)], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method type.Name(string) to exist *failure message*, but type is <null>.");
+                .WithMessage("Expected method type.Name(string) to exist because*failure message*, but type is <null>.");
         }
 
         [Fact]
@@ -152,12 +147,11 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassWithMembers);
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveMethod("VoidMethod", [], "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveMethod("VoidMethod", [], "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected method Void *.ClassWithMembers.VoidMethod() to not exist *failure message*, but it does.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected method Void *.ClassWithMembers.VoidMethod() to not exist because*failure message*, but it does.");
         }
 
         [Fact]
@@ -168,11 +162,11 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveMethod("Name", [typeof(string)], "we want to test the failure {0}", "message");
+                type.Should().NotHaveMethod("Name", [typeof(string)], "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method type.Name(string) to not exist *failure message*, but type is <null>.");
+                .WithMessage("Expected method type.Name(string) to not exist because*failure message*, but type is <null>.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveProperty.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.HaveProperty.cs
@@ -63,11 +63,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
+                type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected AwesomeAssertions.*ClassWithNoMembers to have a property PublicProperty of type String because we want to test the failure message, but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected AwesomeAssertions.*ClassWithNoMembers to have a property PublicProperty of type String"
+                + " because*failure message, but it does not.");
         }
 
         [Fact]
@@ -77,12 +78,12 @@ public partial class TypeAssertionSpecs
             Type type = typeof(ClassWithNoMembers);
 
             // Act
-            Action act = () =>
-                type.Should().HaveProperty("PublicProperty", "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveProperty("PublicProperty", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected AwesomeAssertions.*ClassWithNoMembers to have a property PublicProperty because we want to test the failure message, but it does not.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected AwesomeAssertions.*ClassWithNoMembers to have a property PublicProperty because*failure message,"
+                + " but it does not.");
         }
 
         [Fact]
@@ -92,14 +93,13 @@ public partial class TypeAssertionSpecs
             Type type = typeof(ClassWithMembers);
 
             // Act
-            Action act = () =>
-                type.Should()
-                    .HaveProperty(typeof(int), "PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
+            Action act = () => type.Should()
+                .HaveProperty(typeof(int), "PrivateWriteProtectedReadProperty", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected property PrivateWriteProtectedReadProperty " +
-                    "to be of type int because we want to test the failure message, but it is not.");
+                    "to be of type int because*failure message, but it is not.");
         }
 
         [Fact]
@@ -109,8 +109,7 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveProperty(typeof(string), "PublicProperty");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -124,8 +123,7 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().HaveProperty("PublicProperty", "we want to test the failure {0}", "message");
+            Action act = () => type.Should().HaveProperty("PublicProperty");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -275,11 +273,12 @@ public partial class TypeAssertionSpecs
 
             // Act
             Action act = () =>
-                type.Should().NotHaveProperty("PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
+                type.Should().NotHaveProperty("PrivateWriteProtectedReadProperty", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect AwesomeAssertions.*.ClassWithMembers to have a property PrivateWriteProtectedReadProperty because we want to test the failure message, but it does.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect AwesomeAssertions.*.ClassWithMembers to have a property PrivateWriteProtectedReadProperty"
+                + " because we want to test the failure message, but it does.");
         }
 
         [Fact]
@@ -289,8 +288,7 @@ public partial class TypeAssertionSpecs
             Type type = null;
 
             // Act
-            Action act = () =>
-                type.Should().NotHaveProperty("PublicProperty", "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotHaveProperty("PublicProperty");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.Implement.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeAssertionSpecs.Implement.cs
@@ -28,14 +28,13 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassThatDoesNotImplementInterface);
 
             // Act
-            Action act = () =>
-                type.Should().Implement(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+            Action act = () => type.Should().Implement(typeof(IDummyInterface), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected type *.ClassThatDoesNotImplementInterface to implement interface *.IDummyInterface " +
-                    "*failure message*, but it does not.");
+                    "because*failure message*, but it does not.");
         }
 
         [Fact]
@@ -45,14 +44,12 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassThatDoesNotImplementInterface);
 
             // Act
-            Action act = () =>
-                type.Should().Implement(typeof(DateTime), "we want to test the failure {0}", "message");
+            Action act = () => type.Should().Implement(typeof(DateTime), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatDoesNotImplementInterface to implement interface *.DateTime *failure message*" +
-                    ", but *.DateTime is not an interface.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassThatDoesNotImplementInterface to implement interface *.DateTime because*failure message*" +
+                ", but *.DateTime is not an interface.");
         }
 
         [Fact]
@@ -117,14 +114,13 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassThatImplementsInterface);
 
             // Act
-            Action act = () =>
-                type.Should().NotImplement(typeof(IDummyInterface), "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotImplement(typeof(IDummyInterface), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected type *.ClassThatImplementsInterface to not implement interface *.IDummyInterface " +
-                    "*failure message*, but it does.");
+                    "because *failure message*, but it does.");
         }
 
         [Fact]
@@ -134,14 +130,12 @@ public partial class TypeAssertionSpecs
             var type = typeof(ClassThatDoesNotImplementInterface);
 
             // Act
-            Action act = () =>
-                type.Should().NotImplement(typeof(DateTime), "we want to test the failure {0}", "message");
+            Action act = () => type.Should().NotImplement(typeof(DateTime), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type *.ClassThatDoesNotImplementInterface to not implement interface *.DateTime *failure message*" +
-                    ", but *.DateTime is not an interface.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type *.ClassThatDoesNotImplementInterface to not implement interface *.DateTime"
+                + " because*failure message*, but *.DateTime is not an interface.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
@@ -36,12 +36,11 @@ public class TypeSelectorAssertionSpecs
             ]);
 
             // Act
-            Action act = () => types.Should().BeSealed("we want to test the failure {0}", "message");
+            Action act = () => types.Should().BeSealed("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be sealed *failure message*, but the following types are not:*.Abstract.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to be sealed because*failure message*, but the following types are not:*.Abstract.");
         }
     }
 
@@ -71,11 +70,11 @@ public class TypeSelectorAssertionSpecs
             ]);
 
             // Act
-            Action act = () => types.Should().NotBeSealed("we want to test the failure {0}", "message");
+            Action act = () => types.Should().NotBeSealed("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types not to be sealed *failure message*, but the following types are:*.Sealed.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types not to be sealed because*failure message*, but the following types are:*.Sealed.");
         }
     }
 
@@ -106,15 +105,13 @@ public class TypeSelectorAssertionSpecs
             ]);
 
             // Act
-            Action act = () =>
-                types.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+            Action act = () => types.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be decorated with *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was not found on the following types:" +
-                    "**.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to be decorated with *.DummyClassAttribute because*failure message*,"
+                + " but the attribute was not found on the following types:"
+                + "**.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
         }
 
         [Fact]
@@ -144,17 +141,14 @@ public class TypeSelectorAssertionSpecs
             ]);
 
             // Act
-            Action act = () =>
-                types.Should()
-                    .BeDecoratedWith<DummyClassAttribute>(
-                        a => a.Name == "Expected" && a.IsEnabled, "we want to test the failure {0}", "message");
+            Action act = () => types.Should().BeDecoratedWith<DummyClassAttribute>(
+                a => a.Name == "Expected" && a.IsEnabled, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be decorated with *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but no matching attribute was found on " +
-                    "the following types:*.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to be decorated with *.DummyClassAttribute that matches " +
+                "(a.Name == \"Expected\") * a.IsEnabled because*failure message*, but no matching attribute was found on " +
+                "the following types:*.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
         }
     }
 
@@ -186,14 +180,13 @@ public class TypeSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                types.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+                types.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be decorated with or inherit *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was not found on the following types:" +
-                    "*.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to be decorated with or inherit *.DummyClassAttribute because*failure message*" +
+                ", but the attribute was not found on the following types:" +
+                "*.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
         }
 
         [Fact]
@@ -225,17 +218,14 @@ public class TypeSelectorAssertionSpecs
             ]);
 
             // Act
-            Action act = () =>
-                types.Should()
-                    .BeDecoratedWithOrInherit<DummyClassAttribute>(
-                        a => a.Name == "Expected" && a.IsEnabled, "we want to test the failure {0}", "message");
+            Action act = () => types.Should().BeDecoratedWithOrInherit<DummyClassAttribute>(
+                a => a.Name == "Expected" && a.IsEnabled, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be decorated with or inherit *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Expected\")*a.IsEnabled *failure message*, but no matching attribute was found " +
-                    "on the following types:*.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to be decorated with or inherit *.DummyClassAttribute that matches " +
+                "(a.Name == \"Expected\")*a.IsEnabled because*failure message*, but no matching attribute was found " +
+                "on the following types:*.ClassWithoutAttribute*.OtherClassWithoutAttribute.");
         }
     }
 
@@ -267,13 +257,12 @@ public class TypeSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                types.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
+                types.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to not be decorated *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was found on the following types:*.ClassWithAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to not be decorated *.DummyClassAttribute because*failure message*" +
+                ", but the attribute was found on the following types:*.ClassWithAttribute.");
         }
 
         [Fact]
@@ -302,17 +291,14 @@ public class TypeSelectorAssertionSpecs
             ]);
 
             // Act
-            Action act = () =>
-                types.Should()
-                    .NotBeDecoratedWith<DummyClassAttribute>(
-                        a => a.Name == "Expected" && a.IsEnabled, "we want to test the failure {0}", "message");
+            Action act = () => types.Should().NotBeDecoratedWith<DummyClassAttribute>(
+                a => a.Name == "Expected" && a.IsEnabled, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to not be decorated with *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
-                    "on the following types:*.ClassWithAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to not be decorated with *.DummyClassAttribute that matches " +
+                "(a.Name == \"Expected\") * a.IsEnabled because*failure message*, but a matching attribute was found " +
+                "on the following types:*.ClassWithAttribute.");
         }
     }
 
@@ -344,13 +330,12 @@ public class TypeSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                types.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+                types.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to not be decorated with or inherit *.DummyClassAttribute *failure message*" +
-                    ", but the attribute was found on the following types:*.ClassWithInheritedAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to not be decorated with or inherit *.DummyClassAttribute because*failure message*" +
+                ", but the attribute was found on the following types:*.ClassWithInheritedAttribute.");
         }
 
         [Fact]
@@ -360,16 +345,14 @@ public class TypeSelectorAssertionSpecs
             var types = new TypeSelector(typeof(ClassWithInheritedAttribute));
 
             // Act
-            Action act = () => types.Should()
-                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(
-                    a => a.Name == "Expected" && a.IsEnabled, "we want to test the failure {0}", "message");
+            Action act = () => types.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>(
+                a => a.Name == "Expected" && a.IsEnabled, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to not be decorated with or inherit *.DummyClassAttribute that matches " +
-                    "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
-                    "on the following types:*.ClassWithInheritedAttribute.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to not be decorated with or inherit *.DummyClassAttribute that matches " +
+                "(a.Name == \"Expected\") * a.IsEnabled because*failure message*, but a matching attribute was found " +
+                "on the following types:*.ClassWithInheritedAttribute.");
         }
 
         [Fact]
@@ -424,13 +407,12 @@ public class TypeSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                types.Should().BeInNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
+                types.Should().BeInNamespace(nameof(DummyNamespace), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected all types to be in namespace \"DummyNamespace\" *failure message*, but the following types " +
-                    "are in a different namespace:*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected all types to be in namespace \"DummyNamespace\" because*failure message*, but the following types " +
+                "are in a different namespace:*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace.");
         }
 
         [Fact]
@@ -516,13 +498,12 @@ public class TypeSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                types.Should().NotBeInNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
+                types.Should().NotBeInNamespace(nameof(DummyNamespace), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected no types to be in namespace \"DummyNamespace\" *failure message*" +
-                    ", but the following types are in the namespace:*DummyNamespace.ClassInDummyNamespace.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected no types to be in namespace \"DummyNamespace\" because*failure message*" +
+                ", but the following types are in the namespace:*DummyNamespace.ClassInDummyNamespace.");
         }
     }
 
@@ -591,12 +572,12 @@ public class TypeSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                types.Should().BeUnderNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
+                types.Should().BeUnderNamespace(nameof(DummyNamespace), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\" *failure message*" +
-                    ", but the namespaces of the following types do not start with it:*.ClassInDummyNamespaceTwo.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the namespaces of all types to start with \"DummyNamespace\" because*failure message*" +
+                ", but the namespaces of the following types do not start with it:*.ClassInDummyNamespaceTwo.");
         }
 
         [Fact]
@@ -646,13 +627,12 @@ public class TypeSelectorAssertionSpecs
 
             // Act
             Action act = () =>
-                types.Should().NotBeUnderNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
+                types.Should().NotBeUnderNamespace(nameof(DummyNamespace), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected the namespaces of all types to not start with \"DummyNamespace\" *failure message*" +
-                    ", but the namespaces of the following types start with it:*.ClassInDummyNamespace.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected the namespaces of all types to not start with \"DummyNamespace\" because*failure message*" +
+                ", but the namespaces of the following types start with it:*.ClassInDummyNamespace.");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
@@ -29,8 +29,7 @@ public class XAttributeAssertionSpecs
             var otherAttribute = new XAttribute("name2", "value");
 
             // Act
-            Action act = () =>
-                theAttribute.Should().Be(otherAttribute, "because we want to test the failure {0}", "message");
+            Action act = () => theAttribute.Should().Be(otherAttribute, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -53,11 +52,11 @@ public class XAttributeAssertionSpecs
 
             // Act
             Action act = () =>
-                theAttribute.Should().Be(new XAttribute("name", "value"), "we want to test the failure {0}", "message");
+                theAttribute.Should().Be(new XAttribute("name", "value"), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theAttribute to be name=\"value\" *failure message*, but found <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theAttribute to be name=\"value\" because*failure message*, but found <null>.");
         }
 
         [Fact]
@@ -66,11 +65,11 @@ public class XAttributeAssertionSpecs
             XAttribute theAttribute = new("name", "value");
 
             // Act
-            Action act = () => theAttribute.Should().Be(null, "we want to test the failure {0}", "message");
+            Action act = () => theAttribute.Should().Be(null, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected theAttribute to be <null> *failure message*, but found name=\"value\".");
+                .WithMessage("Expected theAttribute to be <null> because*failure message*, but found name=\"value\".");
         }
     }
 
@@ -112,8 +111,7 @@ public class XAttributeAssertionSpecs
             var sameAttribute = theAttribute;
 
             // Act
-            Action act = () =>
-                theAttribute.Should().NotBe(sameAttribute, "because we want to test the failure {0}", "message");
+            Action act = () => theAttribute.Should().NotBe(sameAttribute, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -147,11 +145,11 @@ public class XAttributeAssertionSpecs
             XAttribute theAttribute = null;
 
             // Act
-            Action act = () => theAttribute.Should().NotBe(null, "we want to test the failure {0}", "message");
+            Action act = () => theAttribute.Should().NotBe(null, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect theAttribute to be <null> *failure message*.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theAttribute to be <null> because*failure message*.");
         }
     }
 
@@ -189,8 +187,7 @@ public class XAttributeAssertionSpecs
             var theAttribute = new XAttribute("name", "value");
 
             // Act
-            Action act = () =>
-                theAttribute.Should().BeNull("because we want to test the failure {0}", "message");
+            Action act = () => theAttribute.Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -232,8 +229,7 @@ public class XAttributeAssertionSpecs
             XAttribute theAttribute = null;
 
             // Act
-            Action act = () =>
-                theAttribute.Should().NotBeNull("because we want to test the failure {0}", "message");
+            Action act = () => theAttribute.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -276,8 +272,7 @@ public class XAttributeAssertionSpecs
             var theAttribute = new XAttribute("age", "36");
 
             // Act
-            Action act = () =>
-                theAttribute.Should().HaveValue("16", "because we want to test the failure {0}", "message");
+            Action act = () => theAttribute.Should().HaveValue("16", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -290,12 +285,11 @@ public class XAttributeAssertionSpecs
             XAttribute theAttribute = null;
 
             // Act
-            Action act = () =>
-                theAttribute.Should().HaveValue("value", "we want to test the failure {0}", "message");
+            Action act = () => theAttribute.Should().HaveValue("value", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the attribute to have value \"value\" *failure message*, but theAttribute is <null>.");
+                .WithMessage("Expected the attribute to have value \"value\" because*failure message*, but theAttribute is <null>.");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -45,11 +45,11 @@ public class XDocumentAssertionSpecs
             XDocument theDocument = null;
 
             // Act
-            Action act = () => theDocument.Should().Be(new XDocument(), "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().Be(new XDocument(), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to be [XML document without root element] *failure message*, but found <null>.");
+                "Expected theDocument to be [XML document without root element] because*failure message*, but found <null>.");
         }
 
         [Fact]
@@ -72,11 +72,11 @@ public class XDocumentAssertionSpecs
             XDocument theDocument = new();
 
             // Act
-            Action act = () => theDocument.Should().Be(null, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().Be(null, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to be <null> *failure message*, but found [XML document without root element].");
+                "Expected theDocument to be <null> because*failure message*, but found [XML document without root element].");
         }
 
         [Fact]
@@ -87,8 +87,7 @@ public class XDocumentAssertionSpecs
             var otherXDocument = XDocument.Parse("<data></data>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().Be(otherXDocument, "because we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().Be(otherXDocument, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -152,11 +151,11 @@ public class XDocumentAssertionSpecs
             XDocument theDocument = null;
 
             // Act
-            Action act = () => theDocument.Should().NotBe(null, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().NotBe(null, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect theDocument to be <null> *failure message*.");
+                .WithMessage("Did not expect theDocument to be <null> because*failure message*.");
         }
 
         [Fact]
@@ -167,8 +166,7 @@ public class XDocumentAssertionSpecs
             var sameXDocument = theDocument;
 
             // Act
-            Action act = () =>
-                theDocument.Should().NotBe(sameXDocument, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().NotBe(sameXDocument, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -271,8 +269,7 @@ public class XDocumentAssertionSpecs
             var expected = XDocument.Parse("<parent><child /></parent>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -289,8 +286,7 @@ public class XDocumentAssertionSpecs
             var expected = XDocument.Parse("<parent><child /><child2 /></parent>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -313,15 +309,13 @@ public class XDocumentAssertionSpecs
             XDocument theDocument = null;
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(
-                    XDocument.Parse("<parent><child /></parent>"), "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(
+                XDocument.Parse("<parent><child /></parent>"), "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected theDocument to be equivalent to <null> *failure message*" +
-                    ", but found \"<parent><child /></parent>\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to be equivalent to <null> because*failure message*" +
+                ", but found \"<parent><child /></parent>\".");
         }
 
         [Fact]
@@ -330,14 +324,12 @@ public class XDocumentAssertionSpecs
             XDocument theDocument = XDocument.Parse("<parent><child /></parent>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(null, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(null, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected theDocument to be equivalent to \"<parent><child /></parent>\" *failure message*" +
-                    ", but found <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to be equivalent to \"<parent><child /></parent>\" because*failure message*" +
+                ", but found <null>.");
         }
 
         [Fact]
@@ -373,12 +365,11 @@ public class XDocumentAssertionSpecs
             var expected = XDocument.Parse("<xml><element a=\"b\" b=\"1\"/></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message, but found none.");
+                "Expected attribute \"a\" in theDocument at \"/xml/element\" because*failure message, but found none.");
         }
 
         [Fact]
@@ -391,11 +382,11 @@ public class XDocumentAssertionSpecs
 
             // Act
             Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
+                "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because*failure message.");
         }
 
         [Fact]
@@ -407,12 +398,12 @@ public class XDocumentAssertionSpecs
             var expected = XDocument.Parse("<xml><element a=\"c\"/></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+                "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because*failure message,"
+                + " but found \"b\".");
         }
 
         [Fact]
@@ -424,12 +415,11 @@ public class XDocumentAssertionSpecs
             var expected = XDocument.Parse("<xml><element a=\"b\"/></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
+                "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because*failure message.");
         }
 
         [Fact]
@@ -441,12 +431,11 @@ public class XDocumentAssertionSpecs
             var expected = XDocument.Parse("<xml>b</xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected content to be \"b\" in theDocument at \"/xml\" because we want to test the failure message, but found \"a\".");
+                "Expected content to be \"b\" in theDocument at \"/xml\" because*failure message, but found \"a\".");
         }
 
         [Fact]
@@ -600,7 +589,7 @@ public class XDocumentAssertionSpecs
 
             // Act
             Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(otherDocument, "we want to test the failure {0}", "message");
+                theDocument.Should().NotBeEquivalentTo(otherDocument, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -617,7 +606,7 @@ public class XDocumentAssertionSpecs
 
             // Act
             Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(otherXDocument, "because we want to test the failure {0}", "message");
+                theDocument.Should().NotBeEquivalentTo(otherXDocument, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -651,7 +640,7 @@ public class XDocumentAssertionSpecs
 
             // Act
             Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(sameXDocument, "we want to test the failure {0}", "message");
+                theDocument.Should().NotBeEquivalentTo(sameXDocument, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -664,7 +653,7 @@ public class XDocumentAssertionSpecs
             XDocument theDocument = null;
 
             // Act
-            Action act = () => theDocument.Should().NotBeEquivalentTo(null, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().NotBeEquivalentTo(null, "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -724,8 +713,7 @@ public class XDocumentAssertionSpecs
             var theDocument = XDocument.Parse("<configuration></configuration>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeNull("because we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -766,8 +754,7 @@ public class XDocumentAssertionSpecs
             XDocument theDocument = null;
 
             // Act
-            Action act = () =>
-                theDocument.Should().NotBeNull("because we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -826,8 +813,7 @@ public class XDocumentAssertionSpecs
                 """);
 
             // Act
-            Action act = () =>
-                theDocument.Should().HaveRoot("unknown", "because we want to test the failure message");
+            Action act = () => theDocument.Should().HaveRoot("unknown", "we want to test the {0} message", "failure");
 
             // Assert
             string expectedMessage = "Expected theDocument to have root element \"unknown\"" +
@@ -955,9 +941,8 @@ public class XDocumentAssertionSpecs
                 """);
 
             // Act
-            Action act = () =>
-                theDocument.Should().HaveRoot(XName.Get("unknown", "http://www.example.com/2012/test"),
-                    "because we want to test the failure message");
+            Action act = () => theDocument.Should().HaveRoot(
+                XName.Get("unknown", "http://www.example.com/2012/test"), "we want to test the {0} message", "failure");
 
             // Assert
             string expectedMessage =
@@ -1039,8 +1024,7 @@ public class XDocumentAssertionSpecs
                 """);
 
             // Act
-            Action act = () =>
-                theDocument.Should().HaveElement("unknown", "because we want to test the failure message");
+            Action act = () => theDocument.Should().HaveElement("unknown", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1097,9 +1081,8 @@ public class XDocumentAssertionSpecs
                 """);
 
             // Act
-            Action act = () =>
-                theDocument.Should().HaveElement(XName.Get("unknown", "http://www.example.org/2012/test"),
-                    "because we want to test the failure message");
+            Action act = () => theDocument.Should().HaveElement(
+                XName.Get("unknown", "http://www.example.org/2012/test"), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1865,9 +1848,8 @@ public class XDocumentAssertionSpecs
             XDocument element = null;
 
             // Act
-            Action act = () =>
-                element.Should().NotHaveElementWithValue(XNamespace.None + "child", "b", "we want to test the {0} message",
-                    "failure");
+            Action act = () => element.Should().NotHaveElementWithValue(
+                XNamespace.None + "child", "b", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*child*b*failure message*element itself is <null>*");

--- a/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -1181,7 +1181,7 @@ public class XElementAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                theElement.Should().HaveAttributeWithValue("age", "36", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttributeWithValue("age", "36", "we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -1198,9 +1198,8 @@ public class XElementAssertionSpecs
             var theElement = XElement.Parse("""<user xmlns:a="http://www.example.com/2012/test" a:name="martin" />""");
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveAttributeWithValue(XName.Get("age", "http://www.example.com/2012/test"), "36",
-                    "because we want to test the failure {0}", "message");
+            Action act = () => theElement.Should().HaveAttributeWithValue(
+                XName.Get("age", "http://www.example.com/2012/test"), "36", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1248,9 +1247,8 @@ public class XElementAssertionSpecs
             var theElement = XElement.Parse("""<user name="martin" />""");
 
             // Act
-            Action act = () =>
-                theElement.Should()
-                    .HaveAttributeWithValue("name", "dennis", "because we want to test the failure {0}", "message");
+            Action act = () => theElement.Should().HaveAttributeWithValue(
+                "name", "dennis", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1266,9 +1264,8 @@ public class XElementAssertionSpecs
             var theElement = XElement.Parse("""<user xmlns:a="http://www.example.com/2012/test" a:name="martin" />""");
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveAttributeWithValue(XName.Get("name", "http://www.example.com/2012/test"), "dennis",
-                    "because we want to test the failure {0}", "message");
+            Action act = () => theElement.Should().HaveAttributeWithValue(
+                XName.Get("name", "http://www.example.com/2012/test"), "dennis", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1283,12 +1280,12 @@ public class XElementAssertionSpecs
 
             // Act
             Action act = () =>
-                theElement.Should().HaveAttributeWithValue("name", "value", "we want to test the failure {0}", "message");
+                theElement.Should().HaveAttributeWithValue("name", "value", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected attribute \"name\" in element to have value \"value\" *failure message*" +
+                    "Expected attribute \"name\" in element to have value \"value\" because*failure message*" +
                     ", but theElement is <null>.");
         }
 
@@ -1299,12 +1296,12 @@ public class XElementAssertionSpecs
 
             // Act
             Action act = () =>
-                theElement.Should().HaveAttributeWithValue((XName)"name", "value", "we want to test the failure {0}", "message");
+                theElement.Should().HaveAttributeWithValue((XName)"name", "value", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected attribute \"name\" in element to have value \"value\" *failure message*" +
+                    "Expected attribute \"name\" in element to have value \"value\" because*failure message*" +
                     ", but theElement is <null>.");
         }
 
@@ -1423,14 +1420,12 @@ public class XElementAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-
-                theElement.Should()
-                    .NotHaveAttributeWithValue("name", "martin", "because we want to test the failure {0}", "message");
+                theElement.Should().NotHaveAttributeWithValue("name", "martin", "we want to test the {0} message", "failure");
             };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect theElement to have attribute \"name\" with value \"martin\" because we want to test the failure message,"
+                "Did not expect theElement to have attribute \"name\" with value \"martin\" because*failure message,"
                 + " but found such attribute in <user name=\"martin\" />*");
         }
 
@@ -1441,9 +1436,8 @@ public class XElementAssertionSpecs
             var theElement = XElement.Parse("""<user xmlns:a="http://www.example.com/2012/test" a:name="martin" />""");
 
             // Act
-            Action act = () =>
-                theElement.Should().NotHaveAttributeWithValue(XName.Get("name", "http://www.example.com/2012/test"), "martin",
-                    "because we want to test the failure {0}", "message");
+            Action act = () => theElement.Should().NotHaveAttributeWithValue(
+                XName.Get("name", "http://www.example.com/2012/test"), "martin", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1459,12 +1453,12 @@ public class XElementAssertionSpecs
 
             // Act
             Action act = () =>
-                theElement.Should().NotHaveAttributeWithValue("name", "value", "we want to test the failure {0}", "message");
+                theElement.Should().NotHaveAttributeWithValue("name", "value", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Did not expect attribute \"name\" in element to have value \"value\"*failure message*, but theElement is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect attribute \"name\" in element to have value \"value\" because*failure message*,"
+                + " but theElement is <null>.");
         }
 
         [Fact]
@@ -1473,14 +1467,13 @@ public class XElementAssertionSpecs
             XElement theElement = null;
 
             // Act
-            Action act = () =>
-                theElement.Should()
-                    .NotHaveAttributeWithValue((XName)"name", "value", "we want to test the failure {0}", "message");
+            Action act = () => theElement.Should().NotHaveAttributeWithValue(
+                (XName)"name", "value", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Did not expect attribute \"name\" in element to have value \"value\"*failure message*, but theElement is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect attribute \"name\" in element to have value \"value\" because*failure message*,"
+                + " but theElement is <null>.");
         }
 
         [Fact]
@@ -1638,8 +1631,7 @@ public class XElementAssertionSpecs
                 """);
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveElement("unknown", "because we want to test the failure message");
+            Action act = () => theElement.Should().HaveElement("unknown", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1659,9 +1651,8 @@ public class XElementAssertionSpecs
                 """);
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveElement(XName.Get("unknown", "http://www.example.com/2012/test"),
-                    "because we want to test the failure message");
+            Action act = () => theElement.Should().HaveElement(
+                XName.Get("unknown", "http://www.example.com/2012/test"), "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2377,9 +2368,8 @@ public class XElementAssertionSpecs
             XElement element = null;
 
             // Act
-            Action act = () =>
-                element.Should().NotHaveElementWithValue(XNamespace.None + "child", "b", "we want to test the {0} message",
-                    "failure");
+            Action act = () => element.Should().NotHaveElementWithValue(
+                XNamespace.None + "child", "b", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*child*b*failure message*element itself is <null>*");

--- a/Tests/AwesomeAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
@@ -70,8 +70,7 @@ public class XmlElementAssertionSpecs
             var theElement = document.DocumentElement;
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveInnerText("stamac", "because we want to test the failure {0}", "message");
+            Action act = () => theElement.Should().HaveInnerText("stamac", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -119,8 +118,7 @@ public class XmlElementAssertionSpecs
             var theElement = document.DocumentElement;
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
+            Action act = () => theElement.Should().HaveAttribute("age", "36", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -156,8 +154,7 @@ public class XmlElementAssertionSpecs
             var theElement = document.DocumentElement;
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
+            Action act = () => theElement.Should().HaveAttribute("name", "dennis", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -211,8 +208,8 @@ public class XmlElementAssertionSpecs
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                theElement.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36",
-                    "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttributeWithNamespace(
+                    "age", "http://www.example.com/2012/test", "36", "we want to test the {0} message", "failure");
             };
 
             // Assert
@@ -250,16 +247,14 @@ public class XmlElementAssertionSpecs
             var theElement = document.DocumentElement;
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "dennis",
-                    "because we want to test the failure {0}", "message");
+            Action act = () => theElement.Should().HaveAttributeWithNamespace(
+                "name", "http://www.example.com/2012/test", "dennis", "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\"" +
-                    " because we want to test the failure message" +
-                    ", but found \"martin\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\"" +
+                " because we want to test the failure message" +
+                ", but found \"martin\".");
         }
     }
 
@@ -323,8 +318,7 @@ public class XmlElementAssertionSpecs
             var theElement = document.DocumentElement;
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveElement("unknown", "because we want to test the failure message");
+            Action act = () => theElement.Should().HaveElement("unknown", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -457,9 +451,8 @@ public class XmlElementAssertionSpecs
             var theElement = document.DocumentElement;
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveElementWithNamespace("unknown", "http://www.example.com/2012/test",
-                    "because we want to test the failure message");
+            Action act = () => theElement.Should().HaveElementWithNamespace(
+                "unknown", "http://www.example.com/2012/test", "we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/AwesomeAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
@@ -29,13 +29,11 @@ public class XmlNodeAssertionSpecs
             otherNode.LoadXml("<otherDoc/>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeSameAs(otherNode, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected theDocument to refer to <otherDoc /> because we want to test the failure message, but found <doc />.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to refer to <otherDoc /> because we want to test the failure message, but found <doc />.");
         }
 
         [Fact]
@@ -49,13 +47,11 @@ public class XmlNodeAssertionSpecs
             otherNode.LoadXml("<otherDoc/>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeSameAs(otherNode, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected theDocument to refer to <otherDoc /> because we want to test the failure message, but found <doc>Some very long….");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to refer to <otherDoc /> because*failure message, but found <doc>Some very long….");
         }
 
         [Fact]
@@ -110,13 +106,11 @@ public class XmlNodeAssertionSpecs
             theDocument.LoadXml("<xml/>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeNull("because we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeNull("we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected theDocument to be <null> because we want to test the failure message," +
-                    " but found <xml />.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to be <null> because we want to test the failure message, but found <xml />.");
         }
     }
 
@@ -154,8 +148,7 @@ public class XmlNodeAssertionSpecs
             XmlDocument theDocument = null;
 
             // Act
-            Action act = () =>
-                theDocument.Should().NotBeNull("because we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().NotBeNull("we want to test the {0} message", "failure");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -186,13 +179,12 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<expected/>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected local name of element in theDocument at \"/\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected local name of element in theDocument at \"/\" to be \"expected\" because*failure message,"
+                + " but found \"subject\".");
         }
 
         [Fact]
@@ -249,13 +241,12 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml><child><expected/></child></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected local name of element in theDocument at \"/xml/child\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected local name of element in theDocument at \"/xml/child\" to be \"expected\" because*failure message,"
+                + " but found \"subject\".");
         }
 
         [Fact]
@@ -269,13 +260,12 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml xmlns=\"urn:a\"><child><data xmlns=\"urn:b\"/></child></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected namespace of element \"data\" in theDocument at \"/xml/child\" to be \"urn:b\" because we want to test the failure message, but found \"urn:a\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected namespace of element \"data\" in theDocument at \"/xml/child\" to be \"urn:b\" because*failure message,"
+                + " but found \"urn:a\".");
         }
 
         [Fact]
@@ -289,13 +279,11 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml><data/></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected Element \"data\" in theDocument at \"/xml\" because we want to test the failure message, but found content \"data\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected Element \"data\" in theDocument at \"/xml\" because*failure message, but found content \"data\".");
         }
 
         [Fact]
@@ -309,13 +297,11 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml/>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected end of document in theDocument because we want to test the failure message, but found \"data\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected end of document in theDocument because we want to test the failure message, but found \"data\".");
         }
 
         [Fact]
@@ -329,13 +315,11 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml><data/></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected \"data\" in theDocument because we want to test the failure message, but found end of document.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected \"data\" in theDocument because we want to test the failure message, but found end of document.");
         }
 
         [Fact]
@@ -349,13 +333,11 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml><element a=\"b\" b=\"1\"/></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message, but found none.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"a\" in theDocument at \"/xml/element\" because*failure message, but found none.");
         }
 
         [Fact]
@@ -369,13 +351,11 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml><element/></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because*failure message.");
         }
 
         [Fact]
@@ -389,13 +369,12 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml><element a=\"c\"/></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because*failure message,"
+                + " but found \"b\".");
         }
 
         [Fact]
@@ -409,13 +388,11 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml><element a=\"b\"/></xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because*failure message.");
         }
 
         [Fact]
@@ -429,13 +406,11 @@ public class XmlNodeAssertionSpecs
             expected.LoadXml("<xml>b</xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().BeEquivalentTo(expected, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected content to be \"b\" in theDocument at \"/xml\" because we want to test the failure message, but found \"a\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected content to be \"b\" in theDocument at \"/xml\" because*failure message, but found \"a\".");
         }
 
         [Fact]
@@ -526,13 +501,11 @@ public class XmlNodeAssertionSpecs
             theDocument.LoadXml("<xml>a</xml>");
 
             // Act
-            Action act = () =>
-                theDocument.Should().NotBeEquivalentTo(theDocument, "we want to test the failure {0}", "message");
+            Action act = () => theDocument.Should().NotBeEquivalentTo(theDocument, "we want to test the {0} message", "failure");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
         }
     }
 }


### PR DESCRIPTION
Update of test code according to the design guide, fixes #325 .

In `AwesomeAssertions.Equivalency.Specs` I applied the "because" and the "AAA comment" pattern. This causes a lot of changes need to be reviewed.
So, `AwesomeAssertions.Specs` I applied only the "because" pattern.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
