### PR TITLE
Extend design guidelines for API changes

### DIFF
--- a/DESIGN-GUIDE.md
+++ b/DESIGN-GUIDE.md
@@ -30,6 +30,17 @@ Start reading the section titles, go in deep if the title is not self-explanator
   Pass the predicate to `FailWith` and let the `PredicateLambdaExpressionValueFormatter` handle formatting it properly.
 * ❌ Don't use `type.Name` to format a type, but rather pass it to `FailWith` and let the `TypeValueFormatter` do its thing.
 
+### Preparing API changes
+
+When API members are planned to be replaced, renamed or removed in future versions:
+
+* ✅ Extend the documentation of the member to be deprecated (summary section).
+  Point to the replacement member.
+* ✅ Add a clear note of deprecation in the release notes.
+* ❌ Don't mark deprecated members with the `ObsoleteAttribute`.
+  Several users have enabled "warning as error", so the obsolete warning will cause compiler error.
+* ✅ Use the `EditorBrowsableAttribute` instead to hide the member.
+
 ### Tests in AwesomeAssertions
 
 * Naming and grouping guidelines (based on [this post](https://www.continuousimprover.com/2023/03/test-naming.html))

--- a/DESIGN-GUIDE.md
+++ b/DESIGN-GUIDE.md
@@ -36,7 +36,8 @@ When API members are planned to be replaced, renamed or removed in future versio
 
 * ✅ Extend the documentation of the member to be deprecated (summary section).
   Point to the replacement member.
-* ✅ Add a clear note of deprecation in the release notes.
+* ✅ Add a clear note of deprecation in the release notes
+  (addtional section `Deprecations` as the first section within a version).
 * ❌ Don't mark deprecated members with the `ObsoleteAttribute`.
   Several users have enabled "warning as error", so the obsolete warning will cause compiler error.
 * ✅ Use the `EditorBrowsableAttribute` instead to hide the member.


### PR DESCRIPTION
I propose the handling of deprecation of API members.
Discussion very welcome.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
