### PR TITLE
Return AndWhichConstraint from XElementAssertions.HaveAttribute

### DIFF
--- a/Src/AwesomeAssertions/Xml/XElementAssertions.cs
+++ b/Src/AwesomeAssertions/Xml/XElementAssertions.cs
@@ -180,7 +180,7 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     /// <exception cref="ArgumentNullException"><paramref name="expectedName"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="expectedName"/> is empty.</exception>
     [return: NotNull]
-    public AndConstraint<XElementAssertions> HaveAttribute(string expectedName,
+    public AndWhichConstraint<XElementAssertions, XAttribute> HaveAttribute(string expectedName,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNullOrEmpty(expectedName);
@@ -201,12 +201,14 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="expectedName"/> is <see langword="null"/>.</exception>
     [return: NotNull]
-    public AndConstraint<XElementAssertions> HaveAttribute(XName expectedName,
+    public AndWhichConstraint<XElementAssertions, XAttribute> HaveAttribute(XName expectedName,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNull(expectedName);
 
         string expectedText = expectedName.ToString();
+
+        XAttribute selectedAttribute = null;
 
         assertionChain
             .WithExpectation("Expected attribute {0} in element to exist {reason}, ", expectedText,
@@ -219,11 +221,16 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
             .WithExpectation("Expected {context:subject} to have attribute {0}{reason}, ", expectedText,
                 chain => chain
                     .BecauseOf(because, becauseArgs)
-                    .Given(() => Subject!.Attribute(expectedName))
+                    .Given(() =>
+                    {
+                        selectedAttribute = Subject!.Attribute(expectedName);
+
+                        return selectedAttribute;
+                    })
                     .ForCondition(attribute => attribute is not null)
                     .FailWith("but found no such attribute in {0}.", Subject));
 
-        return new AndConstraint<XElementAssertions>(this);
+        return new AndWhichConstraint<XElementAssertions, XAttribute>(this, selectedAttribute);
     }
 
     /// <summary>

--- a/Src/AwesomeAssertions/Xml/XElementAssertions.cs
+++ b/Src/AwesomeAssertions/Xml/XElementAssertions.cs
@@ -230,7 +230,9 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
                     .ForCondition(attribute => attribute is not null)
                     .FailWith("but found no such attribute in {0}.", Subject));
 
-        return new AndWhichConstraint<XElementAssertions, XAttribute>(this, selectedAttribute);
+        var postfix = $".Attribute(\"{expectedText}\")";
+        return new AndWhichConstraint<XElementAssertions, XAttribute>(this, selectedAttribute, assertionChain, postfix);
+);
     }
 
     /// <summary>

--- a/Src/AwesomeAssertions/Xml/XElementAssertions.cs
+++ b/Src/AwesomeAssertions/Xml/XElementAssertions.cs
@@ -232,7 +232,6 @@ public class XElementAssertions : ReferenceTypeAssertions<XElement, XElementAsse
 
         var postfix = $".Attribute(\"{expectedText}\")";
         return new AndWhichConstraint<XElementAssertions, XAttribute>(this, selectedAttribute, assertionChain, postfix);
-);
     }
 
     /// <summary>

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
@@ -3325,9 +3325,9 @@ namespace AwesomeAssertions.Xml
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(System.Xml.Linq.XName expectedName, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(string expectedName, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttributeWithValue(System.Xml.Linq.XName expectedName, string expectedValue, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
@@ -3527,9 +3527,9 @@ namespace AwesomeAssertions.Xml
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(System.Xml.Linq.XName expectedName, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(string expectedName, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttributeWithValue(System.Xml.Linq.XName expectedName, string expectedValue, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -3548,9 +3548,9 @@ namespace AwesomeAssertions.Xml
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(System.Xml.Linq.XName expectedName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(string expectedName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttributeWithValue(System.Xml.Linq.XName expectedName, string expectedValue, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -3267,9 +3267,9 @@ namespace AwesomeAssertions.Xml
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(System.Xml.Linq.XName expectedName, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(string expectedName, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttributeWithValue(System.Xml.Linq.XName expectedName, string expectedValue, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -3329,9 +3329,9 @@ namespace AwesomeAssertions.Xml
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(System.Xml.Linq.XName expectedName, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
-        public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.AndWhichConstraint<AwesomeAssertions.Xml.XElementAssertions, System.Xml.Linq.XAttribute> HaveAttribute(string expectedName, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<AwesomeAssertions.Xml.XElementAssertions> HaveAttributeWithValue(System.Xml.Linq.XName expectedName, string expectedValue, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -1028,6 +1028,31 @@ public class XElementAssertionSpecs
         }
     }
 
+    public class HaveAttributeWhich
+    {
+        [Fact]
+        public void When_asserting_element_has_attribute_which_has_value_it_should_succeed()
+        {
+            // Arrange
+            var element = XElement.Parse(@"<user name=""martin"" />");
+
+            // Act / Assert
+            element.Should().HaveAttribute("name")
+                .Which.Value.Should().Contain("art");
+        }
+
+        [Fact]
+        public void When_asserting_element_has_attribute_with_ns_which_has_value_it_should_succeed()
+        {
+            // Arrange
+            var element = XElement.Parse("""<user xmlns:a="http://www.example.com/2012/test" a:name="martin" />""");
+
+            // Act / Assert
+            element.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"))
+                .Which.Value.Should().Contain("art");
+        }
+    }
+
     public class HaveAttributeWithValue
     {
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -1092,12 +1092,11 @@ public class XElementAssertionSpecs
             var theElement = XElement.Parse("""<user name="martin" />""");
 
             // Act
-            Action act = () =>
-                theElement.Should().HaveAttribute("name")
-                    .Which.Value.Should().Be("dennis");
+            Action act = () => theElement.Should().HaveAttribute("name").Which.Value.Should().Be("dennis");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*differ at index 0*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement.Attribute(\"name\") to be the same string, but they differ at index 0:*martin*dennis*");
         }
 
         [Fact]

--- a/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -1112,7 +1112,8 @@ public class XElementAssertionSpecs
                     .Which.Value.Should().Be("dennis");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*differ at index 0*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement.Attribute(\"{*}name\") to be the same string, but they differ at index 0:*martin*dennis*");
         }
     }
 

--- a/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -1051,6 +1051,39 @@ public class XElementAssertionSpecs
             element.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"))
                 .Which.Value.Should().Contain("art");
         }
+
+        [Fact]
+        public void When_asserting_element_has_attribute_which_has_value_but_attribute_does_not_exist_it_should_fail()
+        {
+            // Arrange
+            var theElement = XElement.Parse("""<user name="martin" />""");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveAttribute("age")
+                    .Which.Value.Should().Be("36");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have attribute \"age\", but found no such attribute in <user name=\"martin\" />.");
+        }
+
+        [Fact]
+        public void When_asserting_element_has_attribute_with_ns_which_has_value_but_attribute_does_not_exist_it_should_fail()
+        {
+            // Arrange
+            var theElement = XElement.Parse("""<user xmlns:a="http://www.example.com/2012/test" a:name="martin" />""");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"))
+                    .Which.Value.Should().Be("36");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\","
+                + " but found no such attribute in <user xmlns:a=\"http://www.example.com/2012/test\" a:name=\"martin\" />.");
+        }
     }
 
     public class HaveAttributeWithValue

--- a/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -1084,6 +1084,37 @@ public class XElementAssertionSpecs
                 "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\","
                 + " but found no such attribute in <user xmlns:a=\"http://www.example.com/2012/test\" a:name=\"martin\" />.");
         }
+
+        [Fact]
+        public void When_asserting_element_has_attribute_which_has_value_but_attribute_has_different_value_it_should_fail()
+        {
+            // Arrange
+            var theElement = XElement.Parse("""<user name="martin" />""");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveAttribute("name")
+                    .Which.Value.Should().Be("dennis");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*differ at index 0*");
+        }
+
+        [Fact]
+        public void
+            When_asserting_element_has_attribute_with_ns_which_has_value_but_attribute_has_different_value_it_should_fail()
+        {
+            // Arrange
+            var theElement = XElement.Parse("""<user xmlns:a="http://www.example.com/2012/test" a:name="martin" />""");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"))
+                    .Which.Value.Should().Be("dennis");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*differ at index 0*");
+        }
     }
 
     public class HaveAttributeWithValue

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,7 +11,7 @@ sidebar:
 ### What's new
 * Add `[Not]BeDecoratedWith` for `ParameterInfo`- [#449](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/449)
 * Return `AndWhichConstraint` from `IntersectWith` [#495](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/495)
-* Return AndWhichConstraint from XElementAssertions.HaveAttribute [#504](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/504)
+* Return `AndWhichConstraint` from `XElementAssertions.HaveAttribute` [#504](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/504)
 
 ## 9.4.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 ### What's new
 * Add `[Not]BeDecoratedWith` for `ParameterInfo`- [#449](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/449)
 * Return `AndWhichConstraint` from `IntersectWith` [#495](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/495)
+* Return AndWhichConstraint from XElementAssertions.HaveAttribute [#504](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/504)
 
 ## 9.4.0
 


### PR DESCRIPTION
This adds the feature described in #454 

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
