### PR TITLE
Add option ExcludingObsoleteMembers for structural comparison

### DIFF
--- a/Src/AwesomeAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
+++ b/Src/AwesomeAssertions/Equivalency/Execution/CollectionMemberOptionsDecorator.cs
@@ -66,6 +66,8 @@ internal class CollectionMemberOptionsDecorator : IEquivalencyOptions
 
     public bool ExcludeNonBrowsableOnExpectation => inner.ExcludeNonBrowsableOnExpectation;
 
+    public bool ExcludeObsoleteMembers => inner.ExcludeObsoleteMembers;
+
     public bool? CompareRecordsByValue => inner.CompareRecordsByValue;
 
     public EqualityStrategy GetEqualityStrategy(Type type)

--- a/Src/AwesomeAssertions/Equivalency/Field.cs
+++ b/Src/AwesomeAssertions/Equivalency/Field.cs
@@ -12,6 +12,7 @@ internal class Field : Node, IMember
 {
     private readonly FieldInfo fieldInfo;
     private bool? isBrowsable;
+    private bool? isObsolete;
 
     public Field(FieldInfo fieldInfo, INode parent)
     {
@@ -41,4 +42,7 @@ internal class Field : Node, IMember
 
     public bool IsBrowsable =>
         isBrowsable ??= fieldInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
+
+    public bool IsObsolete =>
+        isObsolete ??= fieldInfo.GetCustomAttribute<ObsoleteAttribute>() is not null;
 }

--- a/Src/AwesomeAssertions/Equivalency/Field.cs
+++ b/Src/AwesomeAssertions/Equivalency/Field.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using AwesomeAssertions.Common;
 
@@ -43,5 +44,12 @@ internal class Field : Node, IMember
     public bool IsBrowsable =>
         isBrowsable ??= fieldInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
 
-    public bool IsObsolete => isObsolete ??= Attribute.IsDefined(fieldInfo, typeof(ObsoleteAttribute));
+    public bool IsObsolete
+    {
+        get
+        {
+            isObsolete ??= Attribute.IsDefined(fieldInfo, typeof(ObsoleteAttribute));
+            return isObsolete.Value;
+        }
+    }
 }

--- a/Src/AwesomeAssertions/Equivalency/Field.cs
+++ b/Src/AwesomeAssertions/Equivalency/Field.cs
@@ -43,9 +43,5 @@ internal class Field : Node, IMember
     public bool IsBrowsable =>
         isBrowsable ??= fieldInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
 
-    /// <summary>
-    /// Gets a value indicating whether the field is marked as obsolete.
-    /// </summary>
-    public bool IsObsolete =>
-        isObsolete ??= fieldInfo.GetCustomAttribute<ObsoleteAttribute>() is not null;
+    public bool IsObsolete => isObsolete ??= Attribute.IsDefined(fieldInfo, typeof(ObsoleteAttribute));
 }

--- a/Src/AwesomeAssertions/Equivalency/Field.cs
+++ b/Src/AwesomeAssertions/Equivalency/Field.cs
@@ -43,6 +43,9 @@ internal class Field : Node, IMember
     public bool IsBrowsable =>
         isBrowsable ??= fieldInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
 
+    /// <summary>
+    /// Gets a value indicating whether the field is marked as obsolete.
+    /// </summary>
     public bool IsObsolete =>
         isObsolete ??= fieldInfo.GetCustomAttribute<ObsoleteAttribute>() is not null;
 }

--- a/Src/AwesomeAssertions/Equivalency/IEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/IEquivalencyOptions.cs
@@ -84,6 +84,8 @@ public interface IEquivalencyOptions
     /// </summary>
     bool ExcludeNonBrowsableOnExpectation { get; }
 
+    bool ExcludeObsoleteMembers { get; }
+
     /// <summary>
     /// Gets a value indicating whether records should be compared by value instead of their members
     /// </summary>

