### PR TITLE
feat: Revise `HttpResponseMessage` assertions documentation

### DIFF
--- a/docs/_pages/httpresponsemessages.md
+++ b/docs/_pages/httpresponsemessages.md
@@ -7,4 +7,103 @@ sidebar:
   nav: "sidebar"
 ---
 
-The support for assertions on this type was removed in Awesome Assertions 8.0. If you need to do assertions like these, we recommend you adopt [FluentAssertions.Web](https://github.com/adrianiftode/FluentAssertions.Web).
+Assertions on `HttpResponseMessage` were removed in Awesome Assertions 8.0. Use one of the following community packages instead:
+
+- [FluentAssertions.Web](https://github.com/adrianiftode/FluentAssertions.Web) for asserts on a materialised `HttpResponseMessage`.
+- [Fluent.Client.AwesomeAssertions](https://github.com/lepoco/fluent) for asserts directly on `Task<HttpResponseMessage>`; the task is awaited internally.
+
+## Fluent.Client.AwesomeAssertions
+
+```powershell
+dotnet add package Fluent.Client.AwesomeAssertions
+# optional — adds .Get() / .Post() / .Authorize() helpers on HttpClient
+dotnet add package Fluent.Client
+```
+
+### Status codes
+
+```csharp
+await client.PostAsync("/api/users", content).Should().Succeed();
+await client.PostAsync("/api/users", content).Should().SucceedWith(HttpStatusCode.Created);
+await client.GetAsync("/api/users/999").Should().BeNotFound();
+await client.DeleteAsync("/api/users/1").Should().HaveStatusCode(HttpStatusCode.NoContent);
+```
+
+Named shortcuts: `BeCreated()` · `BeNoContent()` · `BeBadRequest()` · `BeUnauthorized()` · `BeForbidden()` · `BeNotFound()` · `BeConflict()`
+
+Use `FailWith(HttpStatusCode)` when you need to assert a specific non-2xx code without a named shortcut. Use `HaveStatusCode` when the code could be either success or failure.
+
+### Headers
+
+```csharp
+await client.GetAsync("/api/users").Should().HaveHeader("X-Request-Id");
+await client.GetAsync("/api/users").Should().HaveHeaderWithValue("Cache-Control", "no-cache");
+await client.GetAsync("/api/users").Should().HaveContentType("application/json");
+```
+
+### Body
+
+`Satisfy<T>` deserialises the JSON body regardless of status code — useful for asserting `ProblemDetails` on error responses:
+
+```csharp
+await client.GetAsync("/api/users/1").Should().Satisfy<User>(u => u.Id.Should().Be(1));
+
+await client.PostAsync("/api/users", bad).Should().Satisfy<ProblemDetails>(p => p.Status.Should().Be(400));
+```
+
+`SucceedWith<T>` combines the 2xx check and body inspection in one call and short-circuits before deserialising on failure:
+
+```csharp
+await client.PostAsync("/api/users", content).Should().SucceedWith<User>(u => u.Name.Should().Be("John"));
+```
+
+Pass a raw `Action<HttpResponseMessage>` (or its async equivalent) to `Satisfy` for full control:
+
+```csharp
+await client.GetAsync("/api/data").Should().Satisfy(r => r.Headers.ETag.Should().NotBeNull());
+```
+
+### Customising JSON deserialisation
+
+Replace `HttpResponseMessageTaskAssertions.DefaultJsonOptions` once at test-suite start-up to apply custom converters globally. The built-in defaults are case-insensitive property matching, trailing commas allowed, and enums as strings.
+
+### Integration testing
+
+```csharp
+await client.PutAsync($"v1/orders/{id}", body).Should().BeCreated();
+await client.GetAsync($"v1/orders/{id}").Should().Satisfy<Order>(o => o.Status.Should().Be("Pending"));
+await client.PutAsync($"v1/orders/{id}/confirm", null).Should().Succeed();
+```
+
+See the [Fluent.Client.AwesomeAssertions README](https://github.com/lepoco/fluent/blob/main/src/Fluent.Client.AwesomeAssertions/README.md) for the full API reference and more examples.
+
+---
+
+## FluentAssertions.Web
+
+```powershell
+dotnet add package FluentAssertions.Web
+```
+
+It provides assertions specific to HTTP responses and outputs rich errors messages when the tests fail, so less time with debugging is spent.
+
+```csharp
+[Fact]
+public async Task Post_ReturnsOk()
+{
+    // Arrange
+    var client = _factory.CreateClient();
+
+    // Act
+    var response = await client.PostAsync("/api/comments", new StringContent(
+    """
+    {
+      "author": "John",
+      "content": "Hey, you..."
+    }
+    """, Encoding.UTF8, "application/json"));
+
+    // Assert
+    response.Should().Be200Ok();
+}
+```


### PR DESCRIPTION
Hey! I'm a huge fan of Awesome Assertions and have been actively spreading it to all our teams at work. We do a ton of heavy API integration testing, so I actually built my own extension assertions (Fluent.Client.AwesomeAssertions) to make asserting on Task<HttpResponseMessage> cleaner and more fluent.

I figured I'd help fill the gap in the docs and share my solution with others. I've updated the page to recommend FluentAssertions.Web (for standard objects) and my library (for async/task-based workflows), including some concise code snippets to help others get up and running quickly.

Hopefully, this helps people migrate smoothly!
<!-- Please provide a description of your changes above the IMPORTANT checklist -->


Sample:

```csharp
public sealed class FrontEndTests : IntegrationTests
{
    [Fact]
    [TestCaseId(59748)]
    public async Task FrontEndHealthCheck_ShouldReturnHealthy()
    {
        await FrontEndClient.Get("/healthz", cancellationToken: TestContext.Current.CancellationToken)
            .Should()
            .Succeed("because the step 1 requires a front-end service");
    }
}
```

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
