### PR TITLE
Fix NotSupportedException from ReduceConstantSubExpressions

### DIFF
--- a/Src/AwesomeAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -42,7 +42,7 @@ public class PredicateLambdaExpressionValueFormatter : IValueFormatter
         {
             return new ConstantSubExpressionReductionVisitor().Visit(expression);
         }
-        catch (InvalidOperationException)
+        catch (Exception e) when (e is InvalidOperationException or NotSupportedException)
         {
             // Fallback if we make an invalid rewrite of the expression.
             return expression;

--- a/Tests/AwesomeAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
@@ -89,6 +89,7 @@ public class PredicateLambdaExpressionValueFormatterSpecs
         result.Should().Be("a.TextIsNotBlank() AndAlso (a.Number >= 0) AndAlso (a.Number <= 1000)");
     }
 
+#pragma warning disable RCS1196 // Do not call Contains as extension method. This is to exercise first-class spans
     [Fact]
     public void When_condition_contains_linq_extension_method_then_extension_method_must_be_formatted()
     {
@@ -96,11 +97,27 @@ public class PredicateLambdaExpressionValueFormatterSpecs
         IEnumerable<int> allowed = new[] { 1, 2, 3 };
 
         // Act
-        string result = Format<int>(a => allowed.Contains(a));
+        string result = Format<int>(a => Enumerable.Contains(allowed, a));
 
         // Assert
         result.Should().Be("value(System.Int32[]).Contains(a)");
     }
+
+#if NET6_0_OR_GREATER
+    [Fact]
+    public void Methods_using_ReadOnlySpan_can_be_formatted()
+    {
+        // Arrange
+        int[] allowed = [1, 2, 3];
+
+        // Act
+        string result = Format<int>(a => MemoryExtensions.Contains(allowed, a));
+
+        // Assert
+        result.Should().Match("*.Contains(a)");
+    }
+#endif
+#pragma warning restore RCS1196
 
     [Fact]
     public void Formatting_a_lifted_binary_operator()

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,10 +9,13 @@ sidebar:
 ## Unreleased
 
 ### What's new
-* Add `[Not]BeDecoratedWith` for `ParameterInfo`- [#449](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/449)
-* Return `AndWhichConstraint` from `IntersectWith` [#495](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/495)
-* Return `AndWhichConstraint` from `XElementAssertions.HaveAttribute` [#504](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/504)
-* Add overload of `AssertionChain.ForCondition()` that allows for lazy execution of `condition` [#511](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/511)
+* Add `[Not]BeDecoratedWith` for `ParameterInfo` - [#449](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/449)
+* Return `AndWhichConstraint` from `IntersectWith` - [#495](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/495)
+* Return `AndWhichConstraint` from `XElementAssertions.HaveAttribute` - [#504](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/504)
+* Add overload of `AssertionChain.ForCondition()` that allows for lazy execution of `condition` - [#511](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/511)
+
+### Fixes
+* Fix formatting of lambda expressions with `ReadOnlySpan` - [#538](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/538)
 
 ## 9.4.0
 


### PR DESCRIPTION
C# 14 "first-class spans" causes `MemoryExtensions.Contains` to be picked over `Enumerable.Contains`.
`ConstantSubExpressionReductionVisitor.Visit` calls `DynamicInvoke` which then throws a `NotSupportedException` from [`RuntimeMethodInfo.ThrowNoInvokeException`](https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs,70)

Backport of https://github.com/fluentassertions/fluentassertions/commit/6ad1fb824226fc7c4c251c1bd2a6352533d3d0b2

Part of #534 
<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [ ] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
