### PR TITLE
Allow formatting becauseArgs as plain strings

### DIFF
--- a/Src/AwesomeAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/AwesomeAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -34,13 +34,15 @@ internal class MustMatchByNameRule : IMemberMatchingRule
         if (subjectMember is null)
         {
             assertionChain.FailWith(
-                $"Expectation has {expectedMember.Expectation} that the other object does not have.");
+                "Expectation has {0} that the other object does not have.",
+                expectedMember.Expectation.AsNonFormattable());
         }
         else if (options.IgnoreNonBrowsableOnSubject && !subjectMember.IsBrowsable)
         {
             assertionChain.FailWith(
-                $"Expectation has {expectedMember.Expectation} that is non-browsable in the other object, and non-browsable " +
-                "members on the subject are ignored with the current configuration");
+                "Expectation has {0} that is non-browsable in the other object, and non-browsable " +
+                "members on the subject are ignored with the current configuration",
+                expectedMember.Expectation.AsNonFormattable());
         }
         else
         {

--- a/Src/AwesomeAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
@@ -72,13 +72,12 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
 
         assertionChain
                 .ForCondition(subjectIsNull || comparands.Subject.GetType().IsSameOrInherits(typeof(TSubject)))
-                .FailWith("Expected " + context.CurrentNode.Subject + " from subject to be a {0}{reason}, but found a {1}.",
-                    typeof(TSubject), comparands.Subject?.GetType())
+                .FailWith("Expected {0} from subject to be a {1}{reason}, but found a {2}.",
+                    context.CurrentNode.Subject.AsNonFormattable(), typeof(TSubject), comparands.Subject?.GetType())
                 .Then
                 .ForCondition(expectationIsNull || comparands.Expectation.GetType().IsSameOrInherits(typeof(TSubject)))
-                .FailWith(
-                    "Expected " + context.CurrentNode.Subject + " from expectation to be a {0}{reason}, but found a {1}.",
-                    typeof(TSubject), comparands.Expectation?.GetType());
+                .FailWith("Expected {0} from expectation to be a {1}{reason}, but found a {2}.",
+                    context.CurrentNode.Subject.AsNonFormattable(), typeof(TSubject), comparands.Expectation?.GetType());
 
         if (assertionChain.Succeeded)
         {

--- a/Src/AwesomeAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
@@ -82,13 +82,12 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
 
         assertionChain
                 .ForCondition(subjectIsNull || comparands.Subject.GetType().IsSameOrInherits(typeof(TSubject)))
-                .FailWith("Expected " + context.CurrentNode.Subject + " from subject to be a {0}{reason}, but found a {1}.",
-                    typeof(TSubject), comparands.Subject?.GetType())
+                .FailWith("Expected {0} from subject to be a {1}{reason}, but found a {2}.",
+                    context.CurrentNode.Subject.AsNonFormattable(), typeof(TSubject), comparands.Subject?.GetType())
                 .Then
                 .ForCondition(expectationIsNull || comparands.Expectation.GetType().IsSameOrInherits(typeof(TSubject)))
-                .FailWith(
-                    "Expected " + context.CurrentNode.Subject + " from expectation to be a {0}{reason}, but found a {1}.",
-                    typeof(TSubject), comparands.Expectation?.GetType());
+                .FailWith("Expected {0} from expectation to be a {1}{reason}, but found a {2}.",
+                    context.CurrentNode.Subject.AsNonFormattable(), typeof(TSubject), comparands.Expectation?.GetType());
 
         if (assertionChain.Succeeded)
         {

--- a/Src/AwesomeAssertions/Equivalency/Steps/EnumEqualityStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/EnumEqualityStep.cs
@@ -29,8 +29,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
                 return new FailReason(
-                    $"Expected {{context:enum}} to be equivalent to {expectationName}{{reason}}, but found {{0}}.",
-                    comparands.Subject);
+                    "Expected {context:enum} to be equivalent to {0}{reason}, but found {1}.",
+                    expectationName.AsNonFormattable(), comparands.Subject);
             });
 
         if (assertionChain.Succeeded)
@@ -67,7 +67,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
                 return new FailReason(
-                    $"Expected {{context:enum}} to equal {expectationName} by value{{reason}}, but found {subjectsName}.");
+                    "Expected {context:enum} to equal {0} by value{reason}, but found {1}.",
+                    expectationName.AsNonFormattable(), subjectsName.AsNonFormattable());
             });
     }
 
