### PR TITLE
Fix duplicate matching rules

### DIFF
--- a/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -427,7 +427,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     /// </summary>
     public TSelf ExcludingMissingMembers()
     {
-        matchingRules.RemoveAll(x => x is MustMatchByNameRule);
+        matchingRules.RemoveAll(x => x is TryMatchByNameRule or MustMatchByNameRule);
         matchingRules.Add(new TryMatchByNameRule());
         return (TSelf)this;
     }
@@ -452,7 +452,7 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     /// </summary>
     public TSelf ThrowingOnMissingMembers()
     {
-        matchingRules.RemoveAll(x => x is TryMatchByNameRule);
+        matchingRules.RemoveAll(x => x is TryMatchByNameRule or MustMatchByNameRule);
         matchingRules.Add(new MustMatchByNameRule());
         return (TSelf)this;
     }

--- a/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using AwesomeAssertions.Common;

--- a/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
+++ b/Src/AwesomeAssertions/Equivalency/SelfReferenceEquivalencyOptions.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using AwesomeAssertions.Common;
@@ -427,7 +428,8 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     /// </summary>
     public TSelf ExcludingMissingMembers()
     {
-        matchingRules.RemoveAll(x => x is TryMatchByNameRule or MustMatchByNameRule);
+        matchingRules.RemoveAll(x => x is TryMatchByNameRule);
+        matchingRules.RemoveAll(x => x is MustMatchByNameRule);
         matchingRules.Add(new TryMatchByNameRule());
         return (TSelf)this;
     }
@@ -452,7 +454,8 @@ public abstract class SelfReferenceEquivalencyOptions<TSelf> : IEquivalencyOptio
     /// </summary>
     public TSelf ThrowingOnMissingMembers()
     {
-        matchingRules.RemoveAll(x => x is TryMatchByNameRule or MustMatchByNameRule);
+        matchingRules.RemoveAll(x => x is TryMatchByNameRule);
+        matchingRules.RemoveAll(x => x is MustMatchByNameRule);
         matchingRules.Add(new MustMatchByNameRule());
         return (TSelf)this;
     }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -392,6 +392,32 @@ public class MemberMatchingSpecs
     }
 
     [Fact]
+    public void Exclusion_after_throwing_let_exclude_win()
+    {
+        var subject = new[] { 1 };
+        var expectation = new[] { 2 };
+
+        Action act = () => subject.Should().BeEquivalentTo(expectation, o => o
+            .ThrowingOnMissingMembers().ExcludingMissingMembers());
+
+        act.Should().Throw<XunitException>().WithMessage("*Try to match member by name*")
+            .And.Message.Should().NotContain("Match member by name (or throw)");
+    }
+
+    [Fact]
+    public void Throwing_after_exclude_let_throwing_win()
+    {
+        var subject = new[] { 1 };
+        var expectation = new[] { 2 };
+
+        Action act = () => subject.Should().BeEquivalentTo(expectation, o => o
+            .ExcludingMissingMembers().ThrowingOnMissingMembers());
+
+        act.Should().Throw<XunitException>().WithMessage("*Match member by name (or throw)*")
+            .And.Message.Should().NotContain("Try to match member by name");
+    }
+
+    [Fact]
     public void Can_map_members_of_a_root_collection()
     {
         var entity = new Entity { EntityId = 1, Name = "Test" };

--- a/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using JetBrains.Annotations;
 using Xunit;
 using Xunit.Sdk;
@@ -358,6 +359,36 @@ public class MemberMatchingSpecs
             .NotBeEquivalentTo(expectation, opt => opt
                 .ExcludingMissingMembers()
                 .WithMapping("Property2", "Property1"));
+    }
+
+    [Fact]
+    public void Exclusion_can_be_configured_only_once()
+    {
+        var subject = new[] { 1 };
+        var expectation = new[] { 2 };
+
+        Action act = () => subject.Should().BeEquivalentTo(expectation, o => o
+            .ExcludingMissingMembers().ExcludingMissingMembers());
+
+        var message = act.Should().Throw<XunitException>().Which.Message;
+        var configurationMessages =
+            message.Split("\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim());
+        configurationMessages.GroupBy(x => x).Should().OnlyContain(x => x.Count() == 1);
+    }
+
+    [Fact]
+    public void Throwing_can_be_configured_only_once()
+    {
+        var subject = new[] { 1 };
+        var expectation = new[] { 2 };
+
+        Action act = () => subject.Should().BeEquivalentTo(expectation, o => o
+            .ThrowingOnMissingMembers().ThrowingOnMissingMembers());
+
+        var message = act.Should().Throw<XunitException>().Which.Message;
+        var configurationMessages =
+            message.Split("\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim());
+        configurationMessages.GroupBy(x => x).Should().OnlyContain(x => x.Count() == 1);
     }
 
     [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,9 @@ sidebar:
 * Add documentation to all public API - [#TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
 * Add `ExcludingObsoleteMembers` to `SelfReferenceEquivalencyOptions` allowing obsolete members to be ignored in structural comparison - [#558](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/558)
 
+### Fixes
+* Fix duplicate matching rules - [#566](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/566)
+
 ### Deprecations
 * Deprecate `AssertionChain.AddReportable` in favor of `AssertionChain.WithReportable` to get a more consistent fluent API for chaining - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
 


### PR DESCRIPTION
Fixes #565 .

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
