### PR TITLE
Enable renovate updates for the Build project (Fallout)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,11 +10,6 @@
     // Use "dependencies" as a label for all created pull requests.
     "labels": ["dependencies"],
 
-    // Do not update the build project.
-    // NUKE sometimes change API break without a major version.
-    // Let's update manually.
-    "ignorePaths": ["Build/**"],
-
     "packageRules": [
         // Do not update xUnit runner.
         // Versions 3.0.0 and above do not support net47(0) anymore.


### PR DESCRIPTION
As discussed in #547 .

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
