### PR TITLE
Add [Not]BeDecoratedWith for ParameterInfo

### DIFF
--- a/AwesomeAssertions.slnx
+++ b/AwesomeAssertions.slnx
@@ -11,6 +11,7 @@
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
+    <File Path="DESIGN-GUIDE.md" />
     <File Path="Directory.Build.props" />
     <File Path="docs/_pages/releases.md" />
     <File Path="nuget.config" />

--- a/Src/AwesomeAssertions/AssertionExtensions.cs
+++ b/Src/AwesomeAssertions/AssertionExtensions.cs
@@ -813,7 +813,7 @@ public static class AssertionExtensions
 
     /// <summary>
     /// Returns a <see cref="AwesomeAssertions.Types.MethodBaseAssertions{TSubject, TAssertions}"/> object
-    /// that can be used to assert the current <see cref="MethodInfo"/>.
+    /// that can be used to assert the current <see cref="ConstructorInfo"/>.
     /// </summary>
     /// <seealso cref="TypeAssertions"/>
     [Pure]
@@ -851,7 +851,7 @@ public static class AssertionExtensions
 
     /// <summary>
     /// Returns a <see cref="PropertyInfoAssertions"/> object that can be used to assert the
-    /// current <see cref="PropertyInfoSelector"/>.
+    /// current <see cref="PropertyInfo"/>.
     /// </summary>
     /// <seealso cref="TypeAssertions"/>
     [Pure]
@@ -874,6 +874,17 @@ public static class AssertionExtensions
         Guard.ThrowIfArgumentIsNull(propertyInfoSelector);
 
         return new PropertyInfoSelectorAssertions(AssertionChain.GetOrCreate(), propertyInfoSelector.ToArray());
+    }
+
+    /// <summary>
+    /// Returns a <see cref="ParameterInfoAssertions"/> object that can be used to assert the
+    /// current <see cref="ParameterInfo"/>.
+    /// </summary>
+    [Pure]
+    [return: NotNull]
+    public static ParameterInfoAssertions Should([NotNull] this ParameterInfo parameterInfo)
+    {
+        return new ParameterInfoAssertions(parameterInfo, AssertionChain.GetOrCreate());
     }
 
     /// <summary>

