### PR TITLE
Remove package pinning from core library

### DIFF
--- a/Src/AwesomeAssertions/AwesomeAssertions.csproj
+++ b/Src/AwesomeAssertions/AwesomeAssertions.csproj
@@ -68,12 +68,12 @@
     <!--
       System.Threading.Tasks.Extensions
       The version 4.5.4 is part of the API. Changing the version creates a breaking change.
-      So, we pin the version to make an explicit update when it gets required.
+      So, this version must not be changed before starting a new major version.
 
       Note that BenchmarkDotNet requires a higher version.
       When updating STTE, please check wether the warning suppression in Benchmarks.csproj can be removed.
     -->
-    <SystemThreadingTasksExtensionsVersion>[4.5.4]</SystemThreadingTasksExtensionsVersion>
+    <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
   </PropertyGroup>
   <Choose>
     <When Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/renovate.json5
+++ b/renovate.json5
@@ -30,6 +30,13 @@
             "enabled": false
         },
 
+        // Disable major updates of System.Threading.Tasks.Extensions because it is part of the public API.
+        {
+            "matchPackageNames": ["System.Threading.Tasks.Extensions"],
+            "matchFileNames": ["**/AwesomeAssertions/**"],
+            "allowedVersions": "< 4.6.0"
+        },
+
         // We are supporting test frameworks in different major versions.
         // They have different test projects in the solution.
         // We need to limit the updates for individual projects.


### PR DESCRIPTION
We used package pinning in the past to ensure that we do not update `System.Threading.Tasks.Extensions`, because it is "part of the public API".
But, this also influences the generated NuGet package: The reference to STTE if fixed there too. I think, that is not correct, because customers may upgrade to a higher version if necessary.

Instead, I've added a new renovate rule.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
