### PR TITLE
fix: upper and lower case issue

### DIFF
--- a/Src/AwesomeAssertions/Primitives/StringAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/StringAssertions.cs
@@ -2225,9 +2225,9 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
-    private static bool HasNonUpperChar(string subject)
+    private static bool HasNonUpperChar(string value)
     {
-        foreach (var c in subject)
+        foreach (var c in value)
         {
             if (!char.IsUpper(c))
             {
@@ -2238,9 +2238,9 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         return false;
     }
 
-    private static bool HasNonLowerChar(string subject)
+    private static bool HasNonLowerChar(string value)
     {
-        foreach (var c in subject)
+        foreach (var c in value)
         {
             if (!char.IsLower(c))
             {

--- a/Src/AwesomeAssertions/Primitives/StringAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/StringAssertions.cs
@@ -2234,7 +2234,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
 
         foreach (var c in value)
         {
-            if (!char.IsUpper(c))
+            if (char.IsLetter(c) && !char.IsUpper(c))
             {
                 return true;
             }
@@ -2252,7 +2252,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
 
         foreach (var c in value)
         {
-            if (!char.IsLower(c))
+            if (char.IsLetter(c) && !char.IsLower(c))
             {
                 return true;
             }

--- a/Src/AwesomeAssertions/Primitives/StringAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/StringAssertions.cs
@@ -2227,6 +2227,11 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
 
     private static bool HasNonUpperChar(string value)
     {
+        if (string.IsNullOrEmpty(value))
+        {
+            return true;
+        }
+
         foreach (var c in value)
         {
             if (!char.IsUpper(c))
@@ -2240,6 +2245,11 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
 
     private static bool HasNonLowerChar(string value)
     {
+        if (string.IsNullOrEmpty(value))
+        {
+            return true;
+        }
+
         foreach (var c in value)
         {
             if (!char.IsLower(c))

--- a/Src/AwesomeAssertions/Primitives/StringAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/StringAssertions.cs
@@ -2163,7 +2163,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         assertionChain
-            .ForCondition(Subject is null || HasNonUpperChar(Subject))
+            .ForCondition(string.IsNullOrEmpty(Subject) || HasNonUpperChar(Subject))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected some characters in {context:string} to be lower-case{reason}, but found {0}.", Subject);
 
@@ -2218,7 +2218,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         assertionChain
-            .ForCondition(Subject is null || HasNonLowerChar(Subject))
+            .ForCondition(string.IsNullOrEmpty(Subject) || HasNonLowerChar(Subject))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected some characters in {context:string} to be upper-case{reason}, but found {0}.", Subject);
 
@@ -2227,11 +2227,6 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
 
     private static bool HasNonUpperChar(string value)
     {
-        if (string.IsNullOrEmpty(value))
-        {
-            return true;
-        }
-
         foreach (var c in value)
         {
             if (char.IsLetter(c) && !char.IsUpper(c))
@@ -2245,11 +2240,6 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
 
     private static bool HasNonLowerChar(string value)
     {
-        if (string.IsNullOrEmpty(value))
-        {
-            return true;
-        }
-
         foreach (var c in value)
         {
             if (char.IsLetter(c) && !char.IsLower(c))

--- a/Src/AwesomeAssertions/Primitives/StringAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/StringAssertions.cs
@@ -2163,7 +2163,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         assertionChain
-            .ForCondition(Subject is null || HasMixedOrNoCase(Subject))
+            .ForCondition(Subject is null || HasNonUpperChar(Subject))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected some characters in {context:string} to be lower-case{reason}.");
 
@@ -2218,30 +2218,37 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
     {
         assertionChain
-            .ForCondition(Subject is null || HasMixedOrNoCase(Subject))
+            .ForCondition(Subject is null || HasNonLowerChar(Subject))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected some characters in {context:string} to be upper-case{reason}.");
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
-    private static bool HasMixedOrNoCase(string value)
+    private static bool HasNonUpperChar(string subject)
     {
-        var hasUpperCase = false;
-        var hasLowerCase = false;
-
-        foreach (var ch in value)
+        foreach (var c in subject)
         {
-            hasUpperCase |= char.IsUpper(ch);
-            hasLowerCase |= char.IsLower(ch);
-
-            if (hasUpperCase && hasLowerCase)
+            if (!char.IsUpper(c))
             {
                 return true;
             }
         }
 
-        return !hasUpperCase && !hasLowerCase;
+        return false;
+    }
+
+    private static bool HasNonLowerChar(string subject)
+    {
+        foreach (var c in subject)
+        {
+            if (!char.IsLower(c))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     [return: NotNull]

--- a/Src/AwesomeAssertions/Primitives/StringAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/StringAssertions.cs
@@ -2165,7 +2165,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         assertionChain
             .ForCondition(Subject is null || HasNonUpperChar(Subject))
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected some characters in {context:string} to be lower-case{reason}.");
+            .FailWith("Expected some characters in {context:string} to be lower-case{reason}, but found {0}.", Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }
@@ -2220,7 +2220,7 @@ public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAs
         assertionChain
             .ForCondition(Subject is null || HasNonLowerChar(Subject))
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected some characters in {context:string} to be upper-case{reason}.");
+            .FailWith("Expected some characters in {context:string} to be upper-case{reason}, but found {0}.", Subject);
 
         return new AndConstraint<TAssertions>((TAssertions)this);
     }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
@@ -162,16 +162,6 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
-        public void Lower_case_characters_are_okay()
-        {
-            // Arrange
-            string actual = "abc";
-
-            // Act / Assert
-            actual.Should().NotBeUpperCased();
-        }
-
-        [Fact]
         public void Upper_case_characters_are_okay()
         {
             // Arrange

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
@@ -162,6 +162,26 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
+        public void Lower_case_characters_are_okay()
+        {
+            // Arrange
+            string actual = "abc";
+
+            // Act / Assert
+            actual.Should().NotBeUpperCased();
+        }
+
+        [Fact]
+        public void Upper_case_characters_are_okay()
+        {
+            // Arrange
+            string actual = "ABC";
+
+            // Act / Assert
+            actual.Should().NotBeLowerCased();
+        }
+
+        [Fact]
         public void All_cased_characters_being_lower_case_is_not_okay()
         {
             // Arrange

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
@@ -203,7 +203,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected some characters in actual to be upper-case because we want to test the failure message.");
+                "Expected some characters in actual to be upper-case because we want to test the failure message, but found \"abc\".");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeLowerCased.cs
@@ -164,10 +164,8 @@ public partial class StringAssertionSpecs
         [Fact]
         public void Upper_case_characters_are_okay()
         {
-            // Arrange
             string actual = "ABC";
 
-            // Act / Assert
             actual.Should().NotBeLowerCased();
         }
 

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
@@ -45,6 +45,16 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
+        public void A_mixed_case_string_is_not_okay()
+        {
+            string actual = "AbC";
+
+            Action act = () => actual.Should().BeUpperCased();
+
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
         public void Upper_case_and_caseless_characters_are_ok()
         {
             // Arrange

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
@@ -151,10 +151,8 @@ public partial class StringAssertionSpecs
         [Fact]
         public void Lower_case_characters_are_okay()
         {
-            // Arrange
             string actual = "abc";
 
-            // Act / Assert
             actual.Should().NotBeUpperCased();
         }
 

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
@@ -190,7 +190,7 @@ public partial class StringAssertionSpecs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected some characters in actual to be lower-case because we want to test the failure message.");
+                "Expected some characters in actual to be lower-case because we want to test the failure message, but found \"ABC\".");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
+++ b/Tests/AwesomeAssertions.Specs/Primitives/StringAssertionSpecs.BeUpperCased.cs
@@ -149,6 +149,16 @@ public partial class StringAssertionSpecs
         }
 
         [Fact]
+        public void Lower_case_characters_are_okay()
+        {
+            // Arrange
+            string actual = "abc";
+
+            // Act / Assert
+            actual.Should().NotBeUpperCased();
+        }
+
+        [Fact]
         public void All_cased_characters_being_upper_case_is_not_okay()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,7 +16,7 @@ sidebar:
 
 ### Fixes
 * Fix duplicate matching rules - [#566](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/566)
-* Fix `NotBeUpperCased` and `NotBeLowerCased` for all lower-/uppercased strings - [#590](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/590)
+* Fix `NotBeUpperCased` and `NotBeLowerCased` for all lower-/uppercased strings - [#591](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/591)
 
 ### Deprecations
 * Deprecate `AssertionChain.AddReportable` in favor of `AssertionChain.WithReportable` to get a more consistent fluent API for chaining - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,7 +16,7 @@ sidebar:
 
 ### Fixes
 * Fix duplicate matching rules - [#566](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/566)
-* Fix `NotBeUpperCased` and `NotBeLowerCased` for all lower-/uppercased strings - [#591](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/591)
+* Fix `NotBeUpperCased` and `NotBeLowerCased` for all lower-/uppercase strings - [#591](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/591)
 
 ### Deprecations
 * Deprecate `AssertionChain.AddReportable` in favor of `AssertionChain.WithReportable` to get a more consistent fluent API for chaining - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ sidebar:
 
 ### Fixes
 * Fix duplicate matching rules - [#566](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/566)
+* Fix `NotBeUpperCased` and `NotBeLowerCased` for all lower-/uppercased strings - [#590](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/590)
 
 ### Deprecations
 * Deprecate `AssertionChain.AddReportable` in favor of `AssertionChain.WithReportable` to get a more consistent fluent API for chaining - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

Fix #590: The `NotBeUpperCased`/`NotBeLowerCased` on all lower-/upper cases


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
