### PR TITLE
Add documentation to all public API

### DIFF
--- a/Src/AwesomeAssertions/AggregateExceptionExtractor.cs
+++ b/Src/AwesomeAssertions/AggregateExceptionExtractor.cs
@@ -6,8 +6,20 @@ using AwesomeAssertions.Specialized;
 
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Extracts the exceptions of a particular type from an <see cref="AggregateException"/> (or a single exception).
+/// </summary>
 public class AggregateExceptionExtractor : IExtractExceptions
 {
+    /// <summary>
+    /// Extracts all exceptions of type <typeparamref name="T"/> from the specified exception.
+    /// </summary>
+    /// <typeparam name="T">The type of the exceptions to extract.</typeparam>
+    /// <param name="actualException">
+    /// The exception to extract from. When it is an <see cref="AggregateException"/>, its flattened inner
+    /// exceptions are searched; otherwise the exception itself is considered.
+    /// </param>
+    /// <returns>The exceptions of type <typeparamref name="T"/> that were found.</returns>
     public IEnumerable<T> OfType<T>(Exception actualException)
         where T : Exception
     {

--- a/Src/AwesomeAssertions/AndConstraint.cs
+++ b/Src/AwesomeAssertions/AndConstraint.cs
@@ -2,9 +2,17 @@ using System.Diagnostics;
 
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Provides access to the parent assertions object, allowing another assertion to be chained onto the same subject
+/// through its <see cref="And"/> property.
+/// </summary>
+/// <typeparam name="TParent">The type of the parent assertions object.</typeparam>
 [DebuggerNonUserCode]
 public class AndConstraint<TParent>
 {
+    /// <summary>
+    /// Gets the parent assertions object, allowing another assertion to be chained onto the same subject.
+    /// </summary>
     public TParent And { get; }
 
     /// <summary>

--- a/Src/AwesomeAssertions/AssertionConfiguration.cs
+++ b/Src/AwesomeAssertions/AssertionConfiguration.cs
@@ -7,5 +7,8 @@ namespace AwesomeAssertions;
 /// </summary>
 public static class AssertionConfiguration
 {
+    /// <summary>
+    /// Gets the current <see cref="GlobalConfiguration"/> used to customize the behavior of AwesomeAssertions.
+    /// </summary>
     public static GlobalConfiguration Current => AssertionEngine.Configuration;
 }

--- a/Src/AwesomeAssertions/AssertionExtensions.cs
+++ b/Src/AwesomeAssertions/AssertionExtensions.cs
@@ -118,6 +118,7 @@ public static class AssertionExtensions
     /// </summary>
     /// <param name="subject">The object that exposes the method or property.</param>
     /// <param name="action">A reference to the method or property to measure the execution time of.</param>
+    /// <param name="createTimer">A function that creates the <see cref="ITimer"/> used to measure the execution time.</param>
     /// <returns>
     /// Returns an object for asserting that the execution time matches certain conditions.
     /// </returns>
@@ -140,6 +141,7 @@ public static class AssertionExtensions
     /// Provides methods for asserting the execution time of an action.
     /// </summary>
     /// <param name="action">An action to measure the execution time of.</param>
+    /// <param name="createTimer">A function that creates the <see cref="ITimer"/> used to measure the execution time.</param>
     /// <returns>
     /// Returns an object for asserting that the execution time matches certain conditions.
     /// </returns>

--- a/Src/AwesomeAssertions/AsyncAssertionsExtensions.cs
+++ b/Src/AwesomeAssertions/AsyncAssertionsExtensions.cs
@@ -4,6 +4,9 @@ using AwesomeAssertions.Specialized;
 
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Provides extension methods for asserting on the results of asynchronous assertions.
+/// </summary>
 public static class AsyncAssertionsExtensions
 {
 #pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API

--- a/Src/AwesomeAssertions/AtLeast.cs
+++ b/Src/AwesomeAssertions/AtLeast.cs
@@ -1,13 +1,34 @@
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Provides factory methods for <see cref="OccurrenceConstraint"/>s that require an event or item to
+/// occur at least a given number of times.
+/// </summary>
 public static class AtLeast
 {
+    /// <summary>
+    /// Requires the occurrence to happen at least one time.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is at least one.</returns>
     public static OccurrenceConstraint Once() => new AtLeastTimesConstraint(1);
 
+    /// <summary>
+    /// Requires the occurrence to happen at least two times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is at least two.</returns>
     public static OccurrenceConstraint Twice() => new AtLeastTimesConstraint(2);
 
+    /// <summary>
+    /// Requires the occurrence to happen at least three times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is at least three.</returns>
     public static OccurrenceConstraint Thrice() => new AtLeastTimesConstraint(3);
 
+    /// <summary>
+    /// Requires the occurrence to happen at least the specified number of times.
+    /// </summary>
+    /// <param name="expected">The minimum number of times the occurrence is expected to happen.</param>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is at least <paramref name="expected"/>.</returns>
     public static OccurrenceConstraint Times(int expected) => new AtLeastTimesConstraint(expected);
 
     private sealed class AtLeastTimesConstraint : OccurrenceConstraint

--- a/Src/AwesomeAssertions/AtMost.cs
+++ b/Src/AwesomeAssertions/AtMost.cs
@@ -1,13 +1,34 @@
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Provides factory methods for <see cref="OccurrenceConstraint"/>s that require an event or item to
+/// occur at most a given number of times.
+/// </summary>
 public static class AtMost
 {
+    /// <summary>
+    /// Requires the occurrence to happen at most one time.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is at most one.</returns>
     public static OccurrenceConstraint Once() => new AtMostTimesConstraint(1);
 
+    /// <summary>
+    /// Requires the occurrence to happen at most two times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is at most two.</returns>
     public static OccurrenceConstraint Twice() => new AtMostTimesConstraint(2);
 
+    /// <summary>
+    /// Requires the occurrence to happen at most three times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is at most three.</returns>
     public static OccurrenceConstraint Thrice() => new AtMostTimesConstraint(3);
 
+    /// <summary>
+    /// Requires the occurrence to happen at most the specified number of times.
+    /// </summary>
+    /// <param name="expected">The maximum number of times the occurrence is expected to happen.</param>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is at most <paramref name="expected"/>.</returns>
     public static OccurrenceConstraint Times(int expected) => new AtMostTimesConstraint(expected);
 
     private sealed class AtMostTimesConstraint : OccurrenceConstraint

--- a/Src/AwesomeAssertions/AwesomeAssertions.csproj
+++ b/Src/AwesomeAssertions/AwesomeAssertions.csproj
@@ -7,7 +7,6 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../AwesomeAssertions.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591;1573</NoWarn>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Src/AwesomeAssertions/CallerIdentifier.cs
+++ b/Src/AwesomeAssertions/CallerIdentifier.cs
@@ -17,8 +17,17 @@ namespace AwesomeAssertions;
 // REFACTOR: Should be internal and treated as an implementation detail of the AssertionScope
 public static class CallerIdentifier
 {
+    /// <summary>
+    /// Gets or sets the action used to log diagnostic messages produced while determining the caller identity.
+    /// </summary>
     public static Action<string> Logger { get; set; } = _ => { };
 
+    /// <summary>
+    /// Tries to determine the name of the variable or invocation on which the assertion is executed.
+    /// </summary>
+    /// <returns>
+    /// The identified caller expression, or <see langword="null"/> when it could not be determined.
+    /// </returns>
     public static string DetermineCallerIdentity()
     {
         string caller = null;

--- a/Src/AwesomeAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/AwesomeAssertions/Collections/GenericCollectionAssertions.cs
@@ -14,20 +14,36 @@ using AwesomeAssertions.Primitives;
 
 namespace AwesomeAssertions.Collections;
 
+/// <summary>
+/// Contains a number of methods to assert that an <see cref="IEnumerable{T}"/> is in the expected state.
+/// </summary>
 [DebuggerNonUserCode]
 public class GenericCollectionAssertions<T> : GenericCollectionAssertions<IEnumerable<T>, T, GenericCollectionAssertions<T>>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenericCollectionAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="actualValue">The collection to assert.</param>
+    /// <param name="assertionChain">The assertion chain used to build up and terminate the assertion.</param>
     public GenericCollectionAssertions(IEnumerable<T> actualValue, AssertionChain assertionChain)
         : base(actualValue, assertionChain)
     {
     }
 }
 
+/// <summary>
+/// Contains a number of methods to assert that a <typeparamref name="TCollection"/> is in the expected state.
+/// </summary>
 [DebuggerNonUserCode]
 public class GenericCollectionAssertions<TCollection, T>
     : GenericCollectionAssertions<TCollection, T, GenericCollectionAssertions<TCollection, T>>
     where TCollection : IEnumerable<T>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenericCollectionAssertions{TCollection, T}"/> class.
+    /// </summary>
+    /// <param name="actualValue">The collection to assert.</param>
+    /// <param name="assertionChain">The assertion chain used to build up and terminate the assertion.</param>
     public GenericCollectionAssertions(TCollection actualValue, AssertionChain assertionChain)
         : base(actualValue, assertionChain)
     {
@@ -37,6 +53,9 @@ public class GenericCollectionAssertions<TCollection, T>
 #pragma warning disable CS0659, S1206 // Ignore not overriding Object.GetHashCode()
 #pragma warning disable CA1065 // Ignore throwing NotSupportedException from Equals
 
+/// <summary>
+/// Contains a number of methods to assert that a <typeparamref name="TCollection"/> is in the expected state.
+/// </summary>
 [DebuggerNonUserCode]
 public class GenericCollectionAssertions<TCollection, T, TAssertions> : ReferenceTypeAssertions<TCollection, TAssertions>
     where TCollection : IEnumerable<T>
@@ -44,6 +63,11 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenericCollectionAssertions{TCollection, T, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="actualValue">The collection to assert.</param>
+    /// <param name="assertionChain">The assertion chain used to build up and terminate the assertion.</param>
     public GenericCollectionAssertions(TCollection actualValue, AssertionChain assertionChain)
         : base(actualValue, assertionChain)
     {
@@ -3564,6 +3588,16 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return expectation;
     }
 
+    /// <summary>
+    /// Returns a sequence that repeats the specified <paramref name="value"/> as many times as there are elements
+    /// in the specified <paramref name="enumerable"/>.
+    /// </summary>
+    /// <param name="value">The value to repeat.</param>
+    /// <param name="enumerable">The sequence whose number of elements determines how often <paramref name="value"/> is repeated.</param>
+    /// <returns>
+    /// An empty sequence if <paramref name="enumerable"/> is <see langword="null"/>; otherwise a sequence containing
+    /// <paramref name="value"/> repeated once for each element in <paramref name="enumerable"/>.
+    /// </returns>
     protected static IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, IEnumerable<T> enumerable)
     {
         if (enumerable is null)
@@ -3574,6 +3608,22 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
         return RepeatAsManyAsIterator(value, enumerable);
     }
 
+    /// <summary>
+    /// Asserts that the <paramref name="actual"/> collection ends with the items in the <paramref name="expected"/> collection.
+    /// </summary>
+    /// <param name="actual">The collection to inspect.</param>
+    /// <param name="expected">The items that are expected to appear at the end of <paramref name="actual"/>.</param>
+    /// <param name="equalityComparison">
+    /// A predicate used to determine whether an actual item is equal to an expected item.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="equalityComparison"/> is <see langword="null"/>.</exception>
     protected void AssertCollectionEndsWith<TActual, TExpectation>(IEnumerable<TActual> actual,
         ICollection<TExpectation> expected, Func<TActual, TExpectation, bool> equalityComparison,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
@@ -3596,6 +3646,22 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                 }));
     }
 
+    /// <summary>
+    /// Asserts that the <paramref name="actualItems"/> collection starts with the items in the <paramref name="expected"/> collection.
+    /// </summary>
+    /// <param name="actualItems">The collection to inspect.</param>
+    /// <param name="expected">The items that are expected to appear at the start of <paramref name="actualItems"/>.</param>
+    /// <param name="equalityComparison">
+    /// A predicate used to determine whether an actual item is equal to an expected item.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="equalityComparison"/> is <see langword="null"/>.</exception>
     protected void AssertCollectionStartsWith<TActual, TExpectation>(
         IEnumerable<TActual> actualItems,
         ICollection<TExpectation> expected, Func<TActual, TExpectation, bool> equalityComparison,
@@ -3615,6 +3681,23 @@ public class GenericCollectionAssertions<TCollection, T, TAssertions> : Referenc
                     (a, e) => a.Take(e.Count).IndexOfFirstDifferenceWith(e, equalityComparison)));
     }
 
+    /// <summary>
+    /// Asserts that the current collection is equal to the specified <paramref name="expectation"/> collection,
+    /// meaning that both collections contain the same items in the same order.
+    /// </summary>
+    /// <param name="expectation">The collection of expected items.</param>
+    /// <param name="equalityComparison">
+    /// A predicate used to determine whether an item of the subject is equal to an expected item.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="equalityComparison"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="expectation"/> is <see langword="null"/>.</exception>
     protected void AssertSubjectEquality<TExpectation>(
         IEnumerable<TExpectation> expectation,
         Func<T, TExpectation, bool> equalityComparison,

--- a/Src/AwesomeAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/AwesomeAssertions/Collections/GenericDictionaryAssertions.cs
@@ -17,6 +17,11 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue>
     : GenericDictionaryAssertions<TCollection, TKey, TValue, GenericDictionaryAssertions<TCollection, TKey, TValue>>
     where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenericDictionaryAssertions{TCollection, TKey, TValue}"/> class.
+    /// </summary>
+    /// <param name="keyValuePairs">The dictionary to assert.</param>
+    /// <param name="assertionChain">The assertion chain used to build up and terminate the assertion.</param>
     public GenericDictionaryAssertions(TCollection keyValuePairs, AssertionChain assertionChain)
         : base(keyValuePairs, assertionChain)
     {
@@ -33,6 +38,11 @@ public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenericDictionaryAssertions{TCollection, TKey, TValue, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="keyValuePairs">The dictionary to assert.</param>
+    /// <param name="assertionChain">The assertion chain used to build up and terminate the assertion.</param>
     public GenericDictionaryAssertions(TCollection keyValuePairs, AssertionChain assertionChain)
         : base(keyValuePairs, assertionChain)
     {

--- a/Src/AwesomeAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/AwesomeAssertions/Collections/StringCollectionAssertions.cs
@@ -8,6 +8,9 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Collections;
 
+/// <summary>
+/// Contains a number of methods to assert that an <see cref="IEnumerable{T}"/> of <see cref="string"/> is in the expected state.
+/// </summary>
 public class StringCollectionAssertions : StringCollectionAssertions<IEnumerable<string>>
 {
     /// <summary>
@@ -19,6 +22,9 @@ public class StringCollectionAssertions : StringCollectionAssertions<IEnumerable
     }
 }
 
+/// <summary>
+/// Contains a number of methods to assert that a <typeparamref name="TCollection"/> of <see cref="string"/> is in the expected state.
+/// </summary>
 public class StringCollectionAssertions<TCollection>
     : StringCollectionAssertions<TCollection, StringCollectionAssertions<TCollection>>
     where TCollection : IEnumerable<string>
@@ -32,6 +38,9 @@ public class StringCollectionAssertions<TCollection>
     }
 }
 
+/// <summary>
+/// Contains a number of methods to assert that a <typeparamref name="TCollection"/> of <see cref="string"/> is in the expected state.
+/// </summary>
 public class StringCollectionAssertions<TCollection, TAssertions> : GenericCollectionAssertions<TCollection, string, TAssertions>
     where TCollection : IEnumerable<string>
     where TAssertions : StringCollectionAssertions<TCollection, TAssertions>

--- a/Src/AwesomeAssertions/Collections/SubsequentOrderingAssertions.cs
+++ b/Src/AwesomeAssertions/Collections/SubsequentOrderingAssertions.cs
@@ -9,6 +9,10 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Collections;
 
+/// <summary>
+/// Contains a number of methods to assert that an <see cref="IEnumerable{T}"/> is ordered by one or more
+/// subsequent orderings in addition to a previously applied ordering.
+/// </summary>
 [DebuggerNonUserCode]
 public class SubsequentOrderingAssertions<T>
     : GenericCollectionAssertions<IEnumerable<T>, T>
@@ -16,6 +20,12 @@ public class SubsequentOrderingAssertions<T>
     private readonly IOrderedEnumerable<T> previousOrderedEnumerable;
     private bool subsequentOrdering;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubsequentOrderingAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="actualValue">The collection to assert.</param>
+    /// <param name="previousOrderedEnumerable">The result of the previously applied ordering.</param>
+    /// <param name="assertionChain">The assertion chain used to build up and terminate the assertion.</param>
     public SubsequentOrderingAssertions(IEnumerable<T> actualValue, IOrderedEnumerable<T> previousOrderedEnumerable, AssertionChain assertionChain)
         : base(actualValue, assertionChain)
     {

--- a/Src/AwesomeAssertions/Collections/WhoseValueConstraint.cs
+++ b/Src/AwesomeAssertions/Collections/WhoseValueConstraint.cs
@@ -2,6 +2,10 @@ using System.Collections.Generic;
 
 namespace AwesomeAssertions.Collections;
 
+/// <summary>
+/// Provides access to the value associated with a key that was asserted to be present in a dictionary,
+/// while still allowing the assertion chain to be continued.
+/// </summary>
 public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : AndConstraint<TAssertions>
     where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
     where TAssertions : GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>

--- a/Src/AwesomeAssertions/Common/CSharpAccessModifier.cs
+++ b/Src/AwesomeAssertions/Common/CSharpAccessModifier.cs
@@ -1,12 +1,42 @@
 namespace AwesomeAssertions.Common;
 
+/// <summary>
+/// Represents the access modifier of a C# member or type.
+/// </summary>
 public enum CSharpAccessModifier
 {
+    /// <summary>
+    /// The member or type is accessible from anywhere (<c>public</c>).
+    /// </summary>
     Public,
+
+    /// <summary>
+    /// The member or type is only accessible within its containing type (<c>private</c>).
+    /// </summary>
     Private,
+
+    /// <summary>
+    /// The member or type is accessible within its containing type and by derived types (<c>protected</c>).
+    /// </summary>
     Protected,
+
+    /// <summary>
+    /// The member or type is accessible only within the same assembly (<c>internal</c>).
+    /// </summary>
     Internal,
+
+    /// <summary>
+    /// The member or type is accessible within the same assembly or by derived types (<c>protected internal</c>).
+    /// </summary>
     ProtectedInternal,
+
+    /// <summary>
+    /// The combination of access modifiers does not map to a valid C# access modifier keyword.
+    /// </summary>
     InvalidForCSharp,
+
+    /// <summary>
+    /// The member or type is accessible by derived types within the same assembly (<c>private protected</c>).
+    /// </summary>
     PrivateProtected,
 }

--- a/Src/AwesomeAssertions/Common/DateTimeExtensions.cs
+++ b/Src/AwesomeAssertions/Common/DateTimeExtensions.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AwesomeAssertions.Common;
 
+/// <summary>
+/// Provides extension methods for converting <see cref="DateTime"/> values.
+/// </summary>
 public static class DateTimeExtensions
 {
     /// <summary>
@@ -13,6 +16,14 @@ public static class DateTimeExtensions
         return dateTime.ToDateTimeOffset(TimeSpan.Zero);
     }
 
+    /// <summary>
+    /// Converts an existing <see cref="DateTime"/> to a <see cref="DateTimeOffset"/> using the specified <paramref name="offset"/>,
+    /// while normalizing the <see cref="DateTimeKind"/> so that comparisons of converted <see cref="DateTime"/> instances retain the
+    /// UTC/local agnostic behavior.
+    /// </summary>
+    /// <param name="dateTime">The <see cref="DateTime"/> to convert.</param>
+    /// <param name="offset">The offset from Coordinated Universal Time (UTC) to associate with the result.</param>
+    /// <returns>A <see cref="DateTimeOffset"/> representing the same point in time with the specified <paramref name="offset"/>.</returns>
     public static DateTimeOffset ToDateTimeOffset(this DateTime dateTime, TimeSpan offset)
     {
         return new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified), offset);

--- a/Src/AwesomeAssertions/Configuration/GlobalConfiguration.cs
+++ b/Src/AwesomeAssertions/Configuration/GlobalConfiguration.cs
@@ -1,5 +1,8 @@
 namespace AwesomeAssertions.Configuration;
 
+/// <summary>
+/// Provides access to the global configuration and defaults used by Awesome Assertions.
+/// </summary>
 public class GlobalConfiguration
 {
     private TestFramework? testFramework;

--- a/Src/AwesomeAssertions/Configuration/GlobalEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Configuration/GlobalEquivalencyOptions.cs
@@ -5,6 +5,9 @@ using JetBrains.Annotations;
 
 namespace AwesomeAssertions.Configuration;
 
+/// <summary>
+/// Provides access to the defaults used by the structural equivalency assertions.
+/// </summary>
 public class GlobalEquivalencyOptions
 {
     private EquivalencyOptions defaults = new();

--- a/Src/AwesomeAssertions/Configuration/GlobalFormattingOptions.cs
+++ b/Src/AwesomeAssertions/Configuration/GlobalFormattingOptions.cs
@@ -3,10 +3,17 @@ using AwesomeAssertions.Formatting;
 
 namespace AwesomeAssertions.Configuration;
 
+/// <summary>
+/// Provides access to the formatting defaults used by all assertions.
+/// </summary>
 public class GlobalFormattingOptions : FormattingOptions
 {
     private string valueFormatterAssembly;
 
+    /// <summary>
+    /// Gets or sets the name of the assembly that is scanned for custom value formatters.
+    /// Setting this property changes <see cref="ValueFormatterDetectionMode"/> to <see cref="AwesomeAssertions.Common.ValueFormatterDetectionMode.Specific"/>.
+    /// </summary>
     public string ValueFormatterAssembly
     {
         get => valueFormatterAssembly;
@@ -17,6 +24,9 @@ public class GlobalFormattingOptions : FormattingOptions
         }
     }
 
+    /// <summary>
+    /// Gets or sets the mode that determines how custom value formatters are detected.
+    /// </summary>
     public ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
 
     internal new GlobalFormattingOptions Clone()

--- a/Src/AwesomeAssertions/Configuration/TestFramework.cs
+++ b/Src/AwesomeAssertions/Configuration/TestFramework.cs
@@ -5,15 +5,34 @@ namespace AwesomeAssertions.Configuration;
 /// </summary>
 public enum TestFramework
 {
+    /// <summary>
+    ///     xUnit.net version 2.
+    /// </summary>
     XUnit2,
+
+    /// <summary>
+    ///     xUnit.net version 3.
+    /// </summary>
     XUnit3,
+
+    /// <summary>
+    ///     TUnit.
+    /// </summary>
     TUnit,
 
     /// <summary>
     ///     MSTest version 2 an 3.
     /// </summary>
     MsTest,
+
+    /// <summary>
+    ///     NUnit.
+    /// </summary>
     NUnit,
+
+    /// <summary>
+    ///     Machine.Specifications (MSpec).
+    /// </summary>
     MSpec,
 
     /// <summary>

--- a/Src/AwesomeAssertions/Equivalency/Comparands.cs
+++ b/Src/AwesomeAssertions/Equivalency/Comparands.cs
@@ -4,14 +4,27 @@ using static System.FormattableString;
 
 namespace AwesomeAssertions.Equivalency;
 
+/// <summary>
+/// Holds the subject and expectation that are currently being compared, together with the compile-time type
+/// through which the expectation was declared.
+/// </summary>
 public class Comparands
 {
     private Type compileTimeType;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Comparands"/> class.
+    /// </summary>
     public Comparands()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Comparands"/> class.
+    /// </summary>
+    /// <param name="subject">The value of the subject object graph.</param>
+    /// <param name="expectation">The value of the expected object graph.</param>
+    /// <param name="compileTimeType">The declared (compile-time) type of the <paramref name="expectation"/>.</param>
     public Comparands(object subject, object expectation, Type compileTimeType)
     {
         this.compileTimeType = compileTimeType;
@@ -29,6 +42,10 @@ public class Comparands
     /// </summary>
     public object Expectation { get; set; }
 
+    /// <summary>
+    /// Gets or sets the compile-time type of the <see cref="Expectation"/>, falling back to the <see cref="RuntimeType"/>
+    /// when the declared type is <see cref="object"/> and an expectation value is available.
+    /// </summary>
     public Type CompileTimeType
     {
         get
@@ -69,6 +86,9 @@ public class Comparands
         return type.NullableOrActualType();
     }
 
+    /// <summary>
+    /// Returns a string representation of the <see cref="Subject"/> and <see cref="Expectation"/> being compared.
+    /// </summary>
     public override string ToString()
     {
         return Invariant($"{{Subject={Subject}, Expectation={Expectation}}}");

--- a/Src/AwesomeAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/AwesomeAssertions/Equivalency/ConversionSelector.cs
@@ -29,6 +29,9 @@ public class ConversionSelector
     private readonly List<ConversionSelectorRule> inclusions;
     private readonly List<ConversionSelectorRule> exclusions;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConversionSelector"/> class without any conversion rules.
+    /// </summary>
     public ConversionSelector()
         : this([], [])
     {
@@ -40,6 +43,10 @@ public class ConversionSelector
         this.exclusions = exclusions;
     }
 
+    /// <summary>
+    /// Instructs the equivalency comparison to try to convert the value of all members on the expectation object
+    /// before running any of the other steps.
+    /// </summary>
     public void IncludeAll()
     {
         inclusions.Add(new ConversionSelectorRule(_ => true, "Try conversion of all members. "));
@@ -73,6 +80,16 @@ public class ConversionSelector
             $"Do not convert member {predicate.Body}."));
     }
 
+    /// <summary>
+    /// Determines whether the member identified by <paramref name="currentNode"/> should be converted before the
+    /// remaining equivalency steps are applied.
+    /// </summary>
+    /// <param name="comparands">The subject and expectation that are currently being compared.</param>
+    /// <param name="currentNode">The node describing the member being evaluated.</param>
+    /// <returns>
+    /// <see langword="true"/> if the member matches an inclusion rule and is not matched by an exclusion rule;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
     public bool RequiresConversion(Comparands comparands, INode currentNode)
     {
         if (inclusions.Count == 0)
@@ -85,6 +102,9 @@ public class ConversionSelector
         return inclusions.Exists(p => p.Predicate(objectInfo)) && !exclusions.Exists(p => p.Predicate(objectInfo));
     }
 
+    /// <summary>
+    /// Returns a human-readable description of the configured inclusion and exclusion rules.
+    /// </summary>
     public override string ToString()
     {
         if (inclusions.Count == 0 && exclusions.Count == 0)
@@ -107,6 +127,9 @@ public class ConversionSelector
         return descriptionBuilder.ToString();
     }
 
+    /// <summary>
+    /// Creates a deep copy of the current <see cref="ConversionSelector"/> with its inclusion and exclusion rules.
+    /// </summary>
     public ConversionSelector Clone()
     {
         return new ConversionSelector(new List<ConversionSelectorRule>(inclusions), new List<ConversionSelectorRule>(exclusions));

--- a/Src/AwesomeAssertions/Equivalency/EnumEquivalencyHandling.cs
+++ b/Src/AwesomeAssertions/Equivalency/EnumEquivalencyHandling.cs
@@ -1,7 +1,17 @@
 namespace AwesomeAssertions.Equivalency;
 
+/// <summary>
+/// Determines how enums are compared during a structural equivalency assertion.
+/// </summary>
 public enum EnumEquivalencyHandling
 {
+    /// <summary>
+    /// Enums are considered equivalent when their underlying values are equal.
+    /// </summary>
     ByValue,
+
+    /// <summary>
+    /// Enums are considered equivalent when their names are equal.
+    /// </summary>
     ByName
 }

--- a/Src/AwesomeAssertions/Equivalency/EqualityStrategy.cs
+++ b/Src/AwesomeAssertions/Equivalency/EqualityStrategy.cs
@@ -1,5 +1,8 @@
 namespace AwesomeAssertions.Equivalency;
 
+/// <summary>
+/// Determines how equality between two objects is established during a structural equivalency assertion.
+/// </summary>
 public enum EqualityStrategy
 {
     /// <summary>

--- a/Src/AwesomeAssertions/Equivalency/EquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/EquivalencyOptions.cs
@@ -15,10 +15,18 @@ namespace AwesomeAssertions.Equivalency;
 public class EquivalencyOptions<TExpectation>
     : SelfReferenceEquivalencyOptions<EquivalencyOptions<TExpectation>>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EquivalencyOptions{TExpectation}"/> class.
+    /// </summary>
     public EquivalencyOptions()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EquivalencyOptions{TExpectation}"/> class based on defaults
+    /// previously configured by the caller.
+    /// </summary>
+    /// <param name="defaults">The options that provide the defaults to initialize this instance with.</param>
     public EquivalencyOptions(IEquivalencyOptions defaults)
         : base(defaults)
     {
@@ -197,6 +205,10 @@ public class EquivalencyOptions<TExpectation>
 /// </summary>
 public class EquivalencyOptions : SelfReferenceEquivalencyOptions<EquivalencyOptions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EquivalencyOptions"/> class using the default behavior of
+    /// recursively including all public fields and properties based on their declared types.
+    /// </summary>
     public EquivalencyOptions()
     {
         IncludingNestedObjects();

--- a/Src/AwesomeAssertions/Equivalency/EquivalencyPlan.cs
+++ b/Src/AwesomeAssertions/Equivalency/EquivalencyPlan.cs
@@ -18,6 +18,12 @@ public class EquivalencyPlan : IEnumerable<IEquivalencyStep>
 {
     private List<IEquivalencyStep> steps = GetDefaultSteps();
 
+    /// <summary>
+    /// Returns an enumerator that iterates through the ordered collection of equivalency steps.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="IEnumerator{T}"/> that can be used to iterate through the equivalency steps.
+    /// </returns>
     public IEnumerator<IEquivalencyStep> GetEnumerator()
     {
         return steps.GetEnumerator();

--- a/Src/AwesomeAssertions/Equivalency/EquivalencyResult.cs
+++ b/Src/AwesomeAssertions/Equivalency/EquivalencyResult.cs
@@ -1,7 +1,17 @@
 namespace AwesomeAssertions.Equivalency;
 
+/// <summary>
+/// Represents the outcome of executing an <see cref="IEquivalencyStep"/> during a structural equivalency assertion.
+/// </summary>
 public enum EquivalencyResult
 {
+    /// <summary>
+    /// The step did not handle the comparison, so the next <see cref="IEquivalencyStep"/> should be executed.
+    /// </summary>
     ContinueWithNext,
+
+    /// <summary>
+    /// The step handled the comparison and proved the equivalency, so no further steps need to be executed.
+    /// </summary>
     EquivalencyProven
 }

--- a/Src/AwesomeAssertions/Equivalency/EquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/EquivalencyStep.cs
@@ -5,6 +5,7 @@ namespace AwesomeAssertions.Equivalency;
 /// </summary>
 public abstract class EquivalencyStep<T> : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/AwesomeAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -12,6 +12,11 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
 {
     private Tracer tracer;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EquivalencyValidationContext"/> class.
+    /// </summary>
+    /// <param name="root">The node representing the root object of the object graph that is being validated.</param>
+    /// <param name="options">The options that control how the structural equivalency is asserted.</param>
     public EquivalencyValidationContext(INode root, IEquivalencyOptions options)
     {
         Options = options;
@@ -19,16 +24,21 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         CyclicReferenceDetector = new CyclicReferenceDetector();
     }
 
+    /// <inheritdoc />
     public INode CurrentNode { get; }
 
+    /// <inheritdoc />
     public Reason Reason { get; set; }
 
+    /// <inheritdoc />
     public Tracer Tracer => tracer ??= new Tracer(CurrentNode, TraceWriter);
 
+    /// <inheritdoc />
     public IEquivalencyOptions Options { get; }
 
     private CyclicReferenceDetector CyclicReferenceDetector { get; set; }
 
+    /// <inheritdoc />
     public IEquivalencyValidationContext AsNestedMember(IMember expectationMember)
     {
         return new EquivalencyValidationContext(expectationMember, Options)
@@ -39,6 +49,7 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         };
     }
 
+    /// <inheritdoc />
     public IEquivalencyValidationContext AsCollectionItem<TItem>(string index)
     {
         return new EquivalencyValidationContext(Node.FromCollectionItem<TItem>(index, CurrentNode), Options)
@@ -49,6 +60,7 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         };
     }
 
+    /// <inheritdoc />
     public IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key)
     {
         return new EquivalencyValidationContext(Node.FromDictionaryItem<TExpectation>(key, CurrentNode), Options)
@@ -59,6 +71,7 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         };
     }
 
+    /// <inheritdoc />
     public IEquivalencyValidationContext Clone()
     {
         return new EquivalencyValidationContext(CurrentNode, Options)
@@ -69,6 +82,7 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         };
     }
 
+    /// <inheritdoc />
     public bool IsCyclicReference(object expectation)
     {
         bool compareByMembers = expectation is not null && Options.GetEqualityStrategy(expectation.GetType())
@@ -78,6 +92,9 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         return CyclicReferenceDetector.IsCyclicReference(reference);
     }
 
+    /// <summary>
+    /// Gets or sets the <see cref="ITraceWriter"/> used to collect tracing messages produced during the equivalency validation.
+    /// </summary>
     public ITraceWriter TraceWriter { get; set; }
 
     /// <summary>
@@ -94,6 +111,9 @@ public class EquivalencyValidationContext : IEquivalencyValidationContext
         }
     }
 
+    /// <summary>
+    /// Returns a string representation of the path to the <see cref="CurrentNode"/> that is currently being validated.
+    /// </summary>
     public override string ToString()
     {
         return Invariant($"{{Path=\"{CurrentNode.Subject.PathAndName}\"}}");

--- a/Src/AwesomeAssertions/Equivalency/IEquivalencyValidationContext.cs
+++ b/Src/AwesomeAssertions/Equivalency/IEquivalencyValidationContext.cs
@@ -25,6 +25,9 @@ public interface IEquivalencyValidationContext
     /// </summary>
     Tracer Tracer { get; }
 
+    /// <summary>
+    /// Gets the <see cref="IEquivalencyOptions"/> that are in effect for the current equivalency validation.
+    /// </summary>
     IEquivalencyOptions Options { get; }
 
     /// <summary>

--- a/Src/AwesomeAssertions/Equivalency/IValidateChildNodeEquivalency.cs
+++ b/Src/AwesomeAssertions/Equivalency/IValidateChildNodeEquivalency.cs
@@ -1,5 +1,8 @@
 namespace AwesomeAssertions.Equivalency;
 
+/// <summary>
+/// Defines the ability to run a deep recursive equivalency assertion on the nested or child nodes of an object graph.
+/// </summary>
 public interface IValidateChildNodeEquivalency
 {
     /// <summary>

--- a/Src/AwesomeAssertions/Equivalency/MemberFactory.cs
+++ b/Src/AwesomeAssertions/Equivalency/MemberFactory.cs
@@ -4,8 +4,20 @@ using AwesomeAssertions.Common;
 
 namespace AwesomeAssertions.Equivalency;
 
+/// <summary>
+/// Provides factory methods for creating <see cref="IMember"/> instances that wrap the fields and properties of an object graph.
+/// </summary>
 public static class MemberFactory
 {
+    /// <summary>
+    /// Creates an <see cref="IMember"/> representing the field or property described by <paramref name="memberInfo"/>.
+    /// </summary>
+    /// <param name="memberInfo">The reflection metadata of the field or property to wrap.</param>
+    /// <param name="parent">The node representing the object that declares the member.</param>
+    /// <returns>An <see cref="IMember"/> wrapping the specified field or property.</returns>
+    /// <exception cref="NotSupportedException">
+    /// <paramref name="memberInfo"/> represents a member that is neither a field nor a property.
+    /// </exception>
     public static IMember Create(MemberInfo memberInfo, INode parent)
     {
         return memberInfo.MemberType switch

--- a/Src/AwesomeAssertions/Equivalency/MemberSelectionContext.cs
+++ b/Src/AwesomeAssertions/Equivalency/MemberSelectionContext.cs
@@ -12,6 +12,12 @@ public class MemberSelectionContext
     private readonly Type runtimeType;
     private readonly IEquivalencyOptions options;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemberSelectionContext"/> class.
+    /// </summary>
+    /// <param name="compileTimeType">The declared (compile-time) type of the object whose members are being selected.</param>
+    /// <param name="runtimeType">The run-time type of the object whose members are being selected.</param>
+    /// <param name="options">The options that control how the structural equivalency is asserted.</param>
     public MemberSelectionContext(Type compileTimeType, Type runtimeType, IEquivalencyOptions options)
     {
         this.runtimeType = runtimeType;

--- a/Src/AwesomeAssertions/Equivalency/MemberVisibility.cs
+++ b/Src/AwesomeAssertions/Equivalency/MemberVisibility.cs
@@ -9,9 +9,28 @@ namespace AwesomeAssertions.Equivalency;
 [Flags]
 public enum MemberVisibility
 {
+    /// <summary>
+    /// No members are included.
+    /// </summary>
     None = 0,
+
+    /// <summary>
+    /// Members with <c>internal</c> visibility are included.
+    /// </summary>
     Internal = 1,
+
+    /// <summary>
+    /// Members with <c>public</c> visibility are included.
+    /// </summary>
     Public = 2,
+
+    /// <summary>
+    /// Explicitly implemented interface members are included.
+    /// </summary>
     ExplicitlyImplemented = 4,
+
+    /// <summary>
+    /// Default interface properties are included.
+    /// </summary>
     DefaultInterfaceProperties = 8
 }

--- a/Src/AwesomeAssertions/Equivalency/NestedExclusionOptionBuilder.cs
+++ b/Src/AwesomeAssertions/Equivalency/NestedExclusionOptionBuilder.cs
@@ -6,6 +6,12 @@ using AwesomeAssertions.Equivalency.Selection;
 
 namespace AwesomeAssertions.Equivalency;
 
+/// <summary>
+/// Provides a fluent API for excluding a nested member reached by navigating through one or more collections
+/// on the <typeparamref name="TExpectation"/> object graph.
+/// </summary>
+/// <typeparam name="TExpectation">The type of the root expectation the exclusions are configured on.</typeparam>
+/// <typeparam name="TCurrent">The item type of the collection currently selected in the navigation chain.</typeparam>
 public class NestedExclusionOptionBuilder<TExpectation, TCurrent>
 {
     /// <summary>

--- a/Src/AwesomeAssertions/Equivalency/OrderStrictness.cs
+++ b/Src/AwesomeAssertions/Equivalency/OrderStrictness.cs
@@ -1,8 +1,22 @@
 namespace AwesomeAssertions.Equivalency;
 
+/// <summary>
+/// Determines how strictly the ordering of a collection is enforced during a structural equivalency assertion.
+/// </summary>
 public enum OrderStrictness
 {
+    /// <summary>
+    /// The elements must appear in the same order.
+    /// </summary>
     Strict,
+
+    /// <summary>
+    /// The elements may appear in any order.
+    /// </summary>
     NotStrict,
+
+    /// <summary>
+    /// The ordering is not relevant and no ordering preference has been specified.
+    /// </summary>
     Irrelevant
 }

--- a/Src/AwesomeAssertions/Equivalency/OrderingRuleCollection.cs
+++ b/Src/AwesomeAssertions/Equivalency/OrderingRuleCollection.cs
@@ -50,6 +50,10 @@ public class OrderingRuleCollection : IEnumerable<IOrderingRule>
         return GetEnumerator();
     }
 
+    /// <summary>
+    /// Adds an ordering rule to the collection.
+    /// </summary>
+    /// <param name="rule">The ordering rule to add.</param>
     public void Add(IOrderingRule rule)
     {
         rules.Add(rule);

--- a/Src/AwesomeAssertions/Equivalency/Pathway.cs
+++ b/Src/AwesomeAssertions/Equivalency/Pathway.cs
@@ -7,6 +7,11 @@ namespace AwesomeAssertions.Equivalency;
 /// </summary>
 public record Pathway
 {
+    /// <summary>
+    /// Represents a method that produces the display representation of a path from its combined path and name.
+    /// </summary>
+    /// <param name="pathAndName">The combined path and name of the field or property.</param>
+    /// <returns>The display representation of the path.</returns>
     public delegate string GetDescription(string pathAndName);
 
     private readonly string path = string.Empty;
@@ -15,6 +20,13 @@ public record Pathway
 
     private readonly GetDescription getDescription;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Pathway"/> class with the specified path and name and a factory
+    /// to provide a description for the path and name.
+    /// </summary>
+    /// <param name="path">The path of the field or property without the name.</param>
+    /// <param name="name">The name of the field or property without the path.</param>
+    /// <param name="getDescription">A factory that provides the display representation for the combined path and name.</param>
     public Pathway(string path, string name, GetDescription getDescription)
     {
         Path = path;
@@ -69,5 +81,9 @@ public record Pathway
     /// </summary>
     public string Description => getDescription(PathAndName);
 
+    /// <summary>
+    /// Returns the display representation of this path.
+    /// </summary>
+    /// <returns>The value of <see cref="Description"/>.</returns>
     public override string ToString() => Description;
 }

--- a/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -39,6 +39,10 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private CyclicReferenceHandling cyclicReferenceHandling = CyclicReferenceHandling.ThrowException;
 
+    /// <summary>
+    /// Gets the ordered collection of rules that determine whether the order of collections is important during the
+    /// equivalency assertion.
+    /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     protected OrderingRuleCollection OrderingRules { get; } = [];
 
@@ -148,6 +152,10 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     /// </summary>
     IEnumerable<IEquivalencyStep> IEquivalencyOptions.UserEquivalencySteps => userEquivalencySteps;
 
+    /// <summary>
+    /// Gets the selector that determines which member values are converted to the type of the expectation before the
+    /// actual comparison takes place.
+    /// </summary>
     public ConversionSelector ConversionSelector { get; } = new();
 
     /// <summary>
@@ -181,19 +189,39 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
 
     bool IEquivalencyOptions.ExcludeNonBrowsableOnExpectation => excludeNonBrowsableOnExpectation;
 
+    /// <summary>
+    /// Gets a value indicating whether records are compared by value instead of by their members, or
+    /// <see langword="null"/> when this has not been explicitly configured.
+    /// </summary>
     public bool? CompareRecordsByValue => equalityStrategyProvider.CompareRecordsByValue;
 
     EqualityStrategy IEquivalencyOptions.GetEqualityStrategy(Type type)
         => equalityStrategyProvider.GetEqualityStrategy(type);
 
+    /// <summary>
+    /// Gets a value indicating whether leading whitespace should be ignored when comparing <see langword="string"/>s.
+    /// </summary>
     public bool IgnoreLeadingWhitespace { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether trailing whitespace should be ignored when comparing <see langword="string"/>s.
+    /// </summary>
     public bool IgnoreTrailingWhitespace { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether <see langword="string"/>s should be compared case-insensitively.
+    /// </summary>
     public bool IgnoreCase { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the newline style should be ignored when comparing <see langword="string"/>s.
+    /// </summary>
     public bool IgnoreNewlineStyle { get; private set; }
 
+    /// <summary>
+    /// Gets the <see cref="ITraceWriter"/> used to trace the steps the equivalency validation followed, or
+    /// <see langword="null"/> when tracing is not enabled.
+    /// </summary>
     public ITraceWriter TraceWriter { get; private set; }
 
     /// <summary>
@@ -376,8 +404,8 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     }
 
     /// <summary>
-    /// Tries to match the members of the expectation with equally named members on the subject. Ignores those
-    /// members that don't exist on the subject and previously registered matching rules.
+    /// Tries to match the members of the expectation with equally named members on the subject. Excludes those
+    /// members of the expectation that do not exist on the subject, so their absence does not fail the assertion.
     /// </summary>
     public TSelf ExcludingMissingMembers()
     {
@@ -869,6 +897,11 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         private readonly Action<IAssertionContext<TMember>> action;
         private readonly TSelf options;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Restriction{TMember}"/> class.
+        /// </summary>
+        /// <param name="options">The equivalency options the override is registered on.</param>
+        /// <param name="action">The assertion to execute when the restriction's predicate is met.</param>
         public Restriction(TSelf options, Action<IAssertionContext<TMember>> action)
         {
             this.options = options;
@@ -911,12 +944,20 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         selectionRules.RemoveAll(selectionRule => selectionRule is T);
     }
 
+    /// <summary>
+    /// Adds a selection rule that is evaluated after all previously registered selection rules.
+    /// </summary>
+    /// <param name="selectionRule">The selection rule to add.</param>
     protected internal TSelf AddSelectionRule(IMemberSelectionRule selectionRule)
     {
         selectionRules.Add(selectionRule);
         return (TSelf)this;
     }
 
+    /// <summary>
+    /// Adds a matching rule that is evaluated before all previously registered matching rules.
+    /// </summary>
+    /// <param name="matchingRule">The matching rule to add.</param>
     protected TSelf AddMatchingRule(IMemberMatchingRule matchingRule)
     {
         matchingRules.Insert(0, matchingRule);

--- a/Src/AwesomeAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/AssertionRuleEquivalencyStep.cs
@@ -6,6 +6,10 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Applies a user-supplied assertion action to every member that matches a predicate, optionally attempting
+/// an automatic type conversion before the assertion is executed.
+/// </summary>
 public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
 {
     private readonly Func<IObjectInfo, bool> predicate;
@@ -13,6 +17,11 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
     private readonly Action<IAssertionContext<TSubject>> assertionAction;
     private readonly AutoConversionStep converter = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssertionRuleEquivalencyStep{TSubject}"/> class.
+    /// </summary>
+    /// <param name="predicate">A predicate that determines to which members the assertion action applies.</param>
+    /// <param name="assertionAction">The assertion action to execute on the members matching the <paramref name="predicate"/>.</param>
     public AssertionRuleEquivalencyStep(
         Expression<Func<IObjectInfo, bool>> predicate,
         Action<IAssertionContext<TSubject>> assertionAction)
@@ -22,6 +31,7 @@ public class AssertionRuleEquivalencyStep<TSubject> : IEquivalencyStep
         description = predicate.ToString();
     }
 
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/AutoConversionStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/AutoConversionStep.cs
@@ -13,6 +13,7 @@ namespace AwesomeAssertions.Equivalency.Steps;
 /// </remarks>
 public class AutoConversionStep : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {
@@ -80,6 +81,9 @@ public class AutoConversionStep : IEquivalencyStep
         return false;
     }
 
+    /// <summary>
+    /// Returns an empty string, as this step does not contribute a description to the equivalency comparison.
+    /// </summary>
     public override string ToString()
     {
         return string.Empty;

--- a/Src/AwesomeAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/DictionaryEquivalencyStep.cs
@@ -6,8 +6,13 @@ using static System.FormattableString;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two non-generic <see cref="IDictionary"/> instances by comparing their keys and
+/// recursively comparing the associated values.
+/// </summary>
 public class DictionaryEquivalencyStep : EquivalencyStep<IDictionary>
 {
+    /// <inheritdoc />
     [SuppressMessage("ReSharper", "PossibleNullReferenceException")]
     protected override EquivalencyResult OnHandle(Comparands comparands,
         IEquivalencyValidationContext context,

--- a/Src/AwesomeAssertions/Equivalency/Steps/EnumEqualityStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/EnumEqualityStep.cs
@@ -8,8 +8,13 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two enum values, comparing them either by their underlying value or by their name
+/// depending on the configured <see cref="EnumEquivalencyHandling"/>.
+/// </summary>
 public class EnumEqualityStep : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -5,8 +5,12 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two non-generic <see cref="IEnumerable"/> collections by comparing their elements.
+/// </summary>
 public class EnumerableEquivalencyStep : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/EqualityComparerEquivalencyStep.cs
@@ -5,15 +5,24 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of objects of type <typeparamref name="T"/> using a user-supplied
+/// <see cref="IEqualityComparer{T}"/> instead of the default structural comparison.
+/// </summary>
 public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
 {
     private readonly IEqualityComparer<T> comparer;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EqualityComparerEquivalencyStep{T}"/> class.
+    /// </summary>
+    /// <param name="comparer">The equality comparer used to compare objects of type <typeparamref name="T"/>.</param>
     public EqualityComparerEquivalencyStep(IEqualityComparer<T> comparer)
     {
         this.comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
     }
 
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {
@@ -44,6 +53,9 @@ public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
         return EquivalencyResult.EquivalencyProven;
     }
 
+    /// <summary>
+    /// Returns a human-readable description of the comparer and the type it is applied to.
+    /// </summary>
     public override string ToString()
     {
         return $"Use {comparer} for objects of type {typeof(T).ToFormattedString()}";

--- a/Src/AwesomeAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -7,6 +7,10 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two objects that implement <see cref="IDictionary{TKey,TValue}"/> by comparing their
+/// keys and recursively comparing the associated values.
+/// </summary>
 public class GenericDictionaryEquivalencyStep : IEquivalencyStep
 {
 #pragma warning disable SA1110 // Allow opening parenthesis on new line to reduce line length
@@ -16,6 +20,7 @@ public class GenericDictionaryEquivalencyStep : IEquivalencyStep
             (AssertDictionaryEquivalence).GetMethodInfo().GetGenericMethodDefinition();
 #pragma warning restore SA1110
 
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -8,6 +8,9 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two objects that implement <see cref="IEnumerable{T}"/> by comparing their elements.
+/// </summary>
 public class GenericEnumerableEquivalencyStep : IEquivalencyStep
 {
 #pragma warning disable SA1110 // Allow opening parenthesis on new line to reduce line length
@@ -15,6 +18,7 @@ public class GenericEnumerableEquivalencyStep : IEquivalencyStep
         (HandleImpl).GetMethodInfo().GetGenericMethodDefinition();
 #pragma warning restore SA1110
 
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/ReferenceEqualityEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/ReferenceEqualityEquivalencyStep.cs
@@ -1,7 +1,11 @@
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Proves the equivalency of the subject and expectation when they refer to the same object instance.
+/// </summary>
 public class ReferenceEqualityEquivalencyStep : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/RunAllUserStepsEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/RunAllUserStepsEquivalencyStep.cs
@@ -6,6 +6,7 @@ namespace AwesomeAssertions.Equivalency.Steps;
 /// </summary>
 public class RunAllUserStepsEquivalencyStep : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/SimpleEqualityEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/SimpleEqualityEquivalencyStep.cs
@@ -2,8 +2,13 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equality of the subject and expectation using their <see cref="object.Equals(object)"/> implementation
+/// when the comparison is non-recursive and the current node is not the root.
+/// </summary>
 public class SimpleEqualityEquivalencyStep : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -4,8 +4,13 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two <see cref="string"/> values, honoring the string-related equivalency options such as
+/// ignoring case, whitespace, or newline style.
+/// </summary>
 public class StringEqualityEquivalencyStep : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/StructuralEqualityEquivalencyStep.cs
@@ -5,8 +5,12 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two objects by recursively comparing the members that are selected from the expectation.
+/// </summary>
 public class StructuralEqualityEquivalencyStep : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/ValueTypeEquivalencyStep.cs
@@ -8,6 +8,7 @@ namespace AwesomeAssertions.Equivalency.Steps;
 /// </summary>
 public class ValueTypeEquivalencyStep : IEquivalencyStep
 {
+    /// <inheritdoc />
     public EquivalencyResult Handle(Comparands comparands, IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency valueChildNodes)
     {

--- a/Src/AwesomeAssertions/Equivalency/Steps/XAttributeEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/XAttributeEquivalencyStep.cs
@@ -3,8 +3,12 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two <see cref="XAttribute"/> instances.
+/// </summary>
 public class XAttributeEquivalencyStep : EquivalencyStep<XAttribute>
 {
+    /// <inheritdoc />
     protected override EquivalencyResult OnHandle(Comparands comparands,
         IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency nestedValidator)

--- a/Src/AwesomeAssertions/Equivalency/Steps/XDocumentEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/XDocumentEquivalencyStep.cs
@@ -3,8 +3,12 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two <see cref="XDocument"/> instances.
+/// </summary>
 public class XDocumentEquivalencyStep : EquivalencyStep<XDocument>
 {
+    /// <inheritdoc />
     protected override EquivalencyResult OnHandle(Comparands comparands,
         IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency nestedValidator)

--- a/Src/AwesomeAssertions/Equivalency/Steps/XElementEquivalencyStep.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/XElementEquivalencyStep.cs
@@ -3,8 +3,12 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Equivalency.Steps;
 
+/// <summary>
+/// Asserts the equivalency of two <see cref="XElement"/> instances.
+/// </summary>
 public class XElementEquivalencyStep : EquivalencyStep<XElement>
 {
+    /// <inheritdoc />
     protected override EquivalencyResult OnHandle(Comparands comparands,
         IEquivalencyValidationContext context,
         IValidateChildNodeEquivalency nestedValidator)

--- a/Src/AwesomeAssertions/Equivalency/SubjectInfoExtensions.cs
+++ b/Src/AwesomeAssertions/Equivalency/SubjectInfoExtensions.cs
@@ -2,6 +2,10 @@ using AwesomeAssertions.Common;
 
 namespace AwesomeAssertions.Equivalency;
 
+/// <summary>
+/// Provides extension methods on <see cref="IMemberInfo"/> for inspecting the accessibility of a member's getter and
+/// setter.
+/// </summary>
 public static class SubjectInfoExtensions
 {
     /// <summary>

--- a/Src/AwesomeAssertions/Equivalency/Tracing/StringBuilderTraceWriter.cs
+++ b/Src/AwesomeAssertions/Equivalency/Tracing/StringBuilderTraceWriter.cs
@@ -3,16 +3,22 @@ using System.Text;
 
 namespace AwesomeAssertions.Equivalency.Tracing;
 
+/// <summary>
+/// An <see cref="ITraceWriter"/> that collects the trace of a structural equivalency comparison in a
+/// <see cref="StringBuilder"/>.
+/// </summary>
 public class StringBuilderTraceWriter : ITraceWriter
 {
     private readonly StringBuilder builder = new();
     private int depth = 1;
 
+    /// <inheritdoc />
     public void AddSingle(string trace)
     {
         WriteLine(trace);
     }
 
+    /// <inheritdoc />
     public IDisposable AddBlock(string trace)
     {
         WriteLine(trace);
@@ -34,6 +40,7 @@ public class StringBuilderTraceWriter : ITraceWriter
         }
     }
 
+    /// <inheritdoc />
     public override string ToString()
     {
         return builder.ToString();

--- a/Src/AwesomeAssertions/Equivalency/Tracing/Tracer.cs
+++ b/Src/AwesomeAssertions/Equivalency/Tracing/Tracer.cs
@@ -45,5 +45,9 @@ public class Tracer
         return new Disposable(() => { });
     }
 
+    /// <summary>
+    /// Returns the trace collected by the configured <see cref="ITraceWriter"/>, or an empty string if no tracer
+    /// has been configured.
+    /// </summary>
     public override string ToString() => traceWriter is not null ? traceWriter.ToString() : string.Empty;
 }

--- a/Src/AwesomeAssertions/EventRaisingExtensions.cs
+++ b/Src/AwesomeAssertions/EventRaisingExtensions.cs
@@ -17,6 +17,7 @@ public static class EventRaisingExtensions
     /// <summary>
     /// Asserts that all occurrences of the event originates from the <param name="expectedSender"/>.
     /// </summary>
+    /// <param name="eventRecording">The recorded events to filter by sender.</param>
     /// <returns>
     /// Returns only the events that comes from that sender.
     /// </returns>
@@ -154,6 +155,7 @@ public static class EventRaisingExtensions
     /// Asserts that all occurrences of the events has arguments of type <see cref="PropertyChangedEventArgs"/>
     /// and are for property <paramref name="propertyName"/>.
     /// </summary>
+    /// <param name="eventRecording">The recorded events to filter by property name.</param>
     /// <param name="propertyName">
     /// The property name for which the property changed events should have been raised.
     /// </param>

--- a/Src/AwesomeAssertions/Events/EventAssertions.cs
+++ b/Src/AwesomeAssertions/Events/EventAssertions.cs
@@ -18,6 +18,11 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
     private const string PropertyChangedEventName = nameof(INotifyPropertyChanged.PropertyChanged);
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="monitor">The monitor that records the events raised by the object being asserted.</param>
+    /// <param name="assertionChain">The assertion chain used to execute the assertions.</param>
     protected internal EventAssertions(IMonitor<T> monitor, AssertionChain assertionChain)
         : base(monitor.Subject, assertionChain)
     {
@@ -171,5 +176,6 @@ public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>
         }
     }
 
+    /// <inheritdoc />
     protected override string Identifier => "subject";
 }

--- a/Src/AwesomeAssertions/Events/EventMetadata.cs
+++ b/Src/AwesomeAssertions/Events/EventMetadata.cs
@@ -17,6 +17,11 @@ public class EventMetadata
     /// </summary>
     public Type HandlerType { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventMetadata"/> class.
+    /// </summary>
+    /// <param name="eventName">The name of the event member on the monitored object.</param>
+    /// <param name="handlerType">The type of the event handler and event args.</param>
     public EventMetadata(string eventName, Type handlerType)
     {
         EventName = eventName;

--- a/Src/AwesomeAssertions/Events/IMonitor.cs
+++ b/Src/AwesomeAssertions/Events/IMonitor.cs
@@ -22,6 +22,11 @@ public interface IMonitor<T> : IDisposable
     /// </summary>
     EventAssertions<T> Should();
 
+    /// <summary>
+    /// Gets a recording of all events that have been raised for the event with the specified <paramref name="eventName"/>.
+    /// </summary>
+    /// <param name="eventName">The name of the event to get the recording for.</param>
+    /// <returns>An <see cref="IEventRecording"/> exposing the events that were raised for the specified event.</returns>
     IEventRecording GetRecordingFor(string eventName);
 
     /// <summary>

--- a/Src/AwesomeAssertions/Exactly.cs
+++ b/Src/AwesomeAssertions/Exactly.cs
@@ -1,13 +1,34 @@
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Provides factory methods for <see cref="OccurrenceConstraint"/>s that require an event or item to
+/// occur exactly a given number of times.
+/// </summary>
 public static class Exactly
 {
+    /// <summary>
+    /// Requires the occurrence to happen exactly one time.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is exactly one.</returns>
     public static OccurrenceConstraint Once() => new ExactlyTimesConstraint(1);
 
+    /// <summary>
+    /// Requires the occurrence to happen exactly two times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is exactly two.</returns>
     public static OccurrenceConstraint Twice() => new ExactlyTimesConstraint(2);
 
+    /// <summary>
+    /// Requires the occurrence to happen exactly three times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is exactly three.</returns>
     public static OccurrenceConstraint Thrice() => new ExactlyTimesConstraint(3);
 
+    /// <summary>
+    /// Requires the occurrence to happen exactly the specified number of times.
+    /// </summary>
+    /// <param name="expected">The exact number of times the occurrence is expected to happen.</param>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count equals <paramref name="expected"/>.</returns>
     public static OccurrenceConstraint Times(int expected) => new ExactlyTimesConstraint(expected);
 
     private sealed class ExactlyTimesConstraint : OccurrenceConstraint

--- a/Src/AwesomeAssertions/ExceptionAssertionsExtensions.cs
+++ b/Src/AwesomeAssertions/ExceptionAssertionsExtensions.cs
@@ -7,6 +7,9 @@ using AwesomeAssertions.Specialized;
 
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Provides extension methods for asserting on exceptions, including the results of asynchronous exception assertions.
+/// </summary>
 public static class ExceptionAssertionsExtensions
 {
 #pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API

--- a/Src/AwesomeAssertions/Execution/AssertionChain.cs
+++ b/Src/AwesomeAssertions/Execution/AssertionChain.cs
@@ -68,6 +68,9 @@ public sealed class AssertionChain
     /// </summary>
     public bool Succeeded => PreviousAssertionSucceeded && succeeded is null or true;
 
+    /// <summary>
+    /// Forces the objects involved in the assertion to be formatted using line breaks in the failure message.
+    /// </summary>
     public AssertionChain UsingLineBreaks
     {
         get
@@ -171,6 +174,16 @@ public sealed class AssertionChain
         return this;
     }
 
+    /// <summary>
+    /// Specifies the condition that must be satisfied for the assertion to succeed.
+    /// </summary>
+    /// <param name="condition">
+    /// If <see langword="true"/> the assertion is treated as successful; if <see langword="false"/> the next call
+    /// to one of the <c>FailWith</c> overloads records the failure.
+    /// </param>
+    /// <remarks>
+    /// The condition is ignored when a prior assertion in the chain already failed.
+    /// </remarks>
     public AssertionChain ForCondition(bool condition)
     {
         if (PreviousAssertionSucceeded)
@@ -181,6 +194,16 @@ public sealed class AssertionChain
         return this;
     }
 
+    /// <summary>
+    /// Specifies the condition that must be satisfied for the assertion to succeed.
+    /// </summary>
+    /// <param name="condition">
+    /// A function returning <see langword="true"/> when the assertion should be treated as successful, or
+    /// <see langword="false"/> to have the next call to one of the <c>FailWith</c> overloads record the failure.
+    /// </param>
+    /// <remarks>
+    /// The <paramref name="condition"/> is only invoked when a prior assertion in the chain succeeded.
+    /// </remarks>
     public AssertionChain ForCondition(Func<bool> condition)
     {
         if (PreviousAssertionSucceeded)
@@ -191,6 +214,17 @@ public sealed class AssertionChain
         return this;
     }
 
+    /// <summary>
+    /// Specifies that the occurrence <paramref name="constraint"/> must satisfy the number <paramref name="actualOccurrences"/>
+    /// for the assertion to succeed.
+    /// </summary>
+    /// <param name="constraint">
+    /// The occurrence constraint (such as those produced by <c>AtLeast</c>, <c>AtMost</c> or <c>Exactly</c>) to evaluate.
+    /// </param>
+    /// <param name="actualOccurrences">The number of occurrences that were actually found.</param>
+    /// <remarks>
+    /// The constraint is not evaluated when a prior assertion in the chain already failed.
+    /// </remarks>
     public AssertionChain ForConstraint(OccurrenceConstraint constraint, int actualOccurrences)
     {
         if (PreviousAssertionSucceeded)
@@ -204,16 +238,46 @@ public sealed class AssertionChain
         return this;
     }
 
+    /// <summary>
+    /// Defines the expectation part of the failure message that is prepended to the failure reason of the assertions
+    /// executed within <paramref name="chain"/>.
+    /// </summary>
+    /// <param name="message">
+    /// The expectation shown as part of the failure message. May contain numbered
+    /// <see cref="string.Format(string,object[])"/>-style placeholders as well as specialized placeholders.
+    /// </param>
+    /// <param name="arg1">An object to format using the placeholders in <paramref name="message"/>.</param>
+    /// <param name="chain">The assertions to execute using the specified expectation.</param>
     public Continuation WithExpectation(string message, object arg1, Action<AssertionChain> chain)
     {
         return WithExpectation(message, chain, arg1);
     }
 
+    /// <summary>
+    /// Defines the expectation part of the failure message that is prepended to the failure reason of the assertions
+    /// executed within <paramref name="chain"/>.
+    /// </summary>
+    /// <param name="message">
+    /// The expectation shown as part of the failure message. May contain numbered
+    /// <see cref="string.Format(string,object[])"/>-style placeholders as well as specialized placeholders.
+    /// </param>
+    /// <param name="arg1">The first object to format using the placeholders in <paramref name="message"/>.</param>
+    /// <param name="arg2">The second object to format using the placeholders in <paramref name="message"/>.</param>
+    /// <param name="chain">The assertions to execute using the specified expectation.</param>
     public Continuation WithExpectation(string message, object arg1, object arg2, Action<AssertionChain> chain)
     {
         return WithExpectation(message, chain, arg1, arg2);
     }
 
+    /// <summary>
+    /// Defines the expectation part of the failure message that is prepended to the failure reason of the assertions
+    /// executed within <paramref name="chain"/>.
+    /// </summary>
+    /// <param name="message">
+    /// The expectation shown as part of the failure message. May contain specialized placeholders such as
+    /// <em>{context}</em>.
+    /// </param>
+    /// <param name="chain">The assertions to execute using the specified expectation.</param>
     public Continuation WithExpectation(string message, Action<AssertionChain> chain)
     {
         return WithExpectation(message, chain, []);
@@ -242,12 +306,25 @@ public sealed class AssertionChain
         return new Continuation(this);
     }
 
+    /// <summary>
+    /// Sets the identifier that is used in the failure message when the caller identifier could not be determined
+    /// and no other identifier was provided.
+    /// </summary>
+    /// <param name="identifier">The fallback identifier to use in the failure message.</param>
     public AssertionChain WithDefaultIdentifier(string identifier)
     {
         fallbackIdentifier = identifier;
         return this;
     }
 
+    /// <summary>
+    /// Allows executing an assertion against the object returned by <paramref name="selector"/>, which is only invoked
+    /// when the previous assertion in the chain succeeded.
+    /// </summary>
+    /// <param name="selector">A function that returns the object on which the continued assertion is executed.</param>
+    /// <returns>
+    /// A <see cref="GivenSelector{T}"/> that can be used to continue the assertion on the selected object.
+    /// </returns>
     public GivenSelector<T> Given<T>(Func<T> selector)
     {
         return new GivenSelector<T>(selector, this);
@@ -259,18 +336,48 @@ public sealed class AssertionChain
         return FailWith(() => formattedFailReason);
     }
 
+    /// <summary>
+    /// Records a failure with the specified <paramref name="message"/> when the condition set through one of the
+    /// <see cref="ForCondition(bool)"/> overloads was not met.
+    /// </summary>
+    /// <param name="message">
+    /// The failure message. May contain specialized placeholders such as <em>{reason}</em> and <em>{context}</em>.
+    /// </param>
     [StackTraceHidden]
     public Continuation FailWith(string message)
     {
         return FailWith(() => new FailReason(message));
     }
 
+    /// <summary>
+    /// Records a failure with the specified <paramref name="message"/> when the condition set through one of the
+    /// <see cref="ForCondition(bool)"/> overloads was not met.
+    /// </summary>
+    /// <param name="message">
+    /// The failure message. May contain numbered <see cref="string.Format(string,object[])"/>-style placeholders as well
+    /// as specialized placeholders.
+    /// </param>
+    /// <param name="args">
+    /// Zero or more objects to format using the placeholders in <paramref name="message"/>.
+    /// </param>
     [StackTraceHidden]
     public Continuation FailWith(string message, params object[] args)
     {
         return FailWith(() => new FailReason(message, args));
     }
 
+    /// <summary>
+    /// Records a failure with the specified <paramref name="message"/> when the condition set through one of the
+    /// <see cref="ForCondition(bool)"/> overloads was not met.
+    /// </summary>
+    /// <param name="message">
+    /// The failure message. May contain numbered <see cref="string.Format(string,object[])"/>-style placeholders as well
+    /// as specialized placeholders.
+    /// </param>
+    /// <param name="argProviders">
+    /// Zero or more functions that provide the objects to format using the placeholders in <paramref name="message"/>.
+    /// Each function is only invoked when the assertion actually failed.
+    /// </param>
     [StackTraceHidden]
     public Continuation FailWith(string message, params Func<object>[] argProviders)
     {
@@ -280,6 +387,14 @@ public sealed class AssertionChain
                 argProviders.Select(a => a()).ToArray()));
     }
 
+    /// <summary>
+    /// Records a failure using the <see cref="FailReason"/> produced by <paramref name="getFailureReason"/> when the
+    /// condition set through one of the <see cref="ForCondition(bool)"/> overloads was not met.
+    /// </summary>
+    /// <param name="getFailureReason">
+    /// A function that produces the <see cref="FailReason"/> describing the failure. It is only invoked when the
+    /// assertion actually failed.
+    /// </param>
     [StackTraceHidden]
     public Continuation FailWith(Func<FailReason> getFailureReason)
     {

--- a/Src/AwesomeAssertions/Execution/AssertionScope.cs
+++ b/Src/AwesomeAssertions/Execution/AssertionScope.cs
@@ -72,6 +72,7 @@ public sealed class AssertionScope : IDisposable
     /// <summary>
     /// Starts a new scope based on the given assertion strategy and parent assertion scope
     /// </summary>
+    /// <param name="name">A function that returns the name or context of the scope.</param>
     /// <param name="assertionStrategy">The assertion strategy for this scope.</param>
     /// <exception cref="ArgumentNullException"><paramref name="assertionStrategy"/> is <see langword="null"/>.</exception>
     private AssertionScope(Func<string> name, IAssertionStrategy assertionStrategy)
@@ -221,6 +222,12 @@ public sealed class AssertionScope : IDisposable
         return assertionStrategy.DiscardFailures().ToArray();
     }
 
+    /// <summary>
+    /// Determines whether any failures have been collected in the current scope.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if one or more assertions in the scope have failed; otherwise, <see langword="false"/>.
+    /// </returns>
     public bool HasFailures()
     {
         return assertionStrategy.FailureMessages.Any();

--- a/Src/AwesomeAssertions/Execution/ContinuationOfGiven.cs
+++ b/Src/AwesomeAssertions/Execution/ContinuationOfGiven.cs
@@ -15,5 +15,8 @@ public class ContinuationOfGiven<TSubject>
     /// </summary>
     public GivenSelector<TSubject> Then { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the previous assertion in the chain was successful.
+    /// </summary>
     public bool Succeeded => Then.Succeeded;
 }

--- a/Src/AwesomeAssertions/Execution/GivenSelector.cs
+++ b/Src/AwesomeAssertions/Execution/GivenSelector.cs
@@ -20,6 +20,9 @@ public class GivenSelector<T>
         this.selector = assertionChain.Succeeded ? selector() : default;
     }
 
+    /// <summary>
+    /// Gets a value indicating whether the previous assertion in the chain was successful.
+    /// </summary>
     public bool Succeeded => assertionChain.Succeeded;
 
     /// <summary>
@@ -45,6 +48,21 @@ public class GivenSelector<T>
         return this;
     }
 
+    /// <summary>
+    /// Specifies that the occurrence <paramref name="constraint"/> must satisfy the number
+    /// (provided by <paramref name="func"/>) for the assertion to succeed.
+    /// </summary>
+    /// <param name="constraint">
+    /// The occurrence constraint (such as those produced by <c>AtLeast</c>, <c>AtMost</c> or <c>Exactly</c>) to evaluate.
+    /// </param>
+    /// <param name="func">
+    /// A function that returns the number of occurrences found for the selected subject.
+    /// </param>
+    /// <remarks>
+    /// The constraint will not be evaluated if the prior assertion failed,
+    /// nor will <see cref="FailWith(string,System.Func{T,object}[])"/> throw any exceptions.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
     public GivenSelector<T> ForConstraint(OccurrenceConstraint constraint, Func<T, int> func)
     {
         Guard.ThrowIfArgumentIsNull(func);
@@ -57,6 +75,15 @@ public class GivenSelector<T>
         return this;
     }
 
+    /// <summary>
+    /// Allows continuing the assertion on the object returned by <paramref name="selector"/>, which is only invoked when
+    /// the previous assertion in the chain succeeded.
+    /// </summary>
+    /// <param name="selector">A function that returns the object on which the continued assertion is executed.</param>
+    /// <returns>
+    /// A <see cref="GivenSelector{TOut}"/> that can be used to continue the assertion on the selected object.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="selector"/> is <see langword="null"/>.</exception>
     public GivenSelector<TOut> Given<TOut>(Func<T, TOut> selector)
     {
         Guard.ThrowIfArgumentIsNull(selector);
@@ -64,11 +91,30 @@ public class GivenSelector<T>
         return new GivenSelector<TOut>(() => selector(this.selector), assertionChain);
     }
 
+    /// <summary>
+    /// Records a failure with the specified <paramref name="message"/> when the condition specified through
+    /// <see cref="ForCondition"/> was not met.
+    /// </summary>
+    /// <param name="message">
+    /// The failure message. May contain specialized placeholders such as <em>{reason}</em> and <em>{context}</em>.
+    /// </param>
     public ContinuationOfGiven<T> FailWith(string message)
     {
         return FailWith(message, Array.Empty<object>());
     }
 
+    /// <summary>
+    /// Records a failure with the specified <paramref name="message"/> when the condition specified through
+    /// <see cref="ForCondition"/> was not met.
+    /// </summary>
+    /// <param name="message">
+    /// The failure message. May contain numbered <see cref="string.Format(string,object[])"/>-style placeholders as well
+    /// as specialized placeholders.
+    /// </param>
+    /// <param name="args">
+    /// Zero or more functions that provide the objects to format using the placeholders in <paramref name="message"/>,
+    /// based on the selected subject. Each function is only invoked when the assertion actually failed.
+    /// </param>
     public ContinuationOfGiven<T> FailWith(string message, params Func<T, object>[] args)
     {
         assertionChain.FailWith(() => new FailReason(
@@ -77,18 +123,45 @@ public class GivenSelector<T>
         return new ContinuationOfGiven<T>(this);
     }
 
+    /// <summary>
+    /// Records a failure with the specified <paramref name="message"/> when the condition specified through
+    /// <see cref="ForCondition"/> was not met.
+    /// </summary>
+    /// <param name="message">
+    /// The failure message. May contain numbered <see cref="string.Format(string,object[])"/>-style placeholders as well
+    /// as specialized placeholders.
+    /// </param>
+    /// <param name="args">
+    /// Zero or more objects to format using the placeholders in <paramref name="message"/>.
+    /// </param>
     public ContinuationOfGiven<T> FailWith(string message, params object[] args)
     {
         assertionChain.FailWith(message, args);
         return new ContinuationOfGiven<T>(this);
     }
 
+    /// <summary>
+    /// Records a failure with the message produced by <paramref name="message"/> for the selected subject when the
+    /// condition specified through <see cref="ForCondition"/> was not met.
+    /// </summary>
+    /// <param name="message">
+    /// A function that produces the failure message for the selected subject. It is only invoked when the assertion
+    /// actually failed.
+    /// </param>
     public ContinuationOfGiven<T> FailWith(Func<T, string> message)
     {
         assertionChain.FailWith(message(selector));
         return new ContinuationOfGiven<T>(this);
     }
 
+    /// <summary>
+    /// Records a failure using the <see cref="FailReason"/> produced by <paramref name="failReason"/> for the selected
+    /// subject when the condition specified through <see cref="ForCondition"/> was not met.
+    /// </summary>
+    /// <param name="failReason">
+    /// A function that produces the <see cref="FailReason"/> describing the failure for the selected subject. It is only
+    /// invoked when the assertion actually failed.
+    /// </param>
     public ContinuationOfGiven<T> FailWith(Func<T, FailReason> failReason)
     {
         assertionChain.FailWith(() => failReason(selector));

--- a/Src/AwesomeAssertions/Execution/Reason.cs
+++ b/Src/AwesomeAssertions/Execution/Reason.cs
@@ -7,6 +7,16 @@ namespace AwesomeAssertions.Execution;
 /// </summary>
 public class Reason
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Reason"/> class.
+    /// </summary>
+    /// <param name="formattedMessage">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="arguments">
+    /// Zero or more objects to format using the placeholders in <paramref name="formattedMessage"/>.
+    /// </param>
     public Reason([StringSyntax("CompositeFormat")] string formattedMessage, object[] arguments)
     {
         FormattedMessage = formattedMessage;

--- a/Src/AwesomeAssertions/Formatting/AggregateExceptionValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/AggregateExceptionValueFormatter.cs
@@ -3,6 +3,9 @@ using static System.FormattableString;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats an <see cref="AggregateException"/> by writing its inner exceptions.
+/// </summary>
 public class AggregateExceptionValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -17,6 +20,7 @@ public class AggregateExceptionValueFormatter : IValueFormatter
         return value is AggregateException;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var exception = (AggregateException)value;

--- a/Src/AwesomeAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/AttributeBasedFormatter.cs
@@ -30,6 +30,7 @@ public class AttributeBasedFormatter : IValueFormatter
 
     private static bool IsScanningEnabled => AssertionConfiguration.Current.Formatting.ValueFormatterDetectionMode == ValueFormatterDetectionMode.Scan;
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         MethodInfo method = GetFormatter(value);

--- a/Src/AwesomeAssertions/Formatting/ByteValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/ByteValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="byte"/> value as its hexadecimal representation.
+/// </summary>
 public class ByteValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class ByteValueFormatter : IValueFormatter
         return value is byte;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment("0x" + ((byte)value).ToString("X2", CultureInfo.InvariantCulture));

--- a/Src/AwesomeAssertions/Formatting/DateOnlyValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/DateOnlyValueFormatter.cs
@@ -5,6 +5,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="System.DateOnly"/> values.
+/// </summary>
 public class DateOnlyValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -19,6 +22,7 @@ public class DateOnlyValueFormatter : IValueFormatter
         return value is DateOnly;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var dateOnly = (DateOnly)value;

--- a/Src/AwesomeAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -5,6 +5,9 @@ using AwesomeAssertions.Common;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="System.DateTime"/> and <see cref="System.DateTimeOffset"/> values.
+/// </summary>
 public class DateTimeOffsetValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -19,6 +22,7 @@ public class DateTimeOffsetValueFormatter : IValueFormatter
         return value is DateTime or DateTimeOffset;
     }
 
+    /// <inheritdoc />
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Needs to be refactored")]
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {

--- a/Src/AwesomeAssertions/Formatting/DecimalValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/DecimalValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="decimal"/> values.
+/// </summary>
 public class DecimalValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class DecimalValueFormatter : IValueFormatter
         return value is decimal;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((decimal)value).ToString(CultureInfo.InvariantCulture) + "M");

--- a/Src/AwesomeAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/DefaultValueFormatter.cs
@@ -6,6 +6,9 @@ using Reflectify;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// The fallback formatter used to create a human-readable representation of any value for which no more specific formatter applies.
+/// </summary>
 public class DefaultValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -20,6 +23,7 @@ public class DefaultValueFormatter : IValueFormatter
         return true;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         if (value.GetType() == typeof(object))

--- a/Src/AwesomeAssertions/Formatting/DictionaryValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/DictionaryValueFormatter.cs
@@ -7,6 +7,9 @@ using AwesomeAssertions.Common;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="System.Collections.IDictionary"/> values.
+/// </summary>
 public class DictionaryValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -27,6 +30,7 @@ public class DictionaryValueFormatter : IValueFormatter
         return value is IDictionary;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         int startCount = formattedGraph.LineCount;

--- a/Src/AwesomeAssertions/Formatting/DoubleValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/DoubleValueFormatter.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="double"/> values.
+/// </summary>
 public class DoubleValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -17,6 +20,7 @@ public class DoubleValueFormatter : IValueFormatter
         return value is double;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(Format(value));

--- a/Src/AwesomeAssertions/Formatting/EnumValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/EnumValueFormatter.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of enum values.
+/// </summary>
 public class EnumValueFormatter : IValueFormatter
 {
     /// <summary>

--- a/Src/AwesomeAssertions/Formatting/EnumerableValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/EnumerableValueFormatter.cs
@@ -7,6 +7,9 @@ using AwesomeAssertions.Common;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="System.Collections.IEnumerable"/> values.
+/// </summary>
 public class EnumerableValueFormatter : IValueFormatter
 {
     /// <summary>

--- a/Src/AwesomeAssertions/Formatting/ExceptionValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/ExceptionValueFormatter.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="System.Exception"/> values.
+/// </summary>
 public class ExceptionValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class ExceptionValueFormatter : IValueFormatter
         return value is Exception;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((Exception)value).ToString());

--- a/Src/AwesomeAssertions/Formatting/ExpressionValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/ExpressionValueFormatter.cs
@@ -3,6 +3,9 @@ using System.Linq.Expressions;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="System.Linq.Expressions.Expression"/> values.
+/// </summary>
 public class ExpressionValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -17,6 +20,7 @@ public class ExpressionValueFormatter : IValueFormatter
         return value is Expression;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(value.ToString().Replace(" = ", " == ", StringComparison.Ordinal));

--- a/Src/AwesomeAssertions/Formatting/FormatChild.cs
+++ b/Src/AwesomeAssertions/Formatting/FormatChild.cs
@@ -9,4 +9,7 @@ namespace AwesomeAssertions.Formatting;
 /// <param name="value">
 /// The child value to format with the configured <see cref="IValueFormatter"/>s.
 /// </param>
+/// <param name="formattedGraph">
+/// The graph into which the formatted representation of the child value is written.
+/// </param>
 public delegate void FormatChild(string childPath, object value, FormattedObjectGraph formattedGraph);

--- a/Src/AwesomeAssertions/Formatting/FormattedObjectGraph.cs
+++ b/Src/AwesomeAssertions/Formatting/FormattedObjectGraph.cs
@@ -23,6 +23,10 @@ public class FormattedObjectGraph
     private int indentation;
     private string lineBuilderWhitespace = string.Empty;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FormattedObjectGraph"/> class.
+    /// </summary>
+    /// <param name="maxLines">The maximum number of lines the formatted output may contain.</param>
     public FormattedObjectGraph(int maxLines)
     {
         this.maxLines = maxLines;

--- a/Src/AwesomeAssertions/Formatting/FormattingOptions.cs
+++ b/Src/AwesomeAssertions/Formatting/FormattingOptions.cs
@@ -3,6 +3,9 @@ using AwesomeAssertions.Execution;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides the options that control how values are formatted into human-readable strings.
+/// </summary>
 public class FormattingOptions
 {
     internal List<IValueFormatter> ScopedFormatters { get; set; } = [];

--- a/Src/AwesomeAssertions/Formatting/GuidValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/GuidValueFormatter.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="System.Guid"/> values.
+/// </summary>
 public class GuidValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class GuidValueFormatter : IValueFormatter
         return value is Guid;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment($"{{{value}}}");

--- a/Src/AwesomeAssertions/Formatting/Int16ValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/Int16ValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="short"/> values.
+/// </summary>
 public class Int16ValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class Int16ValueFormatter : IValueFormatter
         return value is short;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((short)value).ToString(CultureInfo.InvariantCulture) + "s");

--- a/Src/AwesomeAssertions/Formatting/Int32ValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/Int32ValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="int"/> values.
+/// </summary>
 public class Int32ValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class Int32ValueFormatter : IValueFormatter
         return value is int;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((int)value).ToString(CultureInfo.InvariantCulture));

--- a/Src/AwesomeAssertions/Formatting/Int64ValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/Int64ValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="long"/> values.
+/// </summary>
 public class Int64ValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class Int64ValueFormatter : IValueFormatter
         return value is long;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((long)value).ToString(CultureInfo.InvariantCulture) + "L");

--- a/Src/AwesomeAssertions/Formatting/MaxLinesExceededException.cs
+++ b/Src/AwesomeAssertions/Formatting/MaxLinesExceededException.cs
@@ -3,5 +3,8 @@ using System;
 namespace AwesomeAssertions.Formatting;
 
 #pragma warning disable RCS1194, CA1032 // Add constructors
+/// <summary>
+/// Thrown when the formatted output exceeds the configured maximum number of lines.
+/// </summary>
 public class MaxLinesExceededException : Exception;
 #pragma warning restore CA1032, RCS1194

--- a/Src/AwesomeAssertions/Formatting/MethodInfoFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/MethodInfoFormatter.cs
@@ -2,6 +2,9 @@ using System.Reflection;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="System.Reflection.MethodInfo"/> value.
+/// </summary>
 public class MethodInfoFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class MethodInfoFormatter : IValueFormatter
         return value is MethodInfo;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var method = (MethodInfo)value;

--- a/Src/AwesomeAssertions/Formatting/MultidimensionalArrayFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/MultidimensionalArrayFormatter.cs
@@ -5,6 +5,9 @@ using System.Linq;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a multidimensional <see cref="System.Array"/> value.
+/// </summary>
 public class MultidimensionalArrayFormatter : IValueFormatter
 {
     /// <summary>
@@ -19,6 +22,7 @@ public class MultidimensionalArrayFormatter : IValueFormatter
         return value is Array { Rank: >= 2 };
     }
 
+    /// <inheritdoc />
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Required refactoring")]
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {

--- a/Src/AwesomeAssertions/Formatting/NullValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/NullValueFormatter.cs
@@ -1,5 +1,8 @@
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see langword="null"/> reference.
+/// </summary>
 public class NullValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -14,6 +17,7 @@ public class NullValueFormatter : IValueFormatter
         return value is null;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment("<null>");

--- a/Src/AwesomeAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -11,8 +11,10 @@ namespace AwesomeAssertions.Formatting;
 /// </summary>
 public class PredicateLambdaExpressionValueFormatter : IValueFormatter
 {
+    /// <inheritdoc />
     public bool CanHandle(object value) => value is LambdaExpression;
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var lambdaExpression = (LambdaExpression)value;

--- a/Src/AwesomeAssertions/Formatting/PropertyInfoFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/PropertyInfoFormatter.cs
@@ -2,6 +2,9 @@ using System.Reflection;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="System.Reflection.PropertyInfo"/> value.
+/// </summary>
 public class PropertyInfoFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class PropertyInfoFormatter : IValueFormatter
         return value is PropertyInfo;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var property = (PropertyInfo)value;

--- a/Src/AwesomeAssertions/Formatting/SByteValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/SByteValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="sbyte"/> value.
+/// </summary>
 public class SByteValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class SByteValueFormatter : IValueFormatter
         return value is sbyte;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((sbyte)value).ToString(CultureInfo.InvariantCulture) + "y");

--- a/Src/AwesomeAssertions/Formatting/SingleValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/SingleValueFormatter.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="float"/> value.
+/// </summary>
 public class SingleValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -17,6 +20,7 @@ public class SingleValueFormatter : IValueFormatter
         return value is float;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         float singleValue = (float)value;

--- a/Src/AwesomeAssertions/Formatting/StringValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/StringValueFormatter.cs
@@ -1,5 +1,8 @@
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="string"/> value.
+/// </summary>
 public class StringValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -14,6 +17,7 @@ public class StringValueFormatter : IValueFormatter
         return value is string;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         string result = $"""

--- a/Src/AwesomeAssertions/Formatting/TaskFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/TaskFormatter.cs
@@ -8,11 +8,13 @@ namespace AwesomeAssertions.Formatting;
 /// </summary>
 public class TaskFormatter : IValueFormatter
 {
+    /// <inheritdoc />
     public bool CanHandle(object value)
     {
         return value is Task;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var task = (Task)value;

--- a/Src/AwesomeAssertions/Formatting/TimeOnlyValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/TimeOnlyValueFormatter.cs
@@ -5,6 +5,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Provides a human-readable representation of <see cref="System.TimeOnly"/> values.
+/// </summary>
 public class TimeOnlyValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -19,6 +22,7 @@ public class TimeOnlyValueFormatter : IValueFormatter
         return value is TimeOnly;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var timeOnly = (TimeOnly)value;

--- a/Src/AwesomeAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -5,6 +5,9 @@ using System.Linq;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="System.TimeSpan"/> value.
+/// </summary>
 public class TimeSpanValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -19,6 +22,7 @@ public class TimeSpanValueFormatter : IValueFormatter
         return value is TimeSpan;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var timeSpan = (TimeSpan)value;

--- a/Src/AwesomeAssertions/Formatting/TypeValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/TypeValueFormatter.cs
@@ -5,13 +5,18 @@ using System.Text;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="System.Type"/> value.
+/// </summary>
 public sealed class TypeValueFormatter : IValueFormatter
 {
+    /// <inheritdoc />
     public bool CanHandle(object value)
     {
         return value is Type or ShortTypeValue;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         if (value is ShortTypeValue shortValue)

--- a/Src/AwesomeAssertions/Formatting/UInt16ValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/UInt16ValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="ushort"/> value.
+/// </summary>
 public class UInt16ValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class UInt16ValueFormatter : IValueFormatter
         return value is ushort;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((ushort)value).ToString(CultureInfo.InvariantCulture) + "us");

--- a/Src/AwesomeAssertions/Formatting/UInt32ValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/UInt32ValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="uint"/> value.
+/// </summary>
 public class UInt32ValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class UInt32ValueFormatter : IValueFormatter
         return value is uint;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((uint)value).ToString(CultureInfo.InvariantCulture) + "u");

--- a/Src/AwesomeAssertions/Formatting/UInt64ValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/UInt64ValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Globalization;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="ulong"/> value.
+/// </summary>
 public class UInt64ValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class UInt64ValueFormatter : IValueFormatter
         return value is ulong;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((ulong)value).ToString(CultureInfo.InvariantCulture) + "UL");

--- a/Src/AwesomeAssertions/Formatting/XAttributeValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/XAttributeValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Xml.Linq;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="System.Xml.Linq.XAttribute"/> value.
+/// </summary>
 public class XAttributeValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class XAttributeValueFormatter : IValueFormatter
         return value is XAttribute;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         formattedGraph.AddFragment(((XAttribute)value).ToString());

--- a/Src/AwesomeAssertions/Formatting/XDocumentValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/XDocumentValueFormatter.cs
@@ -2,13 +2,18 @@ using System.Xml.Linq;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="System.Xml.Linq.XDocument"/> value.
+/// </summary>
 public class XDocumentValueFormatter : IValueFormatter
 {
+    /// <inheritdoc />
     public bool CanHandle(object value)
     {
         return value is XDocument;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var document = (XDocument)value;

--- a/Src/AwesomeAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/XElementValueFormatter.cs
@@ -4,6 +4,9 @@ using AwesomeAssertions.Common;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="System.Xml.Linq.XElement"/> value.
+/// </summary>
 public class XElementValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -18,6 +21,7 @@ public class XElementValueFormatter : IValueFormatter
         return value is XElement;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var element = (XElement)value;

--- a/Src/AwesomeAssertions/Formatting/XmlReaderValueFormatter.cs
+++ b/Src/AwesomeAssertions/Formatting/XmlReaderValueFormatter.cs
@@ -2,6 +2,9 @@ using System.Xml;
 
 namespace AwesomeAssertions.Formatting;
 
+/// <summary>
+/// Formats a <see cref="System.Xml.XmlReader"/> value.
+/// </summary>
 public class XmlReaderValueFormatter : IValueFormatter
 {
     /// <summary>
@@ -16,6 +19,7 @@ public class XmlReaderValueFormatter : IValueFormatter
         return value is XmlReader;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         var reader = (XmlReader)value;

--- a/Src/AwesomeAssertions/LessThan.cs
+++ b/Src/AwesomeAssertions/LessThan.cs
@@ -1,11 +1,28 @@
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Provides factory methods for <see cref="OccurrenceConstraint"/>s that require an event or item to
+/// occur less than a given number of times.
+/// </summary>
 public static class LessThan
 {
+    /// <summary>
+    /// Requires the occurrence to happen less than two times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is less than two.</returns>
     public static OccurrenceConstraint Twice() => new LessThanTimesConstraint(2);
 
+    /// <summary>
+    /// Requires the occurrence to happen less than three times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is less than three.</returns>
     public static OccurrenceConstraint Thrice() => new LessThanTimesConstraint(3);
 
+    /// <summary>
+    /// Requires the occurrence to happen less than the specified number of times.
+    /// </summary>
+    /// <param name="expected">The number of times the occurrence must stay below.</param>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is less than <paramref name="expected"/>.</returns>
     public static OccurrenceConstraint Times(int expected) => new LessThanTimesConstraint(expected);
 
     private sealed class LessThanTimesConstraint : OccurrenceConstraint

--- a/Src/AwesomeAssertions/MoreThan.cs
+++ b/Src/AwesomeAssertions/MoreThan.cs
@@ -1,13 +1,34 @@
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Provides factory methods for <see cref="OccurrenceConstraint"/>s that require an event or item to
+/// occur more than a given number of times.
+/// </summary>
 public static class MoreThan
 {
+    /// <summary>
+    /// Requires the occurrence to happen more than one time.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is more than one.</returns>
     public static OccurrenceConstraint Once() => new MoreThanTimesConstraint(1);
 
+    /// <summary>
+    /// Requires the occurrence to happen more than two times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is more than two.</returns>
     public static OccurrenceConstraint Twice() => new MoreThanTimesConstraint(2);
 
+    /// <summary>
+    /// Requires the occurrence to happen more than three times.
+    /// </summary>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is more than three.</returns>
     public static OccurrenceConstraint Thrice() => new MoreThanTimesConstraint(3);
 
+    /// <summary>
+    /// Requires the occurrence to happen more than the specified number of times.
+    /// </summary>
+    /// <param name="expected">The number of times the occurrence must exceed.</param>
+    /// <returns>An <see cref="OccurrenceConstraint"/> that is satisfied when the actual count is more than <paramref name="expected"/>.</returns>
     public static OccurrenceConstraint Times(int expected) => new MoreThanTimesConstraint(expected);
 
     private sealed class MoreThanTimesConstraint : OccurrenceConstraint

--- a/Src/AwesomeAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/AwesomeAssertions/Numeric/ComparableTypeAssertions.cs
@@ -16,6 +16,13 @@ namespace AwesomeAssertions.Numeric;
 [DebuggerNonUserCode]
 public class ComparableTypeAssertions<T> : ComparableTypeAssertions<T, ComparableTypeAssertions<T>>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComparableTypeAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public ComparableTypeAssertions(IComparable<T> value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -32,6 +39,13 @@ public class ComparableTypeAssertions<T, TAssertions> : ReferenceTypeAssertions<
     private const int Equal = 0;
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComparableTypeAssertions{T, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public ComparableTypeAssertions(IComparable<T> value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {

--- a/Src/AwesomeAssertions/Numeric/NullableNumericAssertions.cs
+++ b/Src/AwesomeAssertions/Numeric/NullableNumericAssertions.cs
@@ -14,6 +14,13 @@ namespace AwesomeAssertions.Numeric;
 public class NullableNumericAssertions<T> : NullableNumericAssertions<T, NullableNumericAssertions<T>>
     where T : struct, IComparable<T>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableNumericAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public NullableNumericAssertions(T? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -30,6 +37,13 @@ public class NullableNumericAssertions<T, TAssertions> : NumericAssertionsBase<T
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableNumericAssertions{T, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public NullableNumericAssertions(T? value, AssertionChain assertionChain)
         : base(assertionChain)
     {
@@ -37,6 +51,9 @@ public class NullableNumericAssertions<T, TAssertions> : NumericAssertionsBase<T
         this.assertionChain = assertionChain;
     }
 
+    /// <summary>
+    /// Gets the object whose value is being asserted.
+    /// </summary>
     public override T? Subject { get; }
 
     /// <summary>

--- a/Src/AwesomeAssertions/Numeric/NumericAssertions.cs
+++ b/Src/AwesomeAssertions/Numeric/NumericAssertions.cs
@@ -11,6 +11,13 @@ namespace AwesomeAssertions.Numeric;
 public class NumericAssertions<T> : NumericAssertions<T, NumericAssertions<T>>
     where T : struct, IComparable<T>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NumericAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public NumericAssertions(T value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -25,11 +32,21 @@ public class NumericAssertions<T, TAssertions> : NumericAssertionsBase<T, T, TAs
     where T : struct, IComparable<T>
     where TAssertions : NumericAssertions<T, TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NumericAssertions{T, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public NumericAssertions(T value, AssertionChain assertionChain)
         : base(assertionChain)
     {
         Subject = value;
     }
 
+    /// <summary>
+    /// Gets the object whose value is being asserted.
+    /// </summary>
     public override T Subject { get; }
 }

--- a/Src/AwesomeAssertions/Numeric/NumericAssertionsBase.cs
+++ b/Src/AwesomeAssertions/Numeric/NumericAssertionsBase.cs
@@ -10,12 +10,24 @@ namespace AwesomeAssertions.Numeric;
 
 #pragma warning disable CS0659, S1206 // Ignore not overriding Object.GetHashCode()
 #pragma warning disable CA1065 // Ignore throwing NotSupportedException from Equals
+/// <summary>
+/// Contains a number of methods to assert that a numeric value is in the expected state.
+/// </summary>
 public abstract class NumericAssertionsBase<T, TSubject, TAssertions>
     where T : struct, IComparable<T>
     where TAssertions : NumericAssertionsBase<T, TSubject, TAssertions>
 {
+    /// <summary>
+    /// Gets the object whose value is being asserted.
+    /// </summary>
     public abstract TSubject Subject { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NumericAssertionsBase{T, TSubject, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     protected NumericAssertionsBase(AssertionChain assertionChain)
     {
         CurrentAssertionChain = assertionChain;

--- a/Src/AwesomeAssertions/NumericAssertionsExtensions.cs
+++ b/Src/AwesomeAssertions/NumericAssertionsExtensions.cs
@@ -1579,6 +1579,7 @@ public static class NumericAssertionsExtensions
     /// <summary>
     /// Asserts that the number is seen as not a number (NaN).
     /// </summary>
+    /// <param name="parent">The <see cref="NumericAssertions{T}"/> object that is being extended.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -1604,6 +1605,7 @@ public static class NumericAssertionsExtensions
     /// <summary>
     /// Asserts that the number is seen as not a number (NaN).
     /// </summary>
+    /// <param name="parent">The <see cref="NumericAssertions{T}"/> object that is being extended.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -1629,6 +1631,7 @@ public static class NumericAssertionsExtensions
     /// <summary>
     /// Asserts that the number is seen as not a number (NaN).
     /// </summary>
+    /// <param name="parent">The <see cref="NumericAssertions{T}"/> object that is being extended.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -1654,6 +1657,7 @@ public static class NumericAssertionsExtensions
     /// <summary>
     /// Asserts that the number is seen as not a number (NaN).
     /// </summary>
+    /// <param name="parent">The <see cref="NumericAssertions{T}"/> object that is being extended.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -1683,6 +1687,7 @@ public static class NumericAssertionsExtensions
     /// <summary>
     /// Asserts that the number is not seen as the special value not a number (NaN).
     /// </summary>
+    /// <param name="parent">The <see cref="NumericAssertions{T}"/> object that is being extended.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -1708,6 +1713,7 @@ public static class NumericAssertionsExtensions
     /// <summary>
     /// Asserts that the number is not seen as the special value not a number (NaN).
     /// </summary>
+    /// <param name="parent">The <see cref="NumericAssertions{T}"/> object that is being extended.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -1733,6 +1739,7 @@ public static class NumericAssertionsExtensions
     /// <summary>
     /// Asserts that the number is not seen as the special value not a number (NaN).
     /// </summary>
+    /// <param name="parent">The <see cref="NumericAssertions{T}"/> object that is being extended.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -1759,6 +1766,7 @@ public static class NumericAssertionsExtensions
     /// <summary>
     /// Asserts that the number is not seen as the special value not a number (NaN).
     /// </summary>
+    /// <param name="parent">The <see cref="NumericAssertions{T}"/> object that is being extended.</param>
     /// <param name="because">
     /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
     /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.

--- a/Src/AwesomeAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/AwesomeAssertions/ObjectAssertionsExtensions.cs
@@ -9,6 +9,9 @@ using AwesomeAssertions.Primitives;
 
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Contains a number of extension methods for <see cref="ObjectAssertions"/>.
+/// </summary>
 public static class ObjectAssertionsExtensions
 {
     /// <summary>

--- a/Src/AwesomeAssertions/OccurrenceConstraint.cs
+++ b/Src/AwesomeAssertions/OccurrenceConstraint.cs
@@ -3,8 +3,17 @@ using AwesomeAssertions.Common;
 
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Represents the base class for constraints that specify how many times an event or item is expected to occur,
+/// such as those created by <see cref="Exactly"/>, <see cref="AtLeast"/>, <see cref="AtMost"/>,
+/// <see cref="MoreThan"/> and <see cref="LessThan"/>.
+/// </summary>
 public abstract class OccurrenceConstraint
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OccurrenceConstraint"/> class.
+    /// </summary>
+    /// <param name="expectedCount">The number of times the occurrence is expected to happen.</param>
     protected OccurrenceConstraint(int expectedCount)
     {
         if (expectedCount < 0)

--- a/Src/AwesomeAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/BooleanAssertions.cs
@@ -12,6 +12,13 @@ namespace AwesomeAssertions.Primitives;
 public class BooleanAssertions
     : BooleanAssertions<BooleanAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BooleanAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public BooleanAssertions(bool? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -27,6 +34,13 @@ public class BooleanAssertions
 public class BooleanAssertions<TAssertions>
     where TAssertions : BooleanAssertions<TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BooleanAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public BooleanAssertions(bool? value, AssertionChain assertionChain)
     {
         CurrentAssertionChain = assertionChain;

--- a/Src/AwesomeAssertions/Primitives/DateOnlyAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/DateOnlyAssertions.cs
@@ -15,6 +15,11 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class DateOnlyAssertions : DateOnlyAssertions<DateOnlyAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateOnlyAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public DateOnlyAssertions(DateOnly? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -30,6 +35,11 @@ public class DateOnlyAssertions : DateOnlyAssertions<DateOnlyAssertions>
 public class DateOnlyAssertions<TAssertions>
     where TAssertions : DateOnlyAssertions<TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateOnlyAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public DateOnlyAssertions(DateOnly? value, AssertionChain assertionChain)
     {
         CurrentAssertionChain = assertionChain;

--- a/Src/AwesomeAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/DateTimeAssertions.cs
@@ -18,6 +18,13 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class DateTimeAssertions : DateTimeAssertions<DateTimeAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateTimeAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public DateTimeAssertions(DateTime? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -37,6 +44,13 @@ public class DateTimeAssertions : DateTimeAssertions<DateTimeAssertions>
 public class DateTimeAssertions<TAssertions>
     where TAssertions : DateTimeAssertions<TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateTimeAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public DateTimeAssertions(DateTime? value, AssertionChain assertionChain)
     {
         CurrentAssertionChain = assertionChain;

--- a/Src/AwesomeAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -19,6 +19,13 @@ namespace AwesomeAssertions.Primitives;
 public class DateTimeOffsetAssertions
     : DateTimeOffsetAssertions<DateTimeOffsetAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateTimeOffsetAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public DateTimeOffsetAssertions(DateTimeOffset? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -38,6 +45,13 @@ public class DateTimeOffsetAssertions
 public class DateTimeOffsetAssertions<TAssertions>
     where TAssertions : DateTimeOffsetAssertions<TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateTimeOffsetAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public DateTimeOffsetAssertions(DateTimeOffset? value, AssertionChain assertionChain)
     {
         CurrentAssertionChain = assertionChain;

--- a/Src/AwesomeAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -39,6 +39,16 @@ public class DateTimeOffsetRangeAssertions<TAssertions>
 
     #endregion
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateTimeOffsetRangeAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="parentAssertions">The parent assertions object that this range assertion continues from.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
+    /// <param name="subject">The <see cref="DateTimeOffset"/> whose distance to another value is being asserted.</param>
+    /// <param name="condition">The condition that determines how the <paramref name="timeSpan"/> is compared.</param>
+    /// <param name="timeSpan">The time span against which the distance is compared.</param>
     protected internal DateTimeOffsetRangeAssertions(TAssertions parentAssertions, AssertionChain assertionChain,
         DateTimeOffset? subject,
         TimeSpanCondition condition,

--- a/Src/AwesomeAssertions/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/DateTimeRangeAssertions.cs
@@ -39,6 +39,16 @@ public class DateTimeRangeAssertions<TAssertions>
 
     #endregion
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateTimeRangeAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="parentAssertions">The parent assertions object that this range assertion continues from.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
+    /// <param name="subject">The <see cref="DateTime"/> whose distance to another value is being asserted.</param>
+    /// <param name="condition">The condition that determines how the <paramref name="timeSpan"/> is compared.</param>
+    /// <param name="timeSpan">The time span against which the distance is compared.</param>
     protected internal DateTimeRangeAssertions(TAssertions parentAssertions, AssertionChain assertionChain,
         DateTime? subject,
         TimeSpanCondition condition,

--- a/Src/AwesomeAssertions/Primitives/EnumAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/EnumAssertions.cs
@@ -15,6 +15,13 @@ namespace AwesomeAssertions.Primitives;
 public class EnumAssertions<TEnum> : EnumAssertions<TEnum, EnumAssertions<TEnum>>
     where TEnum : struct, Enum
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnumAssertions{TEnum}"/> class.
+    /// </summary>
+    /// <param name="subject">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public EnumAssertions(TEnum subject, AssertionChain assertionChain)
         : base(subject, assertionChain)
     {
@@ -30,6 +37,13 @@ public class EnumAssertions<TEnum, TAssertions>
     where TEnum : struct, Enum
     where TAssertions : EnumAssertions<TEnum, TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnumAssertions{TEnum, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="subject">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public EnumAssertions(TEnum subject, AssertionChain assertionChain)
         : this((TEnum?)subject, assertionChain)
     {
@@ -41,6 +55,9 @@ public class EnumAssertions<TEnum, TAssertions>
         Subject = value;
     }
 
+    /// <summary>
+    /// Gets the object whose value is being asserted.
+    /// </summary>
     public TEnum? Subject { get; }
 
     /// <summary>

--- a/Src/AwesomeAssertions/Primitives/GuidAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/GuidAssertions.cs
@@ -11,6 +11,13 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class GuidAssertions : GuidAssertions<GuidAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GuidAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public GuidAssertions(Guid? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -26,6 +33,13 @@ public class GuidAssertions : GuidAssertions<GuidAssertions>
 public class GuidAssertions<TAssertions>
     where TAssertions : GuidAssertions<TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GuidAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public GuidAssertions(Guid? value, AssertionChain assertionChain)
     {
         CurrentAssertionChain = assertionChain;

--- a/Src/AwesomeAssertions/Primitives/NullableBooleanAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/NullableBooleanAssertions.cs
@@ -10,6 +10,11 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class NullableBooleanAssertions : NullableBooleanAssertions<NullableBooleanAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableBooleanAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableBooleanAssertions(bool? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -25,6 +30,11 @@ public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAsserti
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableBooleanAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableBooleanAssertions(bool? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {

--- a/Src/AwesomeAssertions/Primitives/NullableDateOnlyAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/NullableDateOnlyAssertions.cs
@@ -13,6 +13,11 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class NullableDateOnlyAssertions : NullableDateOnlyAssertions<NullableDateOnlyAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableDateOnlyAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableDateOnlyAssertions(DateOnly? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -28,6 +33,11 @@ public class NullableDateOnlyAssertions<TAssertions> : DateOnlyAssertions<TAsser
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableDateOnlyAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableDateOnlyAssertions(DateOnly? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {

--- a/Src/AwesomeAssertions/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/NullableDateTimeAssertions.cs
@@ -15,6 +15,11 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class NullableDateTimeAssertions : NullableDateTimeAssertions<NullableDateTimeAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableDateTimeAssertions"/> class.
+    /// </summary>
+    /// <param name="expected">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableDateTimeAssertions(DateTime? expected, AssertionChain assertionChain)
         : base(expected, assertionChain)
     {
@@ -33,6 +38,11 @@ public class NullableDateTimeAssertions<TAssertions> : DateTimeAssertions<TAsser
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableDateTimeAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="expected">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableDateTimeAssertions(DateTime? expected, AssertionChain assertionChain)
         : base(expected, assertionChain)
     {

--- a/Src/AwesomeAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -15,6 +15,11 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class NullableDateTimeOffsetAssertions : NullableDateTimeOffsetAssertions<NullableDateTimeOffsetAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableDateTimeOffsetAssertions"/> class.
+    /// </summary>
+    /// <param name="expected">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableDateTimeOffsetAssertions(DateTimeOffset? expected, AssertionChain assertionChain)
         : base(expected, assertionChain)
     {
@@ -34,6 +39,11 @@ public class NullableDateTimeOffsetAssertions<TAssertions> : DateTimeOffsetAsser
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableDateTimeOffsetAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="expected">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableDateTimeOffsetAssertions(DateTimeOffset? expected, AssertionChain assertionChain)
         : base(expected, assertionChain)
     {

--- a/Src/AwesomeAssertions/Primitives/NullableEnumAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/NullableEnumAssertions.cs
@@ -10,6 +10,11 @@ namespace AwesomeAssertions.Primitives;
 public class NullableEnumAssertions<TEnum> : NullableEnumAssertions<TEnum, NullableEnumAssertions<TEnum>>
     where TEnum : struct, Enum
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableEnumAssertions{TEnum}"/> class.
+    /// </summary>
+    /// <param name="subject">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableEnumAssertions(TEnum? subject, AssertionChain assertionChain)
         : base(subject, assertionChain)
     {
@@ -25,6 +30,11 @@ public class NullableEnumAssertions<TEnum, TAssertions> : EnumAssertions<TEnum, 
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableEnumAssertions{TEnum, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="subject">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableEnumAssertions(TEnum? subject, AssertionChain assertionChain)
         : base(subject, assertionChain)
     {

--- a/Src/AwesomeAssertions/Primitives/NullableGuidAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/NullableGuidAssertions.cs
@@ -11,6 +11,11 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class NullableGuidAssertions : NullableGuidAssertions<NullableGuidAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableGuidAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableGuidAssertions(Guid? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -26,6 +31,11 @@ public class NullableGuidAssertions<TAssertions> : GuidAssertions<TAssertions>
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableGuidAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableGuidAssertions(Guid? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {

--- a/Src/AwesomeAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
@@ -15,6 +15,11 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class NullableSimpleTimeSpanAssertions : NullableSimpleTimeSpanAssertions<NullableSimpleTimeSpanAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableSimpleTimeSpanAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableSimpleTimeSpanAssertions(TimeSpan? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -34,6 +39,11 @@ public class NullableSimpleTimeSpanAssertions<TAssertions> : SimpleTimeSpanAsser
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableSimpleTimeSpanAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableSimpleTimeSpanAssertions(TimeSpan? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {

--- a/Src/AwesomeAssertions/Primitives/NullableTimeOnlyAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/NullableTimeOnlyAssertions.cs
@@ -13,6 +13,11 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class NullableTimeOnlyAssertions : NullableTimeOnlyAssertions<NullableTimeOnlyAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableTimeOnlyAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableTimeOnlyAssertions(TimeOnly? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -28,6 +33,11 @@ public class NullableTimeOnlyAssertions<TAssertions> : TimeOnlyAssertions<TAsser
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableTimeOnlyAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public NullableTimeOnlyAssertions(TimeOnly? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {

--- a/Src/AwesomeAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/ObjectAssertions.cs
@@ -15,6 +15,13 @@ public class ObjectAssertions : ObjectAssertions<object, ObjectAssertions>
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public ObjectAssertions(object value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -127,6 +134,13 @@ public class ObjectAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectAssertions{TSubject, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public ObjectAssertions(TSubject value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {

--- a/Src/AwesomeAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -17,6 +17,13 @@ namespace AwesomeAssertions.Primitives;
 public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
     where TAssertions : ReferenceTypeAssertions<TSubject, TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReferenceTypeAssertions{TSubject, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="subject">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     protected ReferenceTypeAssertions(TSubject subject, AssertionChain assertionChain)
     {
         CurrentAssertionChain = assertionChain;

--- a/Src/AwesomeAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -12,6 +12,13 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class SimpleTimeSpanAssertions : SimpleTimeSpanAssertions<SimpleTimeSpanAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SimpleTimeSpanAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public SimpleTimeSpanAssertions(TimeSpan? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -27,6 +34,13 @@ public class SimpleTimeSpanAssertions : SimpleTimeSpanAssertions<SimpleTimeSpanA
 public class SimpleTimeSpanAssertions<TAssertions>
     where TAssertions : SimpleTimeSpanAssertions<TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SimpleTimeSpanAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public SimpleTimeSpanAssertions(TimeSpan? value, AssertionChain assertionChain)
     {
         CurrentAssertionChain = assertionChain;

--- a/Src/AwesomeAssertions/Primitives/TimeOnlyAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/TimeOnlyAssertions.cs
@@ -16,6 +16,11 @@ namespace AwesomeAssertions.Primitives;
 [DebuggerNonUserCode]
 public class TimeOnlyAssertions : TimeOnlyAssertions<TimeOnlyAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeOnlyAssertions"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public TimeOnlyAssertions(TimeOnly? value, AssertionChain assertionChain)
         : base(value, assertionChain)
     {
@@ -31,6 +36,11 @@ public class TimeOnlyAssertions : TimeOnlyAssertions<TimeOnlyAssertions>
 public class TimeOnlyAssertions<TAssertions>
     where TAssertions : TimeOnlyAssertions<TAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeOnlyAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="value">The value to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public TimeOnlyAssertions(TimeOnly? value, AssertionChain assertionChain)
     {
         CurrentAssertionChain = assertionChain;

--- a/Src/AwesomeAssertions/Primitives/TimeSpanCondition.cs
+++ b/Src/AwesomeAssertions/Primitives/TimeSpanCondition.cs
@@ -1,10 +1,32 @@
 namespace AwesomeAssertions.Primitives;
 
+/// <summary>
+/// Defines how the actual time difference between two values is expected to relate to a specified time span.
+/// </summary>
 public enum TimeSpanCondition
 {
+    /// <summary>
+    /// The actual time difference is expected to be greater than the specified time span.
+    /// </summary>
     MoreThan,
+
+    /// <summary>
+    /// The actual time difference is expected to be greater than or equal to the specified time span.
+    /// </summary>
     AtLeast,
+
+    /// <summary>
+    /// The actual time difference is expected to be exactly equal to the specified time span.
+    /// </summary>
     Exactly,
+
+    /// <summary>
+    /// The actual time difference is expected to be less than or equal to the specified time span.
+    /// </summary>
     Within,
+
+    /// <summary>
+    /// The actual time difference is expected to be less than the specified time span.
+    /// </summary>
     LessThan
 }

--- a/Src/AwesomeAssertions/Specialized/ActionAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/ActionAssertions.cs
@@ -14,12 +14,29 @@ public class ActionAssertions : DelegateAssertions<Action, ActionAssertions>
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActionAssertions"/> class.
+    /// </summary>
+    /// <param name="subject">The <see cref="Action"/> to assert on.</param>
+    /// <param name="extractor">The strategy used to extract exceptions of a specific type from a thrown exception.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
     public ActionAssertions(Action subject, IExtractExceptions extractor, AssertionChain assertionChain)
         : base(subject, extractor, assertionChain)
     {
         this.assertionChain = assertionChain;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActionAssertions"/> class.
+    /// </summary>
+    /// <param name="subject">The <see cref="Action"/> to assert on.</param>
+    /// <param name="extractor">The strategy used to extract exceptions of a specific type from a thrown exception.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
+    /// <param name="clock">The clock used to measure elapsed time.</param>
     public ActionAssertions(Action subject, IExtractExceptions extractor, AssertionChain assertionChain, IClock clock)
         : base(subject, extractor, assertionChain, clock)
     {
@@ -119,6 +136,9 @@ public class ActionAssertions : DelegateAssertions<Action, ActionAssertions>
         return new AndConstraint<ActionAssertions>(this);
     }
 
+    /// <summary>
+    /// Invokes the current <see cref="Action"/> subject.
+    /// </summary>
     protected override void InvokeSubject()
     {
         Subject();

--- a/Src/AwesomeAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -21,6 +21,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncFunctionAssertions{TTask, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="subject">The <see cref="Func{TTask}"/> to assert on.</param>
+    /// <param name="extractor">The strategy used to extract exceptions of a specific type from a thrown exception.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
+    /// <param name="clock">The clock used to measure elapsed time.</param>
     protected AsyncFunctionAssertions(Func<TTask> subject, IExtractExceptions extractor, AssertionChain assertionChain,
         IClock clock)
         : base(subject, extractor, assertionChain, clock)
@@ -28,6 +37,7 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
         this.assertionChain = assertionChain;
     }
 
+    /// <inheritdoc />
     protected override string Identifier => "async function";
 
     /// <summary>

--- a/Src/AwesomeAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/DelegateAssertions.cs
@@ -18,6 +18,14 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegateAssertions{TDelegate, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="delegate">The delegate to assert on.</param>
+    /// <param name="extractor">The strategy used to extract exceptions of a specific type from a thrown exception.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
     protected DelegateAssertions(TDelegate @delegate, IExtractExceptions extractor, AssertionChain assertionChain)
         : base(@delegate, extractor, assertionChain, new Clock())
     {
@@ -135,6 +143,9 @@ public abstract class DelegateAssertions<TDelegate, TAssertions> : DelegateAsser
         return new ExceptionAssertions<TException>([], assertionChain);
     }
 
+    /// <summary>
+    /// Invokes the current delegate subject so that any exception it throws can be captured.
+    /// </summary>
     protected abstract void InvokeSubject();
 
     private protected Exception InvokeSubjectWithInterception()

--- a/Src/AwesomeAssertions/Specialized/DelegateAssertionsBase.cs
+++ b/Src/AwesomeAssertions/Specialized/DelegateAssertionsBase.cs
@@ -33,6 +33,21 @@ public abstract class DelegateAssertionsBase<TDelegate, TAssertions>
 
     private protected IClock Clock { get; }
 
+    /// <summary>
+    /// Asserts that the provided <paramref name="exception"/> contains an exception of type <typeparamref name="TException"/>.
+    /// </summary>
+    /// <typeparam name="TException">The type of exception that is expected.</typeparam>
+    /// <param name="exception">The exception that was thrown by the subject, or <see langword="null"/> if none was thrown.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <returns>
+    /// Returns an object that allows asserting additional members of the thrown exception.
+    /// </returns>
     protected ExceptionAssertions<TException> ThrowInternal<TException>(
         Exception exception,
         [StringSyntax("CompositeFormat")] string because, object[] becauseArgs)
@@ -54,6 +69,18 @@ public abstract class DelegateAssertionsBase<TDelegate, TAssertions>
         return new ExceptionAssertions<TException>(expectedExceptions, assertionChain);
     }
 
+    /// <summary>
+    /// Asserts that no exception was thrown by the subject.
+    /// </summary>
+    /// <param name="exception">The exception that was thrown by the subject, or <see langword="null"/> if none was thrown.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <returns>An <see cref="AndConstraint{T}"/> which can be used to chain assertions.</returns>
     [return: NotNull]
     protected AndConstraint<TAssertions> NotThrowInternal(Exception exception, [StringSyntax("CompositeFormat")] string because,
         object[] becauseArgs)
@@ -66,6 +93,19 @@ public abstract class DelegateAssertionsBase<TDelegate, TAssertions>
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    /// <summary>
+    /// Asserts that the provided <paramref name="exception"/> does not contain an exception of type <typeparamref name="TException"/>.
+    /// </summary>
+    /// <typeparam name="TException">The type of exception that is not expected.</typeparam>
+    /// <param name="exception">The exception that was thrown by the subject, or <see langword="null"/> if none was thrown.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <returns>An <see cref="AndConstraint{T}"/> which can be used to chain assertions.</returns>
     [return: NotNull]
     protected AndConstraint<TAssertions> NotThrowInternal<TException>(Exception exception,
         [StringSyntax("CompositeFormat")] string because, object[] becauseArgs)

--- a/Src/AwesomeAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/ExceptionAssertions.cs
@@ -21,6 +21,13 @@ public class ExceptionAssertions<TException> : ReferenceTypeAssertions<IEnumerab
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExceptionAssertions{TException}"/> class.
+    /// </summary>
+    /// <param name="exceptions">The thrown exceptions to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
     public ExceptionAssertions(IEnumerable<TException> exceptions, AssertionChain assertionChain)
         : base(exceptions, assertionChain)
     {

--- a/Src/AwesomeAssertions/Specialized/ExecutionTime.cs
+++ b/Src/AwesomeAssertions/Specialized/ExecutionTime.cs
@@ -4,6 +4,9 @@ using AwesomeAssertions.Common;
 
 namespace AwesomeAssertions.Specialized;
 
+/// <summary>
+/// Captures the time it takes to execute an action or asynchronous function.
+/// </summary>
 public class ExecutionTime
 {
     private ITimer timer;
@@ -12,6 +15,7 @@ public class ExecutionTime
     /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
     /// </summary>
     /// <param name="action">The action of which the execution time must be asserted.</param>
+    /// <param name="createTimer">A function that creates the <see cref="ITimer"/> used to measure the elapsed time.</param>
     /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     public ExecutionTime(Action action, StartTimer createTimer)
         : this(action, "the action", createTimer)
@@ -22,6 +26,7 @@ public class ExecutionTime
     /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
     /// </summary>
     /// <param name="action">The action of which the execution time must be asserted.</param>
+    /// <param name="createTimer">A function that creates the <see cref="ITimer"/> used to measure the elapsed time.</param>
     /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     public ExecutionTime(Func<Task> action, StartTimer createTimer)
         : this(action, "the action", createTimer)
@@ -33,6 +38,7 @@ public class ExecutionTime
     /// </summary>
     /// <param name="action">The action of which the execution time must be asserted.</param>
     /// <param name="actionDescription">The description of the action to be asserted.</param>
+    /// <param name="createTimer">A function that creates the <see cref="ITimer"/> used to measure the elapsed time.</param>
     /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
     protected ExecutionTime(Action action, string actionDescription, StartTimer createTimer)
     {
@@ -69,6 +75,7 @@ public class ExecutionTime
     /// </summary>
     /// <param name="action">The action of which the execution time must be asserted.</param>
     /// <param name="actionDescription">The description of the action to be asserted.</param>
+    /// <param name="createTimer">A function that creates the <see cref="ITimer"/> used to measure the elapsed time.</param>
     /// <remarks>
     /// This constructor is almost exact copy of the one accepting <see cref="Action"/>.
     /// The original constructor shall stay in place in order to keep backward-compatibility

--- a/Src/AwesomeAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -18,6 +18,9 @@ public class ExecutionTimeAssertions
     /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
     /// </summary>
     /// <param name="executionTime">The execution on which time must be asserted.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
     public ExecutionTimeAssertions(ExecutionTime executionTime, AssertionChain assertionChain)
     {
         execution = executionTime ?? throw new ArgumentNullException(nameof(executionTime));

--- a/Src/AwesomeAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/FunctionAssertions.cs
@@ -14,23 +14,44 @@ public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAsserti
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FunctionAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="subject">The <see cref="Func{T}"/> to assert on.</param>
+    /// <param name="extractor">The strategy used to extract exceptions of a specific type from a thrown exception.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
     public FunctionAssertions(Func<T> subject, IExtractExceptions extractor, AssertionChain assertionChain)
         : base(subject, extractor, assertionChain)
     {
         this.assertionChain = assertionChain;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FunctionAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="subject">The <see cref="Func{T}"/> to assert on.</param>
+    /// <param name="extractor">The strategy used to extract exceptions of a specific type from a thrown exception.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
+    /// <param name="clock">The clock used to measure elapsed time.</param>
     public FunctionAssertions(Func<T> subject, IExtractExceptions extractor, AssertionChain assertionChain, IClock clock)
         : base(subject, extractor, assertionChain, clock)
     {
         this.assertionChain = assertionChain;
     }
 
+    /// <summary>
+    /// Invokes the current <see cref="Func{T}"/> subject.
+    /// </summary>
     protected override void InvokeSubject()
     {
         Subject();
     }
 
+    /// <inheritdoc />
     protected override string Identifier => "function";
 
     /// <summary>

--- a/Src/AwesomeAssertions/Specialized/IExtractExceptions.cs
+++ b/Src/AwesomeAssertions/Specialized/IExtractExceptions.cs
@@ -3,8 +3,17 @@ using System.Collections.Generic;
 
 namespace AwesomeAssertions.Specialized;
 
+/// <summary>
+/// Defines a strategy for extracting exceptions of a specific type from a thrown exception.
+/// </summary>
 public interface IExtractExceptions
 {
+    /// <summary>
+    /// Extracts the exceptions of type <typeparamref name="T"/> from the specified <paramref name="actualException"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of exception to extract.</typeparam>
+    /// <param name="actualException">The exception that was actually thrown.</param>
+    /// <returns>The exceptions of type <typeparamref name="T"/> that were found.</returns>
     IEnumerable<T> OfType<T>(Exception actualException)
         where T : Exception;
 }

--- a/Src/AwesomeAssertions/Specialized/MemberExecutionTime.cs
+++ b/Src/AwesomeAssertions/Specialized/MemberExecutionTime.cs
@@ -4,6 +4,10 @@ using AwesomeAssertions.Common;
 
 namespace AwesomeAssertions.Specialized;
 
+/// <summary>
+/// Captures the time it takes to execute a method or property of a subject of type <typeparamref name="T"/>.
+/// </summary>
+/// <typeparam name="T">The type of the subject that exposes the member being measured.</typeparam>
 public class MemberExecutionTime<T> : ExecutionTime
 {
     /// <summary>
@@ -11,6 +15,7 @@ public class MemberExecutionTime<T> : ExecutionTime
     /// </summary>
     /// <param name="subject">The object that exposes the method or property.</param>
     /// <param name="action">A reference to the method or property to measure the execution time of.</param>
+    /// <param name="createTimer">A function that creates the <see cref="ITimer"/> used to measure the elapsed time.</param>
     /// <exception cref="NullReferenceException"><paramref name="subject"/> is <see langword="null"/>.</exception>
     /// <exception cref="NullReferenceException"><paramref name="action"/> is <see langword="null"/>.</exception>
     public MemberExecutionTime(T subject, Expression<Action<T>> action, StartTimer createTimer)

--- a/Src/AwesomeAssertions/Specialized/TaskCompletionSourceAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/TaskCompletionSourceAssertions.cs
@@ -10,16 +10,34 @@ namespace AwesomeAssertions.Specialized;
 #pragma warning disable CA1065 // Ignore throwing NotSupportedException from Equals
 
 #if NET6_0_OR_GREATER
+/// <summary>
+/// Contains a number of methods to assert that a <see cref="TaskCompletionSource"/> yields the expected result.
+/// </summary>
 public class TaskCompletionSourceAssertions : TaskCompletionSourceAssertionsBase
 {
     private readonly TaskCompletionSource subject;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskCompletionSourceAssertions"/> class.
+    /// </summary>
+    /// <param name="tcs">The <see cref="TaskCompletionSource"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
     public TaskCompletionSourceAssertions(TaskCompletionSource tcs, AssertionChain assertionChain)
         : this(tcs, assertionChain, new Clock())
     {
         CurrentAssertionChain = assertionChain;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskCompletionSourceAssertions"/> class.
+    /// </summary>
+    /// <param name="tcs">The <see cref="TaskCompletionSource"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
+    /// <param name="clock">The clock used to measure elapsed time.</param>
     public TaskCompletionSourceAssertions(TaskCompletionSource tcs, AssertionChain assertionChain, IClock clock)
         : base(clock)
     {
@@ -96,16 +114,34 @@ public class TaskCompletionSourceAssertions : TaskCompletionSourceAssertionsBase
 }
 #endif
 
+/// <summary>
+/// Contains a number of methods to assert that a <see cref="TaskCompletionSource{T}"/> yields the expected result.
+/// </summary>
 public class TaskCompletionSourceAssertions<T> : TaskCompletionSourceAssertionsBase
 {
     private readonly TaskCompletionSource<T> subject;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskCompletionSourceAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="tcs">The <see cref="TaskCompletionSource{T}"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
     public TaskCompletionSourceAssertions(TaskCompletionSource<T> tcs, AssertionChain assertionChain)
         : this(tcs, assertionChain, new Clock())
     {
         CurrentAssertionChain = assertionChain;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskCompletionSourceAssertions{T}"/> class.
+    /// </summary>
+    /// <param name="tcs">The <see cref="TaskCompletionSource{T}"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion and is used to report failures.
+    /// </param>
+    /// <param name="clock">The clock used to measure elapsed time.</param>
     public TaskCompletionSourceAssertions(TaskCompletionSource<T> tcs, AssertionChain assertionChain, IClock clock)
         : base(clock)
     {

--- a/Src/AwesomeAssertions/Specialized/TaskCompletionSourceAssertionsBase.cs
+++ b/Src/AwesomeAssertions/Specialized/TaskCompletionSourceAssertionsBase.cs
@@ -12,6 +12,10 @@ namespace AwesomeAssertions.Specialized;
 /// </summary>
 public class TaskCompletionSourceAssertionsBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskCompletionSourceAssertionsBase"/> class.
+    /// </summary>
+    /// <param name="clock">The clock used to measure elapsed time.</param>
     protected TaskCompletionSourceAssertionsBase(IClock clock)
     {
         Clock = clock ?? throw new ArgumentNullException(nameof(clock));

--- a/Src/AwesomeAssertions/Streams/BufferedStreamAssertions.cs
+++ b/Src/AwesomeAssertions/Streams/BufferedStreamAssertions.cs
@@ -12,12 +12,22 @@ namespace AwesomeAssertions.Streams;
 [DebuggerNonUserCode]
 public class BufferedStreamAssertions : BufferedStreamAssertions<BufferedStreamAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BufferedStreamAssertions"/> class.
+    /// </summary>
+    /// <param name="stream">The <see cref="BufferedStream"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public BufferedStreamAssertions(BufferedStream stream, AssertionChain assertionChain)
         : base(stream, assertionChain)
     {
     }
 }
 
+/// <summary>
+/// Contains a number of methods to assert that a <see cref="BufferedStream"/> is in the expected state.
+/// </summary>
 public class BufferedStreamAssertions<TAssertions> : StreamAssertions<BufferedStream, TAssertions>
     where TAssertions : BufferedStreamAssertions<TAssertions>
 {
@@ -25,6 +35,13 @@ public class BufferedStreamAssertions<TAssertions> : StreamAssertions<BufferedSt
 
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BufferedStreamAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="stream">The <see cref="BufferedStream"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public BufferedStreamAssertions(BufferedStream stream, AssertionChain assertionChain)
         : base(stream, assertionChain)
     {
@@ -97,11 +114,19 @@ public class BufferedStreamAssertions<TAssertions> : StreamAssertions<BufferedSt
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 #else
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BufferedStreamAssertions{TAssertions}"/> class.
+    /// </summary>
+    /// <param name="stream">The <see cref="BufferedStream"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public BufferedStreamAssertions(BufferedStream stream, AssertionChain assertionChain)
         : base(stream, assertionChain)
     {
     }
 #endif
 
+    /// <inheritdoc />
     protected override string Identifier => "buffered stream";
 }

--- a/Src/AwesomeAssertions/Streams/StreamAssertions.cs
+++ b/Src/AwesomeAssertions/Streams/StreamAssertions.cs
@@ -13,6 +13,13 @@ namespace AwesomeAssertions.Streams;
 [DebuggerNonUserCode]
 public class StreamAssertions : StreamAssertions<Stream, StreamAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamAssertions"/> class.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public StreamAssertions(Stream stream, AssertionChain assertionChain)
         : base(stream, assertionChain)
     {
@@ -28,12 +35,20 @@ public class StreamAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<T
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamAssertions{TSubject, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public StreamAssertions(TSubject stream, AssertionChain assertionChain)
         : base(stream, assertionChain)
     {
         this.assertionChain = assertionChain;
     }
 
+    /// <inheritdoc />
     protected override string Identifier => "stream";
 
     /// <summary>

--- a/Src/AwesomeAssertions/Types/ConstructorInfoAssertions.cs
+++ b/Src/AwesomeAssertions/Types/ConstructorInfoAssertions.cs
@@ -22,6 +22,7 @@ public class ConstructorInfoAssertions : MethodBaseAssertions<ConstructorInfo, C
 
     private protected override string SubjectDescription => GetDescriptionFor(Subject);
 
+    /// <inheritdoc />
     protected override string Identifier => "constructor";
 
     private static string GetDescriptionFor(ConstructorInfo constructorInfo)

--- a/Src/AwesomeAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/AwesomeAssertions/Types/MemberInfoAssertions.cs
@@ -21,6 +21,11 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemberInfoAssertions{TSubject, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="subject">The <see cref="MemberInfo"/> to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     protected MemberInfoAssertions(TSubject subject, AssertionChain assertionChain)
         : base(subject, assertionChain)
     {
@@ -155,6 +160,7 @@ public abstract class MemberInfoAssertions<TSubject, TAssertions> : ReferenceTyp
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
+    /// <inheritdoc />
     protected override string Identifier => "member";
 
     private protected virtual string SubjectDescription => $"{Subject.DeclaringType}.{Subject.Name}";

--- a/Src/AwesomeAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/AwesomeAssertions/Types/MethodBaseAssertions.cs
@@ -20,6 +20,11 @@ public abstract class MethodBaseAssertions<TSubject, TAssertions> : MemberInfoAs
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MethodBaseAssertions{TSubject, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="subject">The <see cref="MethodBase"/> to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     protected MethodBaseAssertions(TSubject subject, AssertionChain assertionChain)
         : base(subject, assertionChain)
     {

--- a/Src/AwesomeAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/AwesomeAssertions/Types/MethodInfoAssertions.cs
@@ -16,6 +16,11 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MethodInfoAssertions"/> class.
+    /// </summary>
+    /// <param name="methodInfo">The <see cref="MethodInfo"/> to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public MethodInfoAssertions(MethodInfo methodInfo, AssertionChain assertionChain)
         : base(methodInfo, assertionChain)
     {
@@ -315,5 +320,6 @@ public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoA
 
     private protected override string SubjectDescription => GetDescriptionFor(Subject);
 
+    /// <inheritdoc />
     protected override string Identifier => "method";
 }

--- a/Src/AwesomeAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/AwesomeAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -23,6 +23,7 @@ public class MethodInfoSelectorAssertions
     /// <summary>
     /// Initializes a new instance of the <see cref="MethodInfoSelectorAssertions"/> class.
     /// </summary>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     /// <param name="methods">The methods to assert.</param>
     /// <exception cref="ArgumentNullException"><paramref name="methods"/> is <see langword="null"/>.</exception>
     public MethodInfoSelectorAssertions(AssertionChain assertionChain, params MethodInfo[] methods)

--- a/Src/AwesomeAssertions/Types/ParameterInfoAssertions.cs
+++ b/Src/AwesomeAssertions/Types/ParameterInfoAssertions.cs
@@ -19,6 +19,7 @@ public sealed class ParameterInfoAssertions : ReferenceTypeAssertions<ParameterI
 {
     private readonly AssertionChain assertionChain;
 
+    /// <inheritdoc />
     protected override string Identifier => "parameter";
 
     private string SubjectDescription =>
@@ -26,6 +27,11 @@ public sealed class ParameterInfoAssertions : ReferenceTypeAssertions<ParameterI
             ? $"return parameter {Subject.ParameterType.ToFormattedString()}"
             : $"parameter {Subject.ParameterType.ToFormattedString()} {Subject.Name}";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParameterInfoAssertions"/> class.
+    /// </summary>
+    /// <param name="subject">The <see cref="ParameterInfo"/> to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public ParameterInfoAssertions(ParameterInfo subject, AssertionChain assertionChain)
         : base(subject, assertionChain)
     {

--- a/Src/AwesomeAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/AwesomeAssertions/Types/PropertyInfoAssertions.cs
@@ -15,6 +15,11 @@ public class PropertyInfoAssertions : MemberInfoAssertions<PropertyInfo, Propert
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyInfoAssertions"/> class.
+    /// </summary>
+    /// <param name="propertyInfo">The <see cref="PropertyInfo"/> to assert on.</param>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     public PropertyInfoAssertions(PropertyInfo propertyInfo, AssertionChain assertionChain)
         : base(propertyInfo, assertionChain)
     {

--- a/Src/AwesomeAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/AwesomeAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -21,6 +21,7 @@ public class PropertyInfoSelectorAssertions
     /// <summary>
     /// Initializes a new instance of the <see cref="PropertyInfoSelectorAssertions"/> class, for a number of <see cref="PropertyInfo"/> objects.
     /// </summary>
+    /// <param name="assertionChain">The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.</param>
     /// <param name="properties">The properties to assert.</param>
     /// <exception cref="ArgumentNullException"><paramref name="properties"/> is <see langword="null"/>.</exception>
     public PropertyInfoSelectorAssertions(AssertionChain assertionChain, params PropertyInfo[] properties)

--- a/Src/AwesomeAssertions/Types/TypeSelector.cs
+++ b/Src/AwesomeAssertions/Types/TypeSelector.cs
@@ -14,6 +14,10 @@ public class TypeSelector : IEnumerable<Type>
 {
     private List<Type> types;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TypeSelector"/> class.
+    /// </summary>
+    /// <param name="type">The <see cref="Type"/> to assert on.</param>
     public TypeSelector(Type type)
         : this([type])
     {

--- a/Src/AwesomeAssertions/Xml/XmlElementAssertions.cs
+++ b/Src/AwesomeAssertions/Xml/XmlElementAssertions.cs
@@ -18,7 +18,10 @@ public class XmlElementAssertions : XmlNodeAssertions<XmlElement, XmlElementAsse
     /// <summary>
     /// Initializes a new instance of the <see cref="XmlElementAssertions"/> class.
     /// </summary>
-    /// <param name="xmlElement"></param>
+    /// <param name="xmlElement">The <see cref="XmlElement"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public XmlElementAssertions(XmlElement xmlElement, AssertionChain assertionChain)
         : base(xmlElement, assertionChain)
     {
@@ -176,5 +179,6 @@ public class XmlElementAssertions : XmlNodeAssertions<XmlElement, XmlElementAsse
         return new AndWhichConstraint<XmlElementAssertions, XmlElement>(this, element, assertionChain, "/" + expectedName);
     }
 
+    /// <inheritdoc />
     protected override string Identifier => "XML element";
 }

--- a/Src/AwesomeAssertions/Xml/XmlNodeAssertions.cs
+++ b/Src/AwesomeAssertions/Xml/XmlNodeAssertions.cs
@@ -13,6 +13,13 @@ namespace AwesomeAssertions.Xml;
 [DebuggerNonUserCode]
 public class XmlNodeAssertions : XmlNodeAssertions<XmlNode, XmlNodeAssertions>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XmlNodeAssertions"/> class.
+    /// </summary>
+    /// <param name="xmlNode">The <see cref="XmlNode"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public XmlNodeAssertions(XmlNode xmlNode, AssertionChain assertionChain)
         : base(xmlNode, assertionChain)
     {
@@ -29,6 +36,13 @@ public class XmlNodeAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<
 {
     private readonly AssertionChain assertionChain;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XmlNodeAssertions{TSubject, TAssertions}"/> class.
+    /// </summary>
+    /// <param name="xmlNode">The <see cref="XmlNode"/> to assert on.</param>
+    /// <param name="assertionChain">
+    /// The <see cref="AssertionChain"/> that manages the state of the assertion, including the reason and identifier.
+    /// </param>
     public XmlNodeAssertions(TSubject xmlNode, AssertionChain assertionChain)
         : base(xmlNode, assertionChain)
     {

--- a/Src/AwesomeAssertions/Xml/XmlNodeFormatter.cs
+++ b/Src/AwesomeAssertions/Xml/XmlNodeFormatter.cs
@@ -4,13 +4,18 @@ using AwesomeAssertions.Formatting;
 
 namespace AwesomeAssertions.Xml;
 
+/// <summary>
+/// Formats a <see cref="System.Xml.XmlNode"/> value for display in assertion failure messages.
+/// </summary>
 public class XmlNodeFormatter : IValueFormatter
 {
+    /// <inheritdoc />
     public bool CanHandle(object value)
     {
         return value is XmlNode;
     }
 
+    /// <inheritdoc />
     public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
     {
         string outerXml = ((XmlNode)value).OuterXml;

--- a/Src/AwesomeAssertions/XmlAssertionExtensions.cs
+++ b/Src/AwesomeAssertions/XmlAssertionExtensions.cs
@@ -6,15 +6,30 @@ using AwesomeAssertions.Xml;
 
 namespace AwesomeAssertions;
 
+/// <summary>
+/// Contains extension methods for asserting the state of <see cref="XmlNode"/> and <see cref="XmlElement"/> objects.
+/// </summary>
 [DebuggerNonUserCode]
 public static class XmlAssertionExtensions
 {
+    /// <summary>
+    /// Returns an <see cref="XmlNodeAssertions"/> object that can be used to assert the
+    /// current <see cref="XmlNode"/>.
+    /// </summary>
+    /// <param name="actualValue">The <see cref="XmlNode"/> to assert on.</param>
+    /// <returns>An <see cref="XmlNodeAssertions"/> object for asserting on <paramref name="actualValue"/>.</returns>
     [return: NotNull]
     public static XmlNodeAssertions Should([NotNull] this XmlNode actualValue)
     {
         return new XmlNodeAssertions(actualValue, AssertionChain.GetOrCreate());
     }
 
+    /// <summary>
+    /// Returns an <see cref="XmlElementAssertions"/> object that can be used to assert the
+    /// current <see cref="XmlElement"/>.
+    /// </summary>
+    /// <param name="actualValue">The <see cref="XmlElement"/> to assert on.</param>
+    /// <returns>An <see cref="XmlElementAssertions"/> object for asserting on <paramref name="actualValue"/>.</returns>
     [return: NotNull]
     public static XmlElementAssertions Should([NotNull] this XmlElement actualValue)
     {

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,17 +11,18 @@ sidebar:
 ### What's new
 * Add `AssertionScope.AddReportable` to add custom reportable information to the current scope - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
 * Add more `AssertionChain.WithReportable` overloads - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
+* Add documentation to all public API - [#TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
 
 ### Deprecations
 * Deprecate `AssertionChain.AddReportable` in favor of `AssertionChain.WithReportable` to get a more consistent fluent API for chaining - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
- 
+
 ## 9.5.0
 
 ### What's new
 * Add `[Not]BeDecoratedWith` for `ParameterInfo` - [#449](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/449)
 * Add overload of `AssertionChain.ForCondition()` that allows for lazy execution of `condition` - [#511](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/511)
 
-### Improvements 
+### Improvements
 * Return `AndWhichConstraint` from `IntersectWith` - [#495](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/495)
 * Return `AndWhichConstraint` from `XElementAssertions.HaveAttribute` - [#504](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/504)
 * Evaluate `GivenSelector<T>.FailWith` arguments only upon failure - [#522](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/522)


### PR DESCRIPTION
With the help from AI (Claude) I've created API documentation for all public (and protected) elements.
To ensure having such documentation, the Warnings CS1573 and CS1591 are enabled, now.

I started reviewing the result before publishing. So far I did not notice any nonsense.
I've reviewed the classes I already touched and understood. But, I have to admit, that I (still) do not understand all the classes in AA. This is why I wanted to have this documentation!
Hope the "crowd intelligence" have sufficient knowledge on all classes.

Finally, I think, AI generated documentation is even better than no documentation, even it is not fully correct.
Agree?

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
