### PR TITLE
Update Release Notes regarding interface changes (ExcludeObsoleteMembers)

### DIFF
--- a/Src/AwesomeAssertions/Equivalency/IEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/IEquivalencyOptions.cs
@@ -8,6 +8,10 @@ namespace AwesomeAssertions.Equivalency;
 /// <summary>
 /// Provides the run-time details of the <see cref="EquivalencyOptions{TExpectation}" /> class.
 /// </summary>
+/// <remarks>
+/// Please note that this interface is public only for technical reason and is not part of the public API.
+/// It should not be used outside the library.
+/// </remarks>
 public interface IEquivalencyOptions
 {
     /// <summary>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 * Add more `AssertionChain.WithReportable` overloads - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
 * Add documentation to all public API - [#TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
 * Add `ExcludingObsoleteMembers` to `SelfReferenceEquivalencyOptions` allowing obsolete members to be ignored in structural comparison - [#558](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/558)
+  * Please note that the interface `IEquivalencyOptions` has been marked as "technically public" and not part of the public API.
 
 ### Fixes
 * Fix duplicate matching rules - [#566](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/566)


### PR DESCRIPTION
In #505, I promised to include the changes to the interfaces in the release notes. But I forgot to do that in #558 .

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