@@ -88,7 +89,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
                 return new FailReason(
-                    $"Expected {{context:enum}} to equal {expectationName} by name{{reason}}, but found {subjectsName}.");
+                    "Expected {context:enum} to equal {0} by name{reason}, but found {1}.",
+                    expectationName.AsNonFormattable(), subjectsName.AsNonFormattable());
             });
     }
 
@@ -102,7 +104,7 @@ public class EnumEqualityStep : IEquivalencyStep
         string typePart = o.GetType().Name;
         string namePart = o.ToString().Replace(", ", "|", StringComparison.Ordinal);
         string valuePart = v.Value.ToString(CultureInfo.InvariantCulture);
-        return $"{typePart}.{namePart} {{{{value: {valuePart}}}}}";
+        return $"{typePart}.{namePart} {{value: {valuePart}}}";
     }
 
     private static decimal? ExtractDecimal(object o)

--- a/Src/AwesomeAssertions/Equivalency/Steps/EnumEqualityStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/EnumEqualityStep.cs
@@ -34,8 +34,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
                 return new FailReason(
-                    $"Expected {{context:enum}} to be equivalent to {expectationName}{{reason}}, but found {{0}}.",
-                    comparands.Subject);
+                    "Expected {context:enum} to be equivalent to {0}{reason}, but found {1}.",
+                    expectationName.AsNonFormattable(), comparands.Subject);
             });
 
         if (assertionChain.Succeeded)
@@ -72,7 +72,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
                 return new FailReason(
-                    $"Expected {{context:enum}} to equal {expectationName} by value{{reason}}, but found {subjectsName}.");
+                    "Expected {context:enum} to equal {0} by value{reason}, but found {1}.",
+                    expectationName.AsNonFormattable(), subjectsName.AsNonFormattable());
             });
     }
 
@@ -93,7 +94,8 @@ public class EnumEqualityStep : IEquivalencyStep
                 string expectationName = GetDisplayNameForEnumComparison(comparands.Expectation, expectationsUnderlyingValue);
 
                 return new FailReason(
-                    $"Expected {{context:enum}} to equal {expectationName} by name{{reason}}, but found {subjectsName}.");
+                    "Expected {context:enum} to equal {0} by name{reason}, but found {1}.",
+                    expectationName.AsNonFormattable(), subjectsName.AsNonFormattable());
             });
     }
 
@@ -107,7 +109,7 @@ public class EnumEqualityStep : IEquivalencyStep
         string typePart = o.GetType().Name;
         string namePart = o.ToString().Replace(", ", "|", StringComparison.Ordinal);
         string valuePart = v.Value.ToString(CultureInfo.InvariantCulture);
-        return $"{typePart}.{namePart} {{{{value: {valuePart}}}}}";
+        return $"{typePart}.{namePart} {{value: {valuePart}}}";
     }
 
     private static decimal? ExtractDecimal(object o)

--- a/Src/AwesomeAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -1,5 +1,4 @@
 using System;
-using AwesomeAssertions.Common;
 using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
@@ -80,7 +79,8 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         if (onlyOneNull)
         {
             assertionChain.FailWith(
-                $"Expected {currentNode.Subject.Description.EscapePlaceholders()} to be {{0}}{{reason}}, but found {{1}}.", expected, subject);
+                "Expected {0} to be {1}{reason}, but found {2}.",
+                currentNode.Subject.Description.AsNonFormattable(), expected, subject);
 
             return false;
         }
@@ -96,8 +96,8 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         }
 
         assertionChain.FailWith(
-            $"Expected {currentNode} to be {{0}}, but found {{1}}.",
-            comparands.RuntimeType, comparands.Subject.GetType());
+            "Expected {0} to be {1}, but found {2}.",
+            currentNode.AsNonFormattable(), comparands.RuntimeType, comparands.Subject.GetType());
 
         return assertionChain.Succeeded;
     }

--- a/Src/AwesomeAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -1,5 +1,4 @@
 using System;
-using AwesomeAssertions.Common;
 using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
@@ -85,7 +84,8 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         if (onlyOneNull)
         {
             assertionChain.FailWith(
-                $"Expected {currentNode.Subject.Description.EscapePlaceholders()} to be {{0}}{{reason}}, but found {{1}}.", expected, subject);
+                "Expected {0} to be {1}{reason}, but found {2}.",
+                currentNode.Subject.Description.AsNonFormattable(), expected, subject);
 
             return false;
         }
