### PR TITLE
Fix build due to vulnerabilities in System.Security.Cryptography.Xml

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -52,7 +52,7 @@
         "Quiet"
       ]
     },
-    "NukeBuild": {
+    "FalloutBuild": {
       "properties": {
         "Continue": {
           "type": "boolean",
@@ -140,7 +140,7 @@
       }
     },
     {
-      "$ref": "#/definitions/NukeBuild"
+      "$ref": "#/definitions/FalloutBuild"
     }
   ]
 }

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -19,5 +19,7 @@
     <PackageReference Include="SharpCompress" Version="0.48.0" />
     <!-- Replace the implicitly referenced version 6.12.1, which is defined by the package Fallout.Common and has known vulnerabilities, with a fixed version -->
     <PackageReference Include="Nuget.Packaging" Version="7.3.1" />
+    <!-- Replace the implicitly referenced version 10.0.6, which is defined by the package Fallout.Common and has known vulnerabilities, with a fixed version -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
