### PR TITLE
Remove Microsoft.SourceLink.GitHub

### DIFF
--- a/Src/AwesomeAssertions/AwesomeAssertions.csproj
+++ b/Src/AwesomeAssertions/AwesomeAssertions.csproj
@@ -59,7 +59,6 @@
   <ItemGroup Label="Analyzers">
     <AdditionalFiles Include="BannedSymbols.txt" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
According to https://github.com/AwesomeAssertions/AwesomeAssertions/pull/417#issuecomment-3858646317 the package is not needed anymore.

I've verified this in the build artifact: The url and commit are generated into the nuget package as expected.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