--- a/Src/AwesomeAssertions/Types/ParameterInfoAssertions.cs
+++ b/Src/AwesomeAssertions/Types/ParameterInfoAssertions.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using AwesomeAssertions.Common;
+using AwesomeAssertions.Execution;
+using AwesomeAssertions.Primitives;
+
+namespace AwesomeAssertions.Types;
+
+/// <summary>
+/// Contains a number of methods to assert that a <see cref="ParameterInfo"/> is in the expected state.
+/// </summary>
+[DebuggerNonUserCode]
+public sealed class ParameterInfoAssertions : ReferenceTypeAssertions<ParameterInfo, ParameterInfoAssertions>
+{
+    private readonly AssertionChain assertionChain;
+
+    protected override string Identifier => "parameter";
+
+    private string SubjectDescription =>
+        Subject.Position < 0
+            ? $"return parameter {Subject.ParameterType.ToFormattedString()}"
+            : $"parameter {Subject.ParameterType.ToFormattedString()} {Subject.Name}";
+
+    public ParameterInfoAssertions(ParameterInfo subject, AssertionChain assertionChain)
+        : base(subject, assertionChain)
+    {
+        this.assertionChain = assertionChain;
+    }
+
+    /// <summary>
+    /// Asserts that the selected parameter is decorated with the specified <typeparamref name="TAttribute"/>.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <typeparam name="TAttribute">Expected attribute type.</typeparam>
+    [return: NotNull]
+    public AndWhichConstraint<ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        where TAttribute : Attribute
+    {
+        IEnumerable<TAttribute> attributes = AssertDecoratedWith<TAttribute>(because, becauseArgs);
+        return new(this, attributes);
+    }
+
+    /// <summary>
+    /// Asserts that the selected parameter is decorated with an attribute of type <typeparamref name="TAttribute"/>
+    /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+    /// </summary>
+    /// <param name="isMatchingAttributePredicate">
+    /// The predicate that the attribute must match.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="isMatchingAttributePredicate"/> is <see langword="null"/>.</exception>
+    /// <typeparam name="TAttribute">Expected attribute type.</typeparam>
+    [return: NotNull]
+    public AndWhichConstraint<ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(
+        Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        where TAttribute : Attribute
+    {
+        Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate);
+
+        IEnumerable<TAttribute> attributes = AssertDecoratedWith<TAttribute>(because, becauseArgs);
+
+        if (assertionChain.Succeeded)
+        {
+            attributes = attributes.Where(isMatchingAttributePredicate.Compile()).ToArray();
+
+            assertionChain
+                .ForCondition(attributes.Any())
+                .FailWith(() => new FailReason(
+                    $"Expected {SubjectDescription} to be decorated with {{0}} matching {{1}}{{reason}}" +
+                    ", but no attribute matching the predicate was found.", typeof(TAttribute), isMatchingAttributePredicate.Body));
+        }
+
+        return new(this, attributes);
+    }
+
+    private IEnumerable<TAttribute> AssertDecoratedWith<TAttribute>(string because, object[] becauseArgs)
+        where TAttribute : Attribute
+    {
+        assertionChain
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject is not null)
+                    .FailWith(
+                        "Expected parameter to be decorated with {0}{reason}" +
+                        ", but found {context:parameter} is <null>.", typeof(TAttribute));
+
+        IEnumerable<TAttribute> attributes = [];
+
+        if (assertionChain.Succeeded)
+        {
+            attributes = Subject.GetCustomAttributes<TAttribute>();
+
+            assertionChain
+                .ForCondition(attributes.Any())
+                .FailWith(() => new FailReason(
+                    $"Expected {SubjectDescription} to be decorated with {{0}}{{reason}}" +
+                    ", but that attribute was not found.", typeof(TAttribute)));
+        }
+
+        return attributes;
+    }
+
+    /// <summary>
+    /// Asserts that the selected parameter is not decorated with the specified <typeparamref name="TAttribute"/>.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <typeparam name="TAttribute">Unexpected attribute type.</typeparam>
+    [return: NotNull]
+    public AndConstraint<ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        where TAttribute : Attribute
+    {
+        assertionChain
+           .BecauseOf(because, becauseArgs)
+           .ForCondition(Subject is not null)
+           .FailWith(
+               "Did not expect parameter to be decorated with {0}{reason}" +
+               ", but found {context:parameter} is <null>.", typeof(TAttribute));
+
+        if (assertionChain.Succeeded)
+        {
+            IEnumerable<TAttribute> attributes = Subject.GetCustomAttributes<TAttribute>();
+
+            assertionChain
+                .ForCondition(!attributes.Any())
+                .FailWith(() => new FailReason(
+                    $"Did not expect {SubjectDescription} to be decorated with {{0}}{{reason}}" +
+                    ", but that attribute was found.", typeof(TAttribute)));
+        }
+
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts that the selected parameter is not decorated with an attribute of type <typeparamref name="TAttribute"/>
+    /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+    /// </summary>
+    /// <param name="isMatchingAttributePredicate">
+    /// The predicate that the attribute must match.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="isMatchingAttributePredicate"/> is <see langword="null"/>.</exception>
+    /// <typeparam name="TAttribute">Unexpected attribute type.</typeparam>
+    [return: NotNull]
+    public AndConstraint<ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(
+        Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,
+        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        where TAttribute : Attribute
+    {
+        Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate);
+
+        assertionChain
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(Subject is not null)
+            .FailWith(
+                "Did not expect parameter to be decorated with {0}{reason}" +
+                ", but found {context:parameter} is <null>.", typeof(TAttribute));
+
+        if (assertionChain.Succeeded)
+        {
+            IEnumerable<TAttribute> attributes = Subject.GetCustomAttributes<TAttribute>()
+                .Where(isMatchingAttributePredicate.Compile()).ToArray();
+
+            assertionChain
+                .ForCondition(!attributes.Any())
+                .FailWith(() => new FailReason(
+                    $"Did not expect {SubjectDescription} to be decorated with {{0}} matching {{1}}{{reason}}" +
+                    ", but that attribute was found.", typeof(TAttribute), isMatchingAttributePredicate.Body));
+        }
+
+        return new(this);
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
@@ -116,6 +116,8 @@ namespace AwesomeAssertions
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public static AwesomeAssertions.Types.ParameterInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ParameterInfo parameterInfo) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
@@ -2945,6 +2947,23 @@ namespace AwesomeAssertions.Types
             where TAttribute : System.Attribute { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public sealed class ParameterInfoAssertions : AwesomeAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.ParameterInfo, AwesomeAssertions.Types.ParameterInfoAssertions>
+    {
+        public ParameterInfoAssertions(System.Reflection.ParameterInfo subject, AwesomeAssertions.Execution.AssertionChain assertionChain) { }
+        protected override string Identifier { get; }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
     }
     public class PropertyInfoAssertions : AwesomeAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, AwesomeAssertions.Types.PropertyInfoAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
@@ -120,6 +120,8 @@ namespace AwesomeAssertions
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public static AwesomeAssertions.Types.ParameterInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ParameterInfo parameterInfo) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.TaskCompletionSourceAssertions Should(this System.Threading.Tasks.TaskCompletionSource tcs) { }
@@ -3147,6 +3149,23 @@ namespace AwesomeAssertions.Types
             where TAttribute : System.Attribute { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public sealed class ParameterInfoAssertions : AwesomeAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.ParameterInfo, AwesomeAssertions.Types.ParameterInfoAssertions>
+    {
+        public ParameterInfoAssertions(System.Reflection.ParameterInfo subject, AwesomeAssertions.Execution.AssertionChain assertionChain) { }
+        protected override string Identifier { get; }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
     }
     public class PropertyInfoAssertions : AwesomeAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, AwesomeAssertions.Types.PropertyInfoAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -120,6 +120,8 @@ namespace AwesomeAssertions
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public static AwesomeAssertions.Types.ParameterInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ParameterInfo parameterInfo) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.TaskCompletionSourceAssertions Should(this System.Threading.Tasks.TaskCompletionSource tcs) { }
@@ -3168,6 +3170,23 @@ namespace AwesomeAssertions.Types
             where TAttribute : System.Attribute { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+    }
+    public sealed class ParameterInfoAssertions : AwesomeAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.ParameterInfo, AwesomeAssertions.Types.ParameterInfoAssertions>
+    {
+        public ParameterInfoAssertions(System.Reflection.ParameterInfo subject, AwesomeAssertions.Execution.AssertionChain assertionChain) { }
+        protected override string Identifier { get; }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
     }
     public class PropertyInfoAssertions : AwesomeAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, AwesomeAssertions.Types.PropertyInfoAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -112,6 +112,8 @@ namespace AwesomeAssertions
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public static AwesomeAssertions.Types.ParameterInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ParameterInfo parameterInfo) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
@@ -2887,6 +2889,23 @@ namespace AwesomeAssertions.Types
             where TAttribute : System.Attribute { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public sealed class ParameterInfoAssertions : AwesomeAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.ParameterInfo, AwesomeAssertions.Types.ParameterInfoAssertions>
+    {
+        public ParameterInfoAssertions(System.Reflection.ParameterInfo subject, AwesomeAssertions.Execution.AssertionChain assertionChain) { }
+        protected override string Identifier { get; }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
     }
     public class PropertyInfoAssertions : AwesomeAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, AwesomeAssertions.Types.PropertyInfoAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -116,6 +116,8 @@ namespace AwesomeAssertions
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public static AwesomeAssertions.Types.ParameterInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ParameterInfo parameterInfo) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
@@ -2949,6 +2951,23 @@ namespace AwesomeAssertions.Types
             where TAttribute : System.Attribute { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public sealed class ParameterInfoAssertions : AwesomeAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.ParameterInfo, AwesomeAssertions.Types.ParameterInfoAssertions>
+    {
+        public ParameterInfoAssertions(System.Reflection.ParameterInfo subject, AwesomeAssertions.Execution.AssertionChain assertionChain) { }
+        protected override string Identifier { get; }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Types.ParameterInfoAssertions, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Types.ParameterInfoAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
     }
     public class PropertyInfoAssertions : AwesomeAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, AwesomeAssertions.Types.PropertyInfoAssertions>
     {

--- a/Tests/AwesomeAssertions.Specs/AssertionExtensionsSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/AssertionExtensionsSpecs.cs
@@ -77,8 +77,8 @@ public class AssertionExtensionsSpecs
     {
         GetAllAssertionMethods()
             .Should().AllSatisfy(method =>
-                method.ReturnParameter.GetCustomAttribute<NotNullAttribute>()
-                    .Should().NotBeNull("because assertion {0} of type {1} must never return null", method, method.DeclaringType));
+                method.ReturnParameter.Should().BeDecoratedWith<NotNullAttribute>(
+                    "because assertion {0} of type {1} must never return null", method, method.DeclaringType));
     }
 
     private static IEnumerable<MethodInfo> GetAllAssertionMethods()
@@ -204,16 +204,16 @@ public class AssertionExtensionsSpecs
     [MemberData(nameof(GetShouldMethods), true)]
     public void Should_methods_returning_reference_or_nullable_type_assertions_are_annotated_with_not_null_attribute(MethodInfo method)
     {
-        var notNullAttribute = method.GetParameters().Single().GetCustomAttribute<NotNullAttribute>();
-        notNullAttribute.Should().NotBeNull();
+        method.GetParameters().Should().ContainSingle()
+            .Which.Should().BeDecoratedWith<NotNullAttribute>();
     }
 
     [Theory]
     [MemberData(nameof(GetShouldMethods), false)]
     public void Should_methods_not_returning_reference_or_nullable_type_assertions_are_not_annotated_with_not_null_attribute(MethodInfo method)
     {
-        var notNullAttribute = method.GetParameters().Single().GetCustomAttribute<NotNullAttribute>();
-        notNullAttribute.Should().BeNull();
+        method.GetParameters().Should().ContainSingle()
+            .Which.Should().NotBeDecoratedWith<NotNullAttribute>();
     }
 
     [Fact]
@@ -222,8 +222,8 @@ public class AssertionExtensionsSpecs
         GetAllShouldMethods()
             .Where(x => !IsGuardOverload(x))
             .Should().AllSatisfy(method =>
-                method.ReturnParameter.GetCustomAttribute<NotNullAttribute>()
-                    .Should().NotBeNull("because {0} must never return null", method));
+                method.ReturnParameter.Should().BeDecoratedWith<NotNullAttribute>(
+                    "because {0} must never return null", method));
     }
 
     public static TheoryData<MethodInfo> GetShouldMethods(bool referenceOrNullableTypes)