--- a/Src/AwesomeAssertions/Equivalency/IEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/IEquivalencyOptions.cs
@@ -84,6 +84,9 @@ public interface IEquivalencyOptions
     /// </summary>
     bool ExcludeNonBrowsableOnExpectation { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether members on the expectation marked with <see cref="ObsoleteAttribute"/> should be excluded.
+    /// </summary>
     bool ExcludeObsoleteMembers { get; }
 
     /// <summary>

--- a/Src/AwesomeAssertions/Equivalency/IMember.cs
+++ b/Src/AwesomeAssertions/Equivalency/IMember.cs
@@ -39,4 +39,6 @@ public interface IMember : INode
     /// <see cref="EditorBrowsableAttribute"/>.
     /// </summary>
     bool IsBrowsable { get; }
+
+    bool IsObsolete { get; }
 }

--- a/Src/AwesomeAssertions/Equivalency/IMember.cs
+++ b/Src/AwesomeAssertions/Equivalency/IMember.cs
@@ -40,5 +40,9 @@ public interface IMember : INode
     /// </summary>
     bool IsBrowsable { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the member is marked as obsolete.
+    /// This is controlled with <see cref="ObsoleteAttribute"/>.
+    /// </summary>
     bool IsObsolete { get; }
 }

--- a/Src/AwesomeAssertions/Equivalency/Property.cs
+++ b/Src/AwesomeAssertions/Equivalency/Property.cs
@@ -13,6 +13,7 @@ internal class Property : Node, IMember
 {
     private readonly PropertyInfo propertyInfo;
     private bool? isBrowsable;
+    private bool? isObsolete;
 
     public Property(PropertyInfo propertyInfo, INode parent)
         : this(propertyInfo.ReflectedType, propertyInfo, parent)
@@ -53,6 +54,17 @@ internal class Property : Node, IMember
                 propertyInfo.GetCustomAttribute<EditorBrowsableAttribute>() is not { State: EditorBrowsableState.Never };
 
             return isBrowsable.Value;
+        }
+    }
+
+    public bool IsObsolete
+    {
+        get
+        {
+            isObsolete ??=
+                propertyInfo.GetCustomAttribute<ObsoleteAttribute>() is not null;
+
+            return isObsolete.Value;
         }
     }
 }

--- a/Src/AwesomeAssertions/Equivalency/Property.cs
+++ b/Src/AwesomeAssertions/Equivalency/Property.cs
@@ -61,9 +61,7 @@ internal class Property : Node, IMember
     {
         get
         {
-            isObsolete ??=
-                propertyInfo.GetCustomAttribute<ObsoleteAttribute>() is not null;
-
+            isObsolete ??= propertyInfo.GetCustomAttribute<ObsoleteAttribute>() is not null;
             return isObsolete.Value;
         }
     }

--- a/Src/AwesomeAssertions/Equivalency/Property.cs
+++ b/Src/AwesomeAssertions/Equivalency/Property.cs
@@ -61,7 +61,7 @@ internal class Property : Node, IMember
     {
         get
         {
-            isObsolete ??= propertyInfo.GetCustomAttribute<ObsoleteAttribute>() is not null;
+            isObsolete ??= Attribute.IsDefined(propertyInfo, typeof(ObsoleteAttribute));
             return isObsolete.Value;
         }
     }

--- a/Src/AwesomeAssertions/Equivalency/Selection/ExcludeObsoleteMembersRule.cs
+++ b/Src/AwesomeAssertions/Equivalency/Selection/ExcludeObsoleteMembersRule.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace AwesomeAssertions.Equivalency.Selection;
+
+internal class ExcludeObsoleteMembersRule : IMemberSelectionRule
+{
+    public bool IncludesMembers => false;
+
+    public IEnumerable<IMember> SelectMembers(INode currentNode, IEnumerable<IMember> selectedMembers,
+        MemberSelectionContext context)
+    {
+        return selectedMembers.Where(member => !member.IsObsolete).ToList();
+    }
+}

--- a/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -59,6 +59,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     private MemberVisibility includedFields;
     private bool ignoreNonBrowsableOnSubject;
     private bool excludeNonBrowsableOnExpectation;
+    private bool excludeObsoleteMembers;
 
     private IEqualityComparer<string> stringComparer;
 
@@ -92,6 +93,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         includedFields = defaults.IncludedFields;
         ignoreNonBrowsableOnSubject = defaults.IgnoreNonBrowsableOnSubject;
         excludeNonBrowsableOnExpectation = defaults.ExcludeNonBrowsableOnExpectation;