@@ -101,8 +101,8 @@ public class StringEqualityEquivalencyStep : IEquivalencyStep
         }
 
         assertionChain.FailWith(
-            $"Expected {currentNode} to be {{0}}, but found {{1}}.",
-            comparands.RuntimeType, comparands.Subject.GetType());
+            "Expected {0} to be {1}, but found {2}.",
+            currentNode.AsNonFormattable(), comparands.RuntimeType, comparands.Subject.GetType());
 
         return assertionChain.Succeeded;
     }

--- a/Src/AwesomeAssertions/Execution/StringExtensions.cs
+++ b/Src/AwesomeAssertions/Execution/StringExtensions.cs
@@ -1,0 +1,26 @@
+using AwesomeAssertions.Formatting;
+
+namespace AwesomeAssertions.Execution;
+
+internal static class StringExtensions
+{
+    /// <summary>
+    /// Can be used to wrap a string so that it is not formatted.
+    /// </summary>
+    /// <param name="value">The string to wrap</param>
+    /// <returns>Object to pass to the fail message methods</returns>
+    public static WithoutFormattingWrapper AsNonFormattable(this string value)
+    {
+        return new WithoutFormattingWrapper(value);
+    }
+
+    /// <summary>
+    /// Can be used to wrap an object so that its plain ToString output is preserved during formatting.
+    /// </summary>
+    /// <param name="value">The object to wrap</param>
+    /// <returns>Object to pass to the fail message methods</returns>
+    public static WithoutFormattingWrapper AsNonFormattable(this object value)
+    {
+        return new WithoutFormattingWrapper(value?.ToString());
+    }
+}

--- a/Src/AwesomeAssertions/Execution/StringExtensions.cs
+++ b/Src/AwesomeAssertions/Execution/StringExtensions.cs
@@ -1,0 +1,29 @@
+using AwesomeAssertions.Formatting;
+
+namespace AwesomeAssertions.Execution;
+
+/// <summary>
+/// Provides extension methods for strings and objects to control their formatting behavior in assertion messages.
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    /// Can be used to wrap a string so that it is not formatted.
+    /// </summary>
+    /// <param name="value">The string to wrap</param>
+    /// <returns>Object to pass to the fail message methods</returns>
+    public static object AsNonFormattable(this string value)
+    {
+        return new WithoutFormattingWrapper(value);
+    }
+
+    /// <summary>
+    /// Can be used to wrap an object so that its plain ToString output is preserved during formatting.
+    /// </summary>
+    /// <param name="value">The object to wrap</param>
+    /// <returns>Object to pass to the fail message methods</returns>
+    public static object AsNonFormattable(this object value)
+    {
+        return new WithoutFormattingWrapper(value?.ToString());
+    }
+}

--- a/Src/AwesomeAssertions/Formatting/Formatter.cs
+++ b/Src/AwesomeAssertions/Formatting/Formatter.cs
@@ -19,6 +19,7 @@ public static class Formatter
 
     private static readonly List<IValueFormatter> DefaultFormatters =
     [
+        new PassthroughValueFormatter(),
         new XmlReaderValueFormatter(),
         new XmlNodeFormatter(),
         new AttributeBasedFormatter(),

--- a/Src/AwesomeAssertions/Formatting/PassthroughValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/PassthroughValueFormatter.cs
@@ -1,0 +1,15 @@
+namespace AwesomeAssertions.Formatting;
+
+/// <summary>
+/// Ensures that any value wrapped in a <see cref="WithoutFormattingWrapper"/>
+/// is passed through as-is.
+/// </summary>
+internal sealed class PassthroughValueFormatter : IValueFormatter
+{
+    public bool CanHandle(object value) => value is WithoutFormattingWrapper;
+
+    public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
+    {
+        formattedGraph.AddFragment(((WithoutFormattingWrapper)value).ToString());
+    }
+}

--- a/Src/AwesomeAssertions/Formatting/WithoutFormattingWrapper.cs
+++ b/Src/AwesomeAssertions/Formatting/WithoutFormattingWrapper.cs
@@ -1,0 +1,9 @@
+namespace AwesomeAssertions.Formatting;
+
+/// <summary>
+/// Wrapper to tell the <see cref="Formatter"/> not to apply any value formatters on string <paramref name="value"/>.
+/// </summary>
+internal class WithoutFormattingWrapper(string value)
+{
+    public override string ToString() => value;
+}

--- a/Src/AwesomeAssertions/Formatting/WithoutFormattingWrapper.cs
+++ b/Src/AwesomeAssertions/Formatting/WithoutFormattingWrapper.cs
@@ -1,0 +1,9 @@
+namespace AwesomeAssertions.Formatting;
+
+/// <summary>
+/// Wrapper to tell the <see cref="Formatter"/> not to apply any value formatters on string <paramref name="value"/>.
+/// </summary>
+internal sealed class WithoutFormattingWrapper(string value)
+{
+    public override string ToString() => value;
+}

--- a/Src/AwesomeAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/ExceptionAssertions.cs
@@ -295,10 +295,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
 
         foreach (string failure in results.GetTheFailuresForTheSetWithTheFewestFailures())
         {
-            string replacedCurlyBraces =
-                failure.EscapePlaceholders();
-
-            assertionChain.FailWith(replacedCurlyBraces);
+            assertionChain.FailWith("{0}", failure.AsNonFormattable());
         }
     }
 }

