### PR TITLE
chore(deps): update dependency polysharp to 1.16.0

### DIFF
--- a/Src/AwesomeAssertions/AwesomeAssertions.csproj
+++ b/Src/AwesomeAssertions/AwesomeAssertions.csproj
@@ -36,6 +36,7 @@
 
   <PropertyGroup>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+    <PolySharpUseEmbeddedAttributeForGeneratedTypes>false</PolySharpUseEmbeddedAttributeForGeneratedTypes>
   </PropertyGroup>
 
   <ItemGroup Label="Internals visible to">
@@ -59,7 +60,7 @@
   <ItemGroup Label="Analyzers">
     <AdditionalFiles Include="BannedSymbols.txt" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" PrivateAssets="all" />
-    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.16.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Target framework dependent configuration -->

--- a/Tests/AwesomeAssertions.Extensibility.Specs/AwesomeAssertions.Extensibility.Specs.csproj
+++ b/Tests/AwesomeAssertions.Extensibility.Specs/AwesomeAssertions.Extensibility.Specs.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PolySharp" Version="1.15.0">
+    <PackageReference Include="PolySharp" Version="1.16.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

PolySharp 1.16.0 changed the polyfilled attributes to be generated with `[Embedded]`.
This makes problems when checking if some assertions are marked e.g. with `[return:NotNull]`. There might have been other ways around, but these complicated thing unnecessarily. So I decided to set `PolySharpUseEmbeddedAttributeForGeneratedTypes` to `false` to restore the previous behavior.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [ ] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
