### PR TITLE
Remove the public modifier on interface members

### DIFF
--- a/Src/AwesomeAssertions/Equivalency/IEquivalencyValidationContext.cs
+++ b/Src/AwesomeAssertions/Equivalency/IEquivalencyValidationContext.cs
@@ -17,7 +17,7 @@ public interface IEquivalencyValidationContext
     /// <summary>
     /// A formatted phrase and the placeholder values explaining why the assertion is needed.
     /// </summary>
-    public Reason Reason { get; }
+    Reason Reason { get; }
 
     /// <summary>
     /// Gets an object that can be used by the equivalency algorithm to provide a trace when the
@@ -31,7 +31,7 @@ public interface IEquivalencyValidationContext
     /// Determines whether the specified object reference is a cyclic reference to the same object earlier in the
     /// equivalency validation.
     /// </summary>
-    public bool IsCyclicReference(object expectation);
+    bool IsCyclicReference(object expectation);
 
     /// <summary>
     /// Creates a context from the current object intended to assert the equivalency of a nested member.

--- a/Tests/AwesomeAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -1124,17 +1124,17 @@ public class EventAssertionSpecs
 
     private interface IAddFailingRecordableEvent
     {
-        public event EventHandler AddFailingRecorableEvent;
+        event EventHandler AddFailingRecorableEvent;
     }
 
     private interface IAddFailingEvent
     {
-        public event EventHandler AddFailingEvent;
+        event EventHandler AddFailingEvent;
     }
 
     private interface IRemoveFailingEvent
     {
-        public event EventHandler RemoveFailingEvent;
+        event EventHandler RemoveFailingEvent;
     }
 
     private class TestEventBrokenEventHandlerRaising


### PR DESCRIPTION
Two interfaces had public modifiers on some members. They should probably not have been there in the first place.

Running `./AcceptApiChanges.sh` did not do anything, so I guess it's not a breaking change.

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
