### PR TITLE
Fix build project

### DIFF
--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Nuke.Common" Version="$(NukeVersion)" />
     <PackageReference Include="Nuke.Components" Version="$(NukeVersion)" />
     <PackageReference Include="SharpCompress" Version="0.48.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.3.3" />
     <!-- Replace the implicitly referenced version 9.0.11, which is defined by the package Nuke.Common and has known vulnerabilities, with a fixed version -->
     <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
     <!-- Replace the implicitly referenced version 6.12.1, which is defined by the package Nuke.Common and has known vulnerabilities, with a fixed version -->


### PR DESCRIPTION
Building with 10.0.300 resulted in an error from the _build.csproj.
The actual cause for the error is unclear, but both updating or removing the Microsoft.Build.Tasks.Core package fixes the problem. Removing because it isn't needed at all.