### PR TITLE
Fix for #521: Re-wrote `GivenSelector<T>.FailWith()` to match `AssertionChain.FailWith()`

### DIFF
--- a/Src/AwesomeAssertions/Execution/GivenSelector.cs
+++ b/Src/AwesomeAssertions/Execution/GivenSelector.cs
@@ -71,12 +71,9 @@ public class GivenSelector<T>
 
     public ContinuationOfGiven<T> FailWith(string message, params Func<T, object>[] args)
     {
-        if (assertionChain.PreviousAssertionSucceeded)
-        {
-            object[] mappedArguments = args.Select(a => a(selector)).ToArray();
-            return FailWith(message, mappedArguments);
-        }
-
+        assertionChain.FailWith(() => new FailReason(
+            message,
+            args.Select(a => a(selector)).ToArray()));
         return new ContinuationOfGiven<T>(this);
     }
 

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.Chaining.cs
@@ -638,6 +638,68 @@ public partial class AssertionChainSpecs
             lazyConditionEvaluated.Should().BeFalse();
         }
 
+        [Fact]
+        public void When_an_assertion_succeeds_it_should_not_invoke_the_fail_reason_provider()
+        {
+            var invocationCount = 0;
+
+            AssertionChain.GetOrCreate()
+                .ForCondition(true)
+                .FailWith("Expected {0}", () =>
+                {
+                    ++invocationCount;
+
+                    return "nothing";
+                });
+
+            invocationCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void When_an_assertion_succeeds_it_should_not_invoke_argument_providers()
+        {
+            var invocationCount = 0;
+
+            AssertionChain.GetOrCreate()
+                .ForCondition(true)
+                .FailWith(() =>
+                {
+                    ++invocationCount;
+
+                    return new FailReason("Expected nothing");
+                });
+
+            invocationCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void When_an_assertion_fails_it_should_invoke_the_fail_reason_provider()
+        {
+            Action act = () =>
+            {
+                AssertionChain.GetOrCreate()
+                    .ForCondition(() => false)
+                    .FailWith("Expected {0}", () => "a failure");
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected \"a failure\"");
+        }
+
+        [Fact]
+        public void When_an_assertion_fails_it_should_invoke_argument_providers()
+        {
+            Action act = () =>
+            {
+                AssertionChain.GetOrCreate()
+                    .ForCondition(() => false)
+                    .FailWith(() => new FailReason("Expected a failure"));
+            };
+
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected a failure");
+        }
+
         // [Fact]
         // public void Get_info_about_line_breaks_from_parent_scope_after_continuing_chained_assertion()
         // {

--- a/Tests/AwesomeAssertions.Specs/Execution/GivenSelectorSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/GivenSelectorSpecs.cs
@@ -226,4 +226,74 @@ public class GivenSelectorSpecs
         // Assert
         assertionChain.Succeeded.Should().BeTrue();
     }
+
+    [Fact]
+    public void When_an_assertion_succeeds_it_should_not_invoke_argument_providers()
+    {
+        var invocationCount = 0;
+
+        AssertionChain.GetOrCreate()
+            .Given(static () => "Don't care")
+            .ForCondition(static _ => true)
+            .FailWith("Expected {0}", _ =>
+            {
+                ++invocationCount;
+
+                return "nothing";
+            });
+
+        invocationCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void When_an_assertion_succeeds_it_should_not_invoke_the_fail_reason_provider()
+    {
+        var invocationCount = 0;
+
+        AssertionChain.GetOrCreate()
+            .Given(static () => "Don't care")
+            .ForCondition(static _ => true)
+            .FailWith(_ =>
+            {
+                ++invocationCount;
+
+                return new FailReason("Expected nothing");
+            });
+
+        invocationCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void When_an_assertion_fails_it_should_invoke_argument_providers()
+    {
+        // Act
+        Action act = () =>
+        {
+            AssertionChain.GetOrCreate()
+                .Given(static () => "Don't care")
+                .ForCondition(static _ => false)
+                .FailWith("Expected {0}", _ => "a failure");
+        };
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected \"a failure\"");
+    }
+
+    [Fact]
+    public void When_an_assertion_fails_it_should_invoke_the_fail_reason_provider()
+    {
+        // Act
+        Action act = () =>
+        {
+            AssertionChain.GetOrCreate()
+                .Given(static () => "Don't care")
+                .ForCondition(static _ => false)
+                .FailWith(_ => new FailReason("Expected a failure"));
+        };
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected a failure");
+    }
 }


### PR DESCRIPTION
Re-wrote the overload of `GivenSelector<T>.FailWith()` that accepts `Func<>` args to match the behavior of the equivalent overload of `AssertionChain.FailWith()`.

The previous implementation seems to have been based on a faulty assumption of how `AssertionChain.PreviousAssertionSucceeded` works. Checking it does not ensure that logic doesn't run in the event of a failure of the current assertion that the `.FailWith()` call applies to, but rather the previous assertion in the chain (if any).

This implementation matches the logic of all the other `.FailWith()` implementations on `GivenSelector<T>`, as well as most of them on `AssertionChain`: it just wraps up the message-rendering logic and passes off the real work for dealing with fail/pass conditions to existing logic within `AssertionChain`.

Also added tests to cover this functionality, and confirm similar functionality in several overloads of `.FailWith()` for both `AssertionChain` and `GivenSelector<T>`.

Fix #521 
## IMPORTANT 

* [X] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [X] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [X] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [X] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [X] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [X] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