--- a/Src/AwesomeAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/ExceptionAssertions.cs
@@ -302,10 +302,7 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
 
         foreach (string failure in results.GetTheFailuresForTheSetWithTheFewestFailures())
         {
-            string replacedCurlyBraces =
-                failure.EscapePlaceholders();
-
-            assertionChain.FailWith(replacedCurlyBraces);
+            assertionChain.FailWith("{0}", failure.AsNonFormattable());
         }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
@@ -1560,6 +1560,11 @@ namespace AwesomeAssertions.Execution
         public object[] Arguments { get; set; }
         public string FormattedMessage { get; set; }
     }
+    public static class StringExtensions
+    {
+        public static object AsNonFormattable(this object value) { }
+        public static object AsNonFormattable(this string value) { }
+    }
 }
 namespace AwesomeAssertions.Extensibility
 {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -1598,6 +1598,11 @@ namespace AwesomeAssertions.Execution
         public object[] Arguments { get; set; }
         public string FormattedMessage { get; set; }
     }
+    public static class StringExtensions
+    {
+        public static object AsNonFormattable(this object value) { }
+        public static object AsNonFormattable(this string value) { }
+    }
 }
 namespace AwesomeAssertions.Extensibility
 {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -1502,6 +1502,11 @@ namespace AwesomeAssertions.Execution
         public object[] Arguments { get; set; }
         public string FormattedMessage { get; set; }
     }
+    public static class StringExtensions
+    {
+        public static object AsNonFormattable(this object value) { }
+        public static object AsNonFormattable(this string value) { }
+    }
 }
 namespace AwesomeAssertions.Extensibility
 {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -1560,6 +1560,11 @@ namespace AwesomeAssertions.Execution
         public object[] Arguments { get; set; }
         public string FormattedMessage { get; set; }
     }
+    public static class StringExtensions
+    {
+        public static object AsNonFormattable(this object value) { }
+        public static object AsNonFormattable(this string value) { }
+    }
 }
 namespace AwesomeAssertions.Extensibility
 {

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
@@ -439,5 +439,39 @@ public partial class AssertionChainSpecs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected because reasons with arguments");
         }
