### PR TITLE
Enable automatic upgrade for all build project packages

### DIFF
--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -6,7 +6,6 @@
     <NoWarn>CS0649;CS0169</NoWarn>
     <FalloutRootDirectory>..\</FalloutRootDirectory>
     <FalloutScriptDirectory>..\</FalloutScriptDirectory>
-    <FalloutVersion>10.3.49</FalloutVersion>
     <FalloutTelemetryVersion>1</FalloutTelemetryVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -14,8 +13,8 @@
     <PackageDownload Include="ReportGenerator" Version="[5.5.0]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.9.2]" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Include="Fallout.Common" Version="$(FalloutVersion)" />
-    <PackageReference Include="Fallout.Components" Version="$(FalloutVersion)" />
+    <PackageReference Include="Fallout.Common" Version="10.3.49" />
+    <PackageReference Include="Fallout.Components" Version="10.3.49" />
     <PackageReference Include="SharpCompress" Version="0.48.0" />
     <!-- Replace the implicitly referenced version 6.12.1, which is defined by the package Fallout.Common and has known vulnerabilities, with a fixed version -->
     <PackageReference Include="Nuget.Packaging" Version="7.3.1" />

--- a/renovate.json5
+++ b/renovate.json5
@@ -81,10 +81,12 @@
             "matchFileNames": ["**/NUnit4.Specs/**"]
         },
 
-        // Disable updates for pinned packages.
+        // Disable updates for pinned packages for Src and Tests.
+        // The Build project must have some pinned versions because dotnet allows only exact versions with PackageDownload
         // https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/nuget/readme.md#disabling-updates-for-pinned-versions
         {
             "matchManagers": ["nuget"],
+            "matchFileNames": ["Src/**", "Tests/**"],
             "matchCurrentValue": "/^\\[[^,]+\\]$/",
             "enabled": false
         },


### PR DESCRIPTION
* Use plain versions for Fallout packages such that renovate can handle them during updates.
* Enable automatic package updates for `PackageDownload` references in build project, which are required by `dotnet` to have exact versions. Renovate should still be able to update them.

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
