### PR TITLE
Fix verify settings while updating Verify.DiffPlex to 3.3.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -63,3 +63,12 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# Verify configuration according to
+# https://github.com/VerifyTests/Verify#text-file-settings
+###############################################################################
+*.verified.txt text eol=lf working-tree-encoding=UTF-8
+*.verified.xml text eol=lf working-tree-encoding=UTF-8
+*.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary

--- a/Tests/Approval.Tests/Approval.Tests.csproj
+++ b/Tests/Approval.Tests/Approval.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
-    <PackageReference Include="Verify.DiffPlex" Version="3.3.0" />
+    <PackageReference Include="Verify.DiffPlex" Version="3.3.1" />
     <PackageReference Include="Verify.XunitV3" Version="31.20.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>


### PR DESCRIPTION
As I cannot push to the branch of #562 I've created new branch and PR.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
