### PR TITLE
Annotate time range related assertions wit the `PureAttribute` incl. enabled "full contract"

### DIFF
--- a/Src/AwesomeAssertions/AwesomeAssertions.csproj
+++ b/Src/AwesomeAssertions/AwesomeAssertions.csproj
@@ -17,6 +17,13 @@
     <Product>AwesomeAssertions</Product>
   </PropertyGroup>
 
+  <PropertyGroup Label="Contract">
+    <!-- Emit System.Diagnostics.Contracts attributes (e.g. [Pure]); they are [Conditional("CONTRACTS_FULL")]
+     and are otherwise stripped at compile time. No Contract.Requires/Ensures/... calls exist in the code,
+     so this only affects attribute emission, not runtime behaviour. -->
+    <DefineConstants>$(DefineConstants);CONTRACTS_FULL</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Label="Package info">
     <Authors>AwesomeAssertions, Dennis Doomen, Jonas Nyrup and contributors</Authors>
     <PackageDescription>

--- a/Src/AwesomeAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/DateTimeAssertions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using AwesomeAssertions.Common;
 using AwesomeAssertions.Execution;
@@ -755,6 +756,7 @@ public class DateTimeAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTime"/>  should exceed compared to another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.MoreThan,
@@ -769,6 +771,7 @@ public class DateTimeAssertions<TAssertions>
     /// The amount of time that the current <see cref="DateTime"/>  should be equal or exceed compared to
     /// another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.AtLeast,
@@ -782,6 +785,7 @@ public class DateTimeAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTime"/>  should differ exactly compared to another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.Exactly,
@@ -795,6 +799,7 @@ public class DateTimeAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTime"/>  should be within another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.Within,
@@ -808,6 +813,7 @@ public class DateTimeAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The maximum amount of time that the current <see cref="DateTime"/>  should differ compared to another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.LessThan,

--- a/Src/AwesomeAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using AwesomeAssertions.Common;
 using AwesomeAssertions.Execution;
@@ -945,6 +946,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTimeOffset"/> should exceed compared to another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
@@ -959,6 +961,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// The amount of time that the current <see cref="DateTimeOffset"/> should be equal or exceed compared to
     /// another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
@@ -972,6 +975,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTimeOffset"/> should differ exactly compared to another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
@@ -985,6 +989,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTimeOffset"/> should be within another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
@@ -998,6 +1003,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The maximum amount of time that the current <see cref="DateTimeOffset"/> should differ compared to another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net47.verified.txt
@@ -284,9 +284,11 @@ namespace AwesomeAssertions
     }
     public static class EnumAssertionsExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
             where TEnum :  struct, System.Enum { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>([System.Diagnostics.CodeAnalysis.NotNull] this TEnum? @enum)
             where TEnum :  struct, System.Enum { }
@@ -1993,15 +1995,19 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -2017,6 +2023,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -2078,17 +2085,21 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -2104,6 +2115,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net6.0.verified.txt
@@ -302,9 +302,11 @@ namespace AwesomeAssertions
     }
     public static class EnumAssertionsExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
             where TEnum :  struct, System.Enum { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>([System.Diagnostics.CodeAnalysis.NotNull] this TEnum? @enum)
             where TEnum :  struct, System.Enum { }
@@ -2085,15 +2087,19 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -2109,6 +2115,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -2170,17 +2177,21 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -2196,6 +2207,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -302,9 +302,11 @@ namespace AwesomeAssertions
     }
     public static class EnumAssertionsExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
             where TEnum :  struct, System.Enum { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>([System.Diagnostics.CodeAnalysis.NotNull] this TEnum? @enum)
             where TEnum :  struct, System.Enum { }
@@ -2094,15 +2096,19 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
@@ -2118,6 +2124,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -2179,17 +2186,21 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
@@ -2205,6 +2216,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -280,9 +280,11 @@ namespace AwesomeAssertions
     }
     public static class EnumAssertionsExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
             where TEnum :  struct, System.Enum { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>([System.Diagnostics.CodeAnalysis.NotNull] this TEnum? @enum)
             where TEnum :  struct, System.Enum { }
@@ -1935,15 +1937,19 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1959,6 +1965,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -2020,17 +2027,21 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -2046,6 +2057,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -284,9 +284,11 @@ namespace AwesomeAssertions
     }
     public static class EnumAssertionsExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
             where TEnum :  struct, System.Enum { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>([System.Diagnostics.CodeAnalysis.NotNull] this TEnum? @enum)
             where TEnum :  struct, System.Enum { }
@@ -1993,15 +1995,19 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -2017,6 +2023,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -2078,17 +2085,21 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -2104,6 +2115,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]


### PR DESCRIPTION
Currently just a proof-of-concept.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
