### PR TITLE
Fix AssertionResultSet

### DIFF
--- a/Src/AwesomeAssertions/Equivalency/Steps/AssertionResultSet.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/AssertionResultSet.cs
@@ -37,6 +37,10 @@ internal class AssertionResultSet
         }
 
         KeyValuePair<object, string[]>[] bestResultSets = GetBestResultSets();
+        if (bestResultSets.Length == 0)
+        {
+            return [];
+        }
 
         KeyValuePair<object, string[]> bestMatch = Array.Find(bestResultSets, r => r.Key.Equals(key));
 
@@ -50,6 +54,11 @@ internal class AssertionResultSet
 
     private KeyValuePair<object, string[]>[] GetBestResultSets()
     {
+        if (set.Values.Count == 0)
+        {
+            return [];
+        }
+
         int fewestFailures = set.Values.Min(r => r.Length);
         return set.Where(r => r.Value.Length == fewestFailures).ToArray();
     }

--- a/Tests/AwesomeAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using AwesomeAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -99,5 +100,21 @@ public class ThrowAssertionsSpecs
             ex.Message.Should().Be(
                 "Expected a <System.Exception> to be thrown, but no exception was thrown.");
         }
+    }
+
+    [Fact]
+    public void When_null_action_is_expected_to_throw_inside_scope_it_should_report_the_null_failure()
+    {
+        Action act = () =>
+        {
+            Action nullAct = null;
+
+            _ = new AssertionScope();
+            nullAct.Should().Throw<InvalidOperationException>()
+                .WithMessage("*");
+        };
+
+        act.Should().Throw<XunitException>()
+            .WithMessage("*InvalidOperationException* <null>*");
     }
 }


### PR DESCRIPTION
* Backported from FA v7.2.2 https://github.com/fluentassertions/fluentassertions/commit/f3b47cb8909c7a89121cc191fac2e4c4de5beaa6
* Added test, which wasn't added to FA
* Part of #534 

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [ ] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