+        excludeObsoleteMembers = defaults.ExcludeObsoleteMembers;
         IgnoreLeadingWhitespace = defaults.IgnoreLeadingWhitespace;
         IgnoreTrailingWhitespace = defaults.IgnoreTrailingWhitespace;
         IgnoreCase = defaults.IgnoreCase;
@@ -132,6 +134,11 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
             if (excludeNonBrowsableOnExpectation)
             {
                 yield return new ExcludeNonBrowsableMembersRule();
+            }
+
+            if (excludeObsoleteMembers)
+            {
+                yield return new ExcludeObsoleteMembersRule();
             }
 
             foreach (IMemberSelectionRule rule in selectionRules)
@@ -188,6 +195,8 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     bool IEquivalencyOptions.IgnoreNonBrowsableOnSubject => ignoreNonBrowsableOnSubject;
 
     bool IEquivalencyOptions.ExcludeNonBrowsableOnExpectation => excludeNonBrowsableOnExpectation;
+
+    bool IEquivalencyOptions.ExcludeObsoleteMembers => excludeObsoleteMembers;
 
     /// <summary>
     /// Gets a value indicating whether records are compared by value instead of by their members, or
@@ -355,6 +364,12 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     public TSelf IgnoringNonBrowsableMembersOnSubject()
     {
         ignoreNonBrowsableOnSubject = true;
+        return (TSelf)this;
+    }
+
+    public TSelf ExcludeObsoleteMembers()
+    {
+        excludeObsoleteMembers = true;
         return (TSelf)this;
     }
 

--- a/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -367,6 +367,9 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         return (TSelf)this;
     }
 
+    /// <summary>
+    /// Instructs the comparison to exclude obsolete members in the expectation.
+    /// </summary>
     public TSelf ExcludingObsoleteMembers()
     {
         excludeObsoleteMembers = true;

--- a/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -367,7 +367,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
         return (TSelf)this;
     }
 