--- a/Tests/AwesomeAssertions.Specs/Types/ParameterInfoAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/ParameterInfoAssertionSpecs.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Xunit;
+using Xunit.Sdk;
+
+namespace AwesomeAssertions.Specs.Types;
+
+public sealed class ParameterInfoAssertionSpecs
+{
+    public sealed class BeDecoratedWith
+    {
+        [Fact]
+        public void When_parameter_is_decorated_with_expected_attribute_it_succeeds()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithAnnotatedParameter)).GetParameters()[0];
+
+            subject.Should().BeDecoratedWith<MaybeNullWhenAttribute>();
+        }
+
+        [Fact]
+        public void When_parameter_is_decorated_with_expected_attribute_with_the_expected_properties_it_succeeds()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithAnnotatedParameter)).GetParameters()[0];
+
+            subject.Should().BeDecoratedWith<MaybeNullWhenAttribute>(x => !x.ReturnValue);
+        }
+
+        [Fact]
+        public void When_input_parameter_is_not_decorated_with_expected_attribute_it_fails()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithoutAnnotations)).GetParameters()[0];
+
+            Action act = () => subject.Should().BeDecoratedWith<MaybeNullWhenAttribute>("we want to test the {0} message", "failure");
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected parameter object input *MaybeNullWhenAttribute because *failure message*not found*");
+        }
+
+        [Fact]
+        public void When_return_parameter_is_not_decorated_with_expected_attribute_it_fails()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithoutAnnotations)).ReturnParameter;
+
+            Action act = () => subject.Should().BeDecoratedWith<NotNullAttribute>("we want to test the {0} message", "failure");
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected return parameter bool *NotNullAttribute because *failure message*not found*");
+        }
+
+        [Fact]
+        public void When_parameter_is_decorated_with_expected_attribute_that_has_unexpected_properties_it_fails()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithAnnotatedParameter)).GetParameters()[0];
+
+            Action act = () => subject.Should().BeDecoratedWith<MaybeNullWhenAttribute>(x => x.ReturnValue,
+                "we want to test the {0} message", "failure");
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*parameter System.Object&*MaybeNullWhenAttribute matching *ReturnValue* because*failure message*no attribute*was found*");
+        }
+
+        [Fact]
+        public void When_injecting_a_null_predicate_it_should_throw()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithAnnotatedParameter)).GetParameters()[0];
+
+            Action act = () => subject.Should().BeDecoratedWith<MaybeNullWhenAttribute>(isMatchingAttributePredicate: null);
+
+            act.Should().Throw<ArgumentNullException>()
+                .WithParameterName("isMatchingAttributePredicate");
+        }
+
+        [Fact]
+        public void When_parameter_is_null_it_fails()
+        {
+            ParameterInfo subject = null;
+
+            Action act = () => subject.Should().BeDecoratedWith<MaybeNullWhenAttribute>();
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected parameter*MaybeNullWhenAttribute*subject is <null>*");
+        }
+    }
+
+    public sealed class NotBeDecoratedWith
+    {
+        [Fact]
+        public void When_parameter_is_not_decorated_with_expected_attribute_it_succeeds()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithoutAnnotations)).GetParameters()[0];
+
+            subject.Should().NotBeDecoratedWith<MaybeNullWhenAttribute>();
+        }
+
+        [Fact]
+        public void When_parameter_is_decorated_with_expected_attribute_with_the_expected_properties_it_fails()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithAnnotatedParameter)).GetParameters()[0];
+
+            Action act = () => subject.Should().NotBeDecoratedWith<MaybeNullWhenAttribute>(x => !x.ReturnValue,
+                "we want to test the {0} message", "failure");
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect parameter System.Object& input to be decorated with *.MaybeNullWhenAttribute matching Not(x.ReturnValue) because *failure message*was found*");
+        }
+
+        [Fact]
+        public void When_input_parameter_is_decorated_with_expected_attribute_it_fails()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithAnnotatedParameter)).GetParameters()[0];
+
+            Action act = () => subject.Should().NotBeDecoratedWith<MaybeNullWhenAttribute>("we want to test the {0} message", "failure");
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect parameter System.Object& input *MaybeNullWhenAttribute because *failure message*was found*");
+        }
+
+        [Fact]
+        public void When_return_parameter_is_decorated_with_expected_attribute_it_fails()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.ReturnsNotNull)).ReturnParameter;
+
+            Action act = () => subject.Should().NotBeDecoratedWith<NotNullAttribute>("we want to test the {0} message", "failure");
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect return parameter object *NotNullAttribute because *failure message*was found*");
+        }
+
+        [Fact]
+        public void When_parameter_is_decorated_with_expected_attribute_that_has_unexpected_properties_it_succeeds()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithAnnotatedParameter)).GetParameters()[0];
+
+            subject.Should().NotBeDecoratedWith<MaybeNullWhenAttribute>(x => x.ReturnValue);
+        }
+
+        [Fact]
+        public void When_injecting_a_null_predicate_it_should_throw()
+        {
+            ParameterInfo subject = typeof(TestStub).GetMethod(nameof(TestStub.WithAnnotatedParameter)).GetParameters()[0];
+
+            Action act = () => subject.Should().NotBeDecoratedWith<MaybeNullWhenAttribute>(isMatchingAttributePredicate: null);
+
+            act.Should().Throw<ArgumentNullException>()
+                .WithParameterName("isMatchingAttributePredicate");
+        }
+
+        [Fact]
+        public void When_parameter_is_null_it_fails()
+        {
+            ParameterInfo subject = null;
+
+            Action act = () => subject.Should().NotBeDecoratedWith<MaybeNullWhenAttribute>();
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect parameter*MaybeNullWhenAttribute*subject is <null>*");
+        }
+    }
+
+    private static class TestStub
+    {
+#pragma warning disable AV1562 // Don't use `ref` or `out` parameters: Used as testing subject.
+        public static bool WithAnnotatedParameter([MaybeNullWhen(false)] out object input)
+        {
+            input = null;
+            return false;
+        }
+
+        public static bool WithoutAnnotations(object input) => input is null;
+
+        [return: NotNull]
+        public static object ReturnsNotNull() => new();
+    }
+}

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -6,6 +6,11 @@ classes: wide
 sidebar:
   nav: "sidebar"
 ---
+## Unreleased
+
+### What's new
+* Add `[Not]BeDecoratedWith` for `ParameterInfo`- [#449](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/449)
+
 ## 9.4.0
 
 ### What's new


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

Fix #432 
## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
