### PR TITLE
Return AndWhichConstraint from IntersectWith

### DIFF
--- a/Src/AwesomeAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/AwesomeAssertions/Collections/GenericCollectionAssertions.cs
@@ -1904,7 +1904,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <see langword="null"/>.</exception>
     [return: NotNull]
-    public AndConstraint<TAssertions> IntersectWith(
+    public AndWhichConstraint<TAssertions, IEnumerable<T>> IntersectWith(
         IEnumerable<T> otherCollection,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
@@ -1916,9 +1916,11 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
             .ForCondition(Subject is not null)
             .FailWith("Expected {context:collection} to intersect with {0}{reason}, but found <null>.", otherCollection);
 
+        IEnumerable<T> sharedItems = [];
+
         if (assertionChain.Succeeded)
         {
-            IEnumerable<T> sharedItems = Subject!.Intersect(otherCollection);
+            sharedItems = Subject!.Intersect(otherCollection);
 
             assertionChain
                 .BecauseOf(because, becauseArgs)
@@ -1928,7 +1930,7 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                     otherCollection, Subject);
         }
 
-        return new AndConstraint<TAssertions>((TAssertions)this);
+        return new AndWhichConstraint<TAssertions, IEnumerable<T>>((TAssertions)this, sharedItems);
     }
 
     /// <summary>

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
@@ -613,7 +613,7 @@ namespace AwesomeAssertions.Collections
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<T>> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
@@ -631,7 +631,7 @@ namespace AwesomeAssertions.Collections
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<T>> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -640,7 +640,7 @@ namespace AwesomeAssertions.Collections
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<T>> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> NotBeEmpty([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -603,7 +603,7 @@ namespace AwesomeAssertions.Collections
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<T>> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -613,7 +613,7 @@ namespace AwesomeAssertions.Collections
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<TAssertions, System.Collections.Generic.IEnumerable<T>> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.IntersectWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.IntersectWith.cs
@@ -57,6 +57,18 @@ public partial class CollectionAssertionSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection to intersect with {4, 5} *failure message*, but found <null>.");
         }
+
+        [Fact]
+        public void When_asserting_the_items_in_two_intersecting_collections_intersect_it_return_the_shared_items()
+        {
+            // Arrange
+            int[] collection = [1, 2, 3, 4, 5];
+            int[] otherCollection = [4, 5, 6, 7];
+
+            // Act / Assert
+            collection.Should().IntersectWith(otherCollection)
+                .Which.Should().Equal(4, 5);
+        }
     }
 
     public class NotIntersectWith

--- a/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.IntersectWith.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.IntersectWith.cs
@@ -35,6 +35,18 @@ public partial class GenericCollectionAssertionOfStringSpecs
                 .WithMessage("Expected collection to intersect with {\"four\", \"five\"} because they should share items," +
                     " but {\"one\", \"two\", \"three\"} does not contain any shared items.");
         }
+
+        [Fact]
+        public void When_asserting_the_items_in_two_intersecting_collections_intersect_it_return_the_shared_items()
+        {
+            // Arrange
+            IEnumerable<string> collection = ["one", "two", "three"];
+            IEnumerable<string> otherCollection = ["three", "four", "five"];
+
+            // Act / Assert
+            collection.Should().IntersectWith(otherCollection)
+                .Which.Should().Equal("three");
+        }
     }
 
     public class NotIntersectWith

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,6 +10,7 @@ sidebar:
 
 ### What's new
 * Add `[Not]BeDecoratedWith` for `ParameterInfo`- [#449](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/449)
+* Return `AndWhichConstraint` from `IntersectWith` [#495](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/495)
 
 ## 9.4.0
 


### PR DESCRIPTION
This adds the feature described in #49
Fix #49
## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
