### PR TITLE
Fixes visibility of some members

### DIFF
--- a/Src/AwesomeAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/FunctionAssertions.cs
@@ -114,7 +114,7 @@ public class FunctionAssertions<T> : DelegateAssertions<Func<T>, FunctionAsserti
         return new AndWhichConstraint<FunctionAssertions<T>, T>(this, result, assertionChain, ".Result");
     }
 
-    internal TResult NotThrowAfter<TResult>(Func<TResult> subject, IClock clock, TimeSpan waitTime, TimeSpan pollInterval,
+    private TResult NotThrowAfter<TResult>(Func<TResult> subject, IClock clock, TimeSpan waitTime, TimeSpan pollInterval,
         string because, object[] becauseArgs)
     {
         Guard.ThrowIfArgumentIsNegative(waitTime);

--- a/Src/AwesomeAssertions/Specialized/TaskCompletionSourceAssertionsBase.cs
+++ b/Src/AwesomeAssertions/Specialized/TaskCompletionSourceAssertionsBase.cs
@@ -17,7 +17,7 @@ public class TaskCompletionSourceAssertionsBase
         Clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
-    private protected IClock Clock { get; }
+    private IClock Clock { get; }
 
     /// <inheritdoc/>
     [SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations")]

--- a/Src/AwesomeAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/AwesomeAssertions/Types/MethodBaseAssertions.cs
@@ -60,8 +60,7 @@ public abstract class MethodBaseAssertions<TSubject, TAssertions> : MemberInfoAs
                 .BecauseOf(because, becauseArgs)
                 .FailWith(() =>
                 {
-                    string subject = GetSubjectDescription(assertionChain);
-
+                    string subject = GetSubjectDescription();
                     return new FailReason(
                         $"Expected {subject} to be {accessModifier}{{reason}}, but it is {subjectAccessModifier}.");
                 });
@@ -103,8 +102,7 @@ public abstract class MethodBaseAssertions<TSubject, TAssertions> : MemberInfoAs
                 .BecauseOf(because, becauseArgs)
                 .FailWith(() =>
                 {
-                    string subject = GetSubjectDescription(assertionChain);
-
+                    string subject = GetSubjectDescription();
                     return new FailReason($"Expected {subject} not to be {accessModifier}{{reason}}, but it is.");
                 });
         }
@@ -119,7 +117,7 @@ public abstract class MethodBaseAssertions<TSubject, TAssertions> : MemberInfoAs
         return string.Join(", ", parameterTypes.Select(p => p.AsFormattableShortType().ToFormattedString()));
     }
 
-    private protected string GetSubjectDescription(AssertionChain assertionChain) =>
+    private string GetSubjectDescription() =>
         assertionChain.HasOverriddenCallerIdentifier
             ? assertionChain.CallerIdentifier
             : $"{Identifier} {Subject.ToFormattedString()}";


### PR DESCRIPTION
I came across some members which are more open (private protected or internal) and used (private).
To reduce warnings in the IDE I changed that.
Because it does not affect the public API, I think it is a small fix without release notes.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
