### PR TITLE
Add AssertionChain.ForCondition with lazy condition

### DIFF
--- a/Src/AwesomeAssertions/Execution/AssertionChain.cs
+++ b/Src/AwesomeAssertions/Execution/AssertionChain.cs
@@ -180,6 +180,16 @@ public sealed class AssertionChain
         return this;
     }
 
+    public AssertionChain ForCondition(Func<bool> condition)
+    {
+        if (PreviousAssertionSucceeded)
+        {
+            succeeded = condition();
+        }
+
+        return this;
+    }
+
     public AssertionChain ForConstraint(OccurrenceConstraint constraint, int actualOccurrences)
     {
         if (PreviousAssertionSucceeded)

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
@@ -1404,6 +1404,7 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.Continuation FailWith(string message) { }
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public AwesomeAssertions.Execution.AssertionChain ForCondition(System.Func<bool> condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
@@ -1426,6 +1426,7 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
         [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public AwesomeAssertions.Execution.AssertionChain ForCondition(System.Func<bool> condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -1435,6 +1435,7 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
         [System.Diagnostics.StackTraceHidden]
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public AwesomeAssertions.Execution.AssertionChain ForCondition(System.Func<bool> condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -1346,6 +1346,7 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.Continuation FailWith(string message) { }
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public AwesomeAssertions.Execution.AssertionChain ForCondition(System.Func<bool> condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -1404,6 +1404,7 @@ namespace AwesomeAssertions.Execution
         public AwesomeAssertions.Execution.Continuation FailWith(string message) { }
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params System.Func<object>[] argProviders) { }
         public AwesomeAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public AwesomeAssertions.Execution.AssertionChain ForCondition(System.Func<bool> condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForCondition(bool condition) { }
         public AwesomeAssertions.Execution.AssertionChain ForConstraint(AwesomeAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public AwesomeAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
@@ -578,21 +578,18 @@ public partial class AssertionChainSpecs
         [Fact]
         public void A_successful_lazy_assertion_does_not_affect_the_chained_failing_assertion()
         {
-            // Act
             Action act = () => AssertionChain.GetOrCreate()
                 .ForCondition(() => true)
                 .FailWith("First assertion")
                 .Then
                 .FailWith("Second assertion");
 
-            // Arrange
             act.Should().Throw<XunitException>().WithMessage("*Second assertion*");
         }
 
         [Fact]
         public void A_successful_assertion_does_not_affect_the_chained_failing_lazy_assertion()
         {
-            // Act
             Action act = () => AssertionChain.GetOrCreate()
                 .ForCondition(true)
                 .FailWith("First assertion")
@@ -600,17 +597,14 @@ public partial class AssertionChainSpecs
                 .ForCondition(() => false)
                 .FailWith("Second assertion");
 
-            // Arrange
             act.Should().Throw<XunitException>().WithMessage("*Second assertion*");
         }
 
         [Fact]
         public void When_the_previous_lazy_assertion_failed_it_should_not_execute_the_succeeding_failure()
         {
-            // Arrange
             var scope = new AssertionScope();
 
-            // Act
             AssertionChain.GetOrCreate()
                 .ForCondition(() => false)
                 .FailWith("First assertion")
@@ -629,7 +623,6 @@ public partial class AssertionChainSpecs
         {
             bool lazyConditionEvaluated = false;
 
-            // Act
             Action act = () => AssertionChain.GetOrCreate()
                 .ForCondition(false)
                 .FailWith("First assertion")
@@ -641,7 +634,6 @@ public partial class AssertionChainSpecs
                 })
                 .FailWith("Second assertion");
 
-            // Arrange
             act.Should().Throw<XunitException>().WithMessage("*First assertion*");
             lazyConditionEvaluated.Should().BeFalse();
         }

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
@@ -575,6 +575,56 @@ public partial class AssertionChainSpecs
             Assert.Contains("First \"assertion\"", failures);
         }
 
+        [Fact]
+        public void A_successful_lazy_assertion_does_not_affect_the_chained_failing_assertion()
+        {
+            // Act
+            Action act = () => AssertionChain.GetOrCreate()
+                .ForCondition(() => true)
+                .FailWith("First assertion")
+                .Then
+                .FailWith("Second assertion");
+
+            // Arrange
+            act.Should().Throw<XunitException>().WithMessage("*Second assertion*");
+        }
+
+        [Fact]
+        public void A_successful_assertion_does_not_affect_the_chained_failing_lazy_assertion()
+        {
+            // Act
+            Action act = () => AssertionChain.GetOrCreate()
+                .ForCondition(true)
+                .FailWith("First assertion")
+                .Then
+                .ForCondition(() => false)
+                .FailWith("Second assertion");
+
+            // Arrange
+            act.Should().Throw<XunitException>().WithMessage("*Second assertion*");
+        }
+
+        [Fact]
+        public void When_the_previous_lazy_assertion_failed_it_should_not_execute_the_succeeding_failure()
+        {
+            // Arrange
+            var scope = new AssertionScope();
+
+            // Act
+            AssertionChain.GetOrCreate()
+                .ForCondition(() => false)
+                .FailWith("First assertion")
+                .Then
+                .ForCondition(false)
+                .FailWith("Second assertion");
+
+            string[] failures = scope.Discard();
+            scope.Dispose();
+
+            Assert.Single(failures);
+            Assert.Contains("First assertion", failures);
+        }
+
         // [Fact]
         // public void Get_info_about_line_breaks_from_parent_scope_after_continuing_chained_assertion()
         // {

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
@@ -621,8 +621,29 @@ public partial class AssertionChainSpecs
             string[] failures = scope.Discard();
             scope.Dispose();
 
-            Assert.Single(failures);
-            Assert.Contains("First assertion", failures);
+            failures.Should().Equal("First assertion");
+        }
+
+        [Fact]
+        public void A_lazy_condition_is_not_evaluated_if_a_previous_assertion_in_chain_failed()
+        {
+            bool lazyConditionEvaluated = false;
+
+            // Act
+            Action act = () => AssertionChain.GetOrCreate()
+                .ForCondition(false)
+                .FailWith("First assertion")
+                .Then
+                .ForCondition(() =>
+                {
+                    lazyConditionEvaluated = true;
+                    return false;
+                })
+                .FailWith("Second assertion");
+
+            // Arrange
+            act.Should().Throw<XunitException>().WithMessage("*First assertion*");
+            lazyConditionEvaluated.Should().BeFalse();
         }
 
         // [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 * Add `[Not]BeDecoratedWith` for `ParameterInfo`- [#449](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/449)
 * Return `AndWhichConstraint` from `IntersectWith` [#495](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/495)
 * Return `AndWhichConstraint` from `XElementAssertions.HaveAttribute` [#504](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/504)
+* Add overload of `AssertionChain.ForCondition()` that allows for lazy execution of `condition` [#511](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/511)
 
 ## 9.4.0
 


### PR DESCRIPTION
This implements #271, adding an overload to `AssertionChain.ForCondition()` where the condition is a `Func<bool>` that will be lazily evaluated.
Fix #271
## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
