### PR TITLE
Removing duplicate ForConditions() in two TypeAssertions methods

### DIFF
--- a/Src/AwesomeAssertions/Types/TypeAssertions.cs
+++ b/Src/AwesomeAssertions/Types/TypeAssertions.cs
@@ -1742,7 +1742,7 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         {
             CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
 
-            assertionChain.ForCondition(accessModifier == subjectAccessModifier)
+            assertionChain
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(accessModifier == subjectAccessModifier)
                 .FailWith(
@@ -1783,7 +1783,6 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
             CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
 
             assertionChain
-                .ForCondition(accessModifier != subjectAccessModifier)
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(accessModifier != subjectAccessModifier)
                 .FailWith($"Expected {{context:type}} {{0}} not to be {accessModifier}{{reason}}, but it is.",


### PR DESCRIPTION
While researching the usages of `AssertionChain.ForCondition()` I came across these two usages where there were duplicate conditions in a chain.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [ ] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