+
+        [Theory]
+        [InlineData("{0}{0}", "\"foo\"\"foo\"")]
+        [InlineData("{{0}}{0}", "{0}\"foo\"")]
+        [InlineData("{0}{{0}}", "\"foo\"{0}")]
+        [InlineData("{{{0}}}{0}", "{\"foo\"}\"foo\"")]
+        [InlineData("{0}{{{0}}}", "\"foo\"{\"foo\"}")]
+        public void Can_handle_escaped_braces(string format, string expected)
+        {
+            Action act = () => AssertionChain.GetOrCreate()
+                .FailWith(format, "foo");
+
+            act.Should().Throw<XunitException>().WithMessage(expected);
+        }
+
+        [Theory]
+        [InlineData("{")]
+        [InlineData("}")]
+        [InlineData("{}")]
+        [InlineData("{0}")]
+        [InlineData("{{0}}")]
+        public void Can_handle_more_braces_in_dictionary_keys(string key)
+        {
+            // Arrange
+            var subject = new Dictionary<string, string> { [key] = "" };
+            var expectation = new Dictionary<string, string> { [key] = null };
+
+            // Act
+            var act = () => expectation.Should().BeEquivalentTo(subject);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected expectation[{key}] to be \"\", but found <null>.*");
+        }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
@@ -532,7 +532,6 @@ public partial class AssertionChainSpecs
         [InlineData("{{0}}")]
         public void Can_handle_more_braces_in_dictionary_keys(string key)
         {
-            // Arrange
             var subject = new Dictionary<string, string> { [key] = "" };
             var expectation = new Dictionary<string, string> { [key] = null };
 

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
@@ -509,5 +509,66 @@ public partial class AssertionChainSpecs
                     }
                     """);
         }
+
+        [Theory]
+        [InlineData("{0}{0}", "\"foo\"\"foo\"")]
+        [InlineData("{{0}}{0}", "{0}\"foo\"")]
+        [InlineData("{0}{{0}}", "\"foo\"{0}")]
+        [InlineData("{{{0}}}{0}", "{\"foo\"}\"foo\"")]
+        [InlineData("{0}{{{0}}}", "\"foo\"{\"foo\"}")]
+        public void Can_handle_escaped_braces(string format, string expected)
+        {
+            Action act = () => AssertionChain.GetOrCreate()
+                .FailWith(format, "foo");
+
+            act.Should().Throw<XunitException>().WithMessage(expected);
+        }
+
+        [Theory]
+        [InlineData("{")]
+        [InlineData("}")]
+        [InlineData("{}")]
+        [InlineData("{0}")]
+        [InlineData("{{0}}")]
+        public void Can_handle_more_braces_in_dictionary_keys(string key)
+        {
+            // Arrange
+            var subject = new Dictionary<string, string> { [key] = "" };
+            var expectation = new Dictionary<string, string> { [key] = null };
+
+            // Act
+            var act = () => expectation.Should().BeEquivalentTo(subject);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected expectation[{key}] to be \"\", but found <null>.*");
+        }
+
+        [Fact]
+        public void String_because_arguments_passed_as_non_formattables_are_kept_unchanged()
+        {
+            var subject = "nonformattable string".AsNonFormattable();
+
+            Action act = () => AssertionChain.GetOrCreate().FailWith("This is a message with {0}.", subject);
+
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should().Be("This is a message with nonformattable string.");
+        }
+
+        [Fact]
+        public void Because_arguments_passed_as_non_formattables_are_formatted_by_their_custom_string_representation()
+        {
+            var subject = new MyClass().AsNonFormattable();
+
+            Action act = () => AssertionChain.GetOrCreate().FailWith("This is a message with {0}.", subject);
+
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should().Be("This is a message with custom string.");
+        }
+
+        private sealed class MyClass
+        {
+            public override string ToString() => "custom string";
+        }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
@@ -535,7 +535,6 @@ public partial class AssertionChainSpecs
             var subject = new Dictionary<string, string> { [key] = "" };
             var expectation = new Dictionary<string, string> { [key] = null };
 
-            // Act
             var act = () => expectation.Should().BeEquivalentTo(subject);
 
             // Assert

--- a/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
+++ b/Tests/AwesomeAssertions.Specs/Execution/AssertionChainSpecs.MessageFormating.cs
@@ -537,7 +537,6 @@ public partial class AssertionChainSpecs
 
             var act = () => expectation.Should().BeEquivalentTo(subject);
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage($"Expected expectation[{key}] to be \"\", but found <null>.*");
         }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -8,6 +8,9 @@ sidebar:
 ---
 ## Unreleased
 
+### What's new
+* Add `AsNonFormattable` extension methods to allow passing "because" arguments without formatting - [#536](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/536)
+
 ### Improvements
 * `ThrowAsync`, `ThrowExactlyAsync` and `ThrowWithinAsync` now return `ExceptionAssertionsTask<TException>`, so that `WithInnerException<TInnerException>` and `WithInnerExceptionExactly<TInnerException>` can be used with a single type parameter, just like their synchronous counterparts - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
 * Add `AsExceptionAssertionsTask` to continue asserting on a `Task<ExceptionAssertions<TException>>` that none of the `ThrowAsync` assertions produced, such as the result of your own helper method - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)


### PR DESCRIPTION
* Backported from FA v7.2.2 https://github.com/fluentassertions/fluentassertions/commit/bb896c7405ba7c4d049af86cf3f35e452a1a8918
* The actual bug was already fixed much earlier by us, so all which was left, is the additional formatting capabilities
* Making extension method public
* Part of #534 
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