-    public TSelf ExcludeObsoleteMembers()
+    public TSelf ExcludingObsoleteMembers()
     {
         excludeObsoleteMembers = true;
         return (TSelf)this;

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
@@ -1003,6 +1003,7 @@ namespace AwesomeAssertions.Equivalency
         AwesomeAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         AwesomeAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
+        bool ExcludeObsoleteMembers { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
         bool IgnoreNewlineStyle { get; }
@@ -1040,6 +1041,7 @@ namespace AwesomeAssertions.Equivalency
         System.Type DeclaringType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
         bool IsBrowsable { get; }
+        bool IsObsolete { get; }
         System.Type ReflectedType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -1165,6 +1167,7 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
+        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
@@ -1167,13 +1167,13 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
-        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMembersNamed(params string[] memberNames) { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNonBrowsableMembers() { }
+        public TSelf ExcludingObsoleteMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
@@ -1021,6 +1021,7 @@ namespace AwesomeAssertions.Equivalency
         AwesomeAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         AwesomeAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
+        bool ExcludeObsoleteMembers { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
         bool IgnoreNewlineStyle { get; }
@@ -1058,6 +1059,7 @@ namespace AwesomeAssertions.Equivalency
         System.Type DeclaringType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
         bool IsBrowsable { get; }
+        bool IsObsolete { get; }
         System.Type ReflectedType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -1183,6 +1185,7 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
+        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
@@ -1185,13 +1185,13 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
-        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMembersNamed(params string[] memberNames) { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNonBrowsableMembers() { }
+        public TSelf ExcludingObsoleteMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -1194,13 +1194,13 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
-        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMembersNamed(params string[] memberNames) { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNonBrowsableMembers() { }
+        public TSelf ExcludingObsoleteMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -1030,6 +1030,7 @@ namespace AwesomeAssertions.Equivalency
         AwesomeAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         AwesomeAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
+        bool ExcludeObsoleteMembers { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
         bool IgnoreNewlineStyle { get; }
@@ -1067,6 +1068,7 @@ namespace AwesomeAssertions.Equivalency
         System.Type DeclaringType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
         bool IsBrowsable { get; }
+        bool IsObsolete { get; }
         System.Type ReflectedType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -1192,6 +1194,7 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
+        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -993,6 +993,7 @@ namespace AwesomeAssertions.Equivalency
         AwesomeAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         AwesomeAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
+        bool ExcludeObsoleteMembers { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
         bool IgnoreNewlineStyle { get; }
@@ -1030,6 +1031,7 @@ namespace AwesomeAssertions.Equivalency
         System.Type DeclaringType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
         bool IsBrowsable { get; }
+        bool IsObsolete { get; }
         System.Type ReflectedType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -1155,6 +1157,7 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
+        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -1157,13 +1157,13 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
-        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMembersNamed(params string[] memberNames) { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNonBrowsableMembers() { }
+        public TSelf ExcludingObsoleteMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -1003,6 +1003,7 @@ namespace AwesomeAssertions.Equivalency
         AwesomeAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         AwesomeAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
         bool ExcludeNonBrowsableOnExpectation { get; }
+        bool ExcludeObsoleteMembers { get; }
         bool IgnoreCase { get; }
         bool IgnoreLeadingWhitespace { get; }
         bool IgnoreNewlineStyle { get; }
@@ -1040,6 +1041,7 @@ namespace AwesomeAssertions.Equivalency
         System.Type DeclaringType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
         bool IsBrowsable { get; }
+        bool IsObsolete { get; }
         System.Type ReflectedType { get; }
         AwesomeAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
@@ -1165,6 +1167,7 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
+        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -1167,13 +1167,13 @@ namespace AwesomeAssertions.Equivalency
         public TSelf ComparingEnumsByValue() { }
         public TSelf ComparingRecordsByMembers() { }
         public TSelf ComparingRecordsByValue() { }
-        public TSelf ExcludeObsoleteMembers() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<AwesomeAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingExplicitlyImplementedProperties() { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMembersNamed(params string[] memberNames) { }
         public TSelf ExcludingMissingMembers() { }
         public TSelf ExcludingNonBrowsableMembers() { }
+        public TSelf ExcludingObsoleteMembers() { }
         public TSelf ExcludingProperties() { }
         public TSelf IgnoringCase() { }
         public TSelf IgnoringCyclicReferences() { }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Xunit;
+
+namespace AwesomeAssertions.Equivalency.Specs;
+
+#pragma warning disable CS0618 // Ignore obsolete warning because we explicitly want to test this
+public partial class SelectionRulesSpecs
+{
+    public class Obsolete
+    {
+        [Fact]
+        public void When_obsolete_property_differs_comparison_should_ignore_it()
+        {
+            var subject = new ClassWithObsoleteMembers { ObsoleteProperty = "SubjectValue" };
+            var expected = new ClassWithObsoleteMembers { ObsoleteProperty = "ExpectedValue" };
+
+            subject.Should().BeEquivalentTo(expected, o => o.ExcludeObsoleteMembers());
+        }
+
+        private class ClassWithObsoleteMembers
+        {
+            public string StringProperty { get; set; }
+
+            [Obsolete("This property is obsolete and will be removed in a future version.")]
+            public string ObsoleteProperty { get; set; }
+        }
+    }
+}

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
@@ -14,7 +14,7 @@ public partial class SelectionRulesSpecs
             var subject = new ClassWithObsoleteMembers { ObsoleteProperty = "SubjectValue" };
             var expected = new ClassWithObsoleteMembers { ObsoleteProperty = "ExpectedValue" };
 
-            subject.Should().BeEquivalentTo(expected, o => o.ExcludeObsoleteMembers());
+            subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
         }
 
         private class ClassWithObsoleteMembers

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
@@ -19,9 +19,18 @@ public partial class SelectionRulesSpecs
         }
 
         [Fact]
+        public void When_obsolete_field_differs_comparison_should_ignore_it()
+        {
+            var subject = new ClassWithObsoleteMembers { ObsoleteField = "SubjectValue" };
+            var expected = new ClassWithObsoleteMembers { ObsoleteField = "ExpectedValue" };
+
+            subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
+        }
+
+        [Fact]
         public void When_obsolete_property_is_missing_comparison_should_ignore_it()
         {
-            var subject = new { StringProperty = "String" };
+            var subject = new { StringProperty = "String", ObsoleteField = (string)null };
             var expected = new ClassWithObsoleteMembers { StringProperty = "String", ObsoleteProperty = "ExpectedValue" };
 
             subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
@@ -29,12 +38,16 @@ public partial class SelectionRulesSpecs
 
         [SuppressMessage("ReSharper", "UnusedMember.Local")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]
+        [SuppressMessage("ReSharper", "NotAccessedField.Local")]
         private class ClassWithObsoleteMembers
         {
             public string StringProperty { get; set; }
 
             [Obsolete("This property is obsolete and will be removed in a future version.")]
             public string ObsoleteProperty { get; set; }
+
+            [Obsolete("This property is obsolete and will be removed in a future version.")]
+            public string ObsoleteField;
         }
     }
 }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using Xunit;
+using Xunit.Sdk;
+using static AwesomeAssertions.FluentActions;
 
 namespace AwesomeAssertions.Equivalency.Specs;
 
@@ -34,6 +36,19 @@ public partial class SelectionRulesSpecs
             var expected = new ClassWithObsoleteMembers { StringProperty = "String", ObsoleteProperty = "ExpectedValue" };
 
             subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
+        }
+
+        [Fact]
+        public void When_obsolete_property_is_defined_on_the_subject_it_is_not_excluded()
+        {
+            var subject = new ClassWithObsoleteMembers { ObsoleteProperty = "SubjectValue" };
+            var expected = new { ObsoleteProperty = "ExpectedValue" };
+
+            Action act = () => subject.Should().BeEquivalentTo(
+                expected, o => o.ExcludingObsoleteMembers(),
+                "we want to test the {0} message", "failure");
+
+            act.Should().Throw<XunitException>().WithMessage("*failure message*SubjectValue*ExpectedValue*");
         }
 
         [SuppressMessage("ReSharper", "UnusedMember.Local")]

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Xunit;
 using Xunit.Sdk;
-using static AwesomeAssertions.FluentActions;
 
 namespace AwesomeAssertions.Equivalency.Specs;
 
@@ -21,10 +21,32 @@ public partial class SelectionRulesSpecs
         }
 
         [Fact]
+        public void When_obsolete_property_in_collection_differs_comparison_should_ignore_it()
+        {
+            var subject = new List<ClassWithObsoleteMembers>
+            { new() { ObsoleteProperty = "SubjectValue1" }, new() { ObsoleteProperty = "SubjectValue2" } };
+            var expected = new List<ClassWithObsoleteMembers>
+            { new() { ObsoleteProperty = "ExpectedValue1" }, new() { ObsoleteProperty = "ExpectedValue2" } };
+
+            subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
+        }
+
+        [Fact]
         public void When_obsolete_field_differs_comparison_should_ignore_it()
         {
             var subject = new ClassWithObsoleteMembers { ObsoleteField = "SubjectValue" };
             var expected = new ClassWithObsoleteMembers { ObsoleteField = "ExpectedValue" };
+
+            subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
+        }
+
+        [Fact]
+        public void When_obsolete_field_in_collection_differs_comparison_should_ignore_it()
+        {
+            var subject = new List<ClassWithObsoleteMembers>
+                { new() { ObsoleteField = "SubjectValue1" }, new() { ObsoleteField = "SubjectValue2" } };
+            var expected = new List<ClassWithObsoleteMembers>
+                { new() { ObsoleteField = "ExpectedValue1" }, new() { ObsoleteField = "ExpectedValue2" } };
 
             subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
         }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
@@ -24,9 +24,9 @@ public partial class SelectionRulesSpecs
         public void When_obsolete_property_in_collection_differs_comparison_should_ignore_it()
         {
             var subject = new List<ClassWithObsoleteMembers>
-            { new() { ObsoleteProperty = "SubjectValue1" }, new() { ObsoleteProperty = "SubjectValue2" } };
+                { new() { ObsoleteProperty = "SubjectValue1" }, new() { ObsoleteProperty = "SubjectValue2" } };
             var expected = new List<ClassWithObsoleteMembers>
-            { new() { ObsoleteProperty = "ExpectedValue1" }, new() { ObsoleteProperty = "ExpectedValue2" } };
+                { new() { ObsoleteProperty = "ExpectedValue1" }, new() { ObsoleteProperty = "ExpectedValue2" } };
 
             subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
         }
@@ -54,8 +54,17 @@ public partial class SelectionRulesSpecs
         [Fact]
         public void When_obsolete_property_is_missing_comparison_should_ignore_it()
         {
-            var subject = new { StringProperty = "String", ObsoleteField = (string)null };
+            var subject = new { StringProperty = "String", StringField = (string)null, ObsoleteField = (string)null };
             var expected = new ClassWithObsoleteMembers { StringProperty = "String", ObsoleteProperty = "ExpectedValue" };
+
+            subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
+        }
+
+        [Fact]
+        public void When_obsolete_field_is_missing_comparison_should_ignore_it()
+        {
+            var subject = new { StringProperty = (string)null, StringField = "String", ObsoleteField = (string)null };
+            var expected = new ClassWithObsoleteMembers { StringField = "String", ObsoleteField = "ExpectedValue" };
 
             subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
         }
@@ -82,6 +91,8 @@ public partial class SelectionRulesSpecs
 
             [Obsolete("This property is obsolete and will be removed in a future version.")]
             public string ObsoleteProperty { get; set; }
+
+            public string StringField;
 
             [Obsolete("This property is obsolete and will be removed in a future version.")]
             public string ObsoleteField;

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.Obsolete.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 namespace AwesomeAssertions.Equivalency.Specs;
@@ -17,6 +18,17 @@ public partial class SelectionRulesSpecs
             subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
         }
 
+        [Fact]
+        public void When_obsolete_property_is_missing_comparison_should_ignore_it()
+        {
+            var subject = new { StringProperty = "String" };
+            var expected = new ClassWithObsoleteMembers { StringProperty = "String", ObsoleteProperty = "ExpectedValue" };
+
+            subject.Should().BeEquivalentTo(expected, o => o.ExcludingObsoleteMembers());
+        }
+
+        [SuppressMessage("ReSharper", "UnusedMember.Local")]
+        [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]
         private class ClassWithObsoleteMembers
         {
             public string StringProperty { get; set; }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -30,7 +30,7 @@ public partial class SelectionRulesSpecs
                 .ExcludingMissingMembers()
                 .WithoutRecursing()
                 .ExcludingNonBrowsableMembers()
-                .ExcludeObsoleteMembers()
+                .ExcludingObsoleteMembers()
                 .ExcludingProperties()
                 .IgnoringCyclicReferences()
                 .IgnoringNonBrowsableMembersOnSubject()

--- a/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/SelectionRulesSpecs.cs
@@ -30,6 +30,7 @@ public partial class SelectionRulesSpecs
                 .ExcludingMissingMembers()
                 .WithoutRecursing()
                 .ExcludingNonBrowsableMembers()
+                .ExcludeObsoleteMembers()
                 .ExcludingProperties()
                 .IgnoringCyclicReferences()
                 .IgnoringNonBrowsableMembersOnSubject()

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -76,6 +76,8 @@ public class UsersOfGetClosedGenericInterfaces
 
         public bool ExcludeNonBrowsableOnExpectation => throw new NotImplementedException();
 
+        public bool ExcludeObsoleteMembers => throw new NotImplementedException();
+
         public bool? CompareRecordsByValue => throw new NotImplementedException();
 
         public ITraceWriter TraceWriter => throw new NotImplementedException();

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 * Add `AssertionScope.AddReportable` to add custom reportable information to the current scope - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
 * Add more `AssertionChain.WithReportable` overloads - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
 * Add documentation to all public API - [#TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
+* Add `ExcludingObsoleteMembers` to `SelfReferenceEquivalencyOptions` allowing obsolete members to be ignored in structural comparison - [#TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
 
 ### Deprecations
 * Deprecate `AssertionChain.AddReportable` in favor of `AssertionChain.WithReportable` to get a more consistent fluent API for chaining - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,7 +12,7 @@ sidebar:
 * Add `AssertionScope.AddReportable` to add custom reportable information to the current scope - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
 * Add more `AssertionChain.WithReportable` overloads - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
 * Add documentation to all public API - [#TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
-* Add `ExcludingObsoleteMembers` to `SelfReferenceEquivalencyOptions` allowing obsolete members to be ignored in structural comparison - [#TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
+* Add `ExcludingObsoleteMembers` to `SelfReferenceEquivalencyOptions` allowing obsolete members to be ignored in structural comparison - [#558](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/558)
 
 ### Deprecations
 * Deprecate `AssertionChain.AddReportable` in favor of `AssertionChain.WithReportable` to get a more consistent fluent API for chaining - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)


### PR DESCRIPTION
Fixed #505 

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
