### PR TITLE
v10: Introduce ExceptionAssertionsTask to improve assertions on exception details

### DIFF
--- a/Src/AwesomeAssertions/ExceptionAssertionsExtensions.cs
+++ b/Src/AwesomeAssertions/ExceptionAssertionsExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using AwesomeAssertions.Common;
 using AwesomeAssertions.Execution;
@@ -11,145 +10,31 @@ namespace AwesomeAssertions;
 /// <summary>
 /// Provides extension methods for asserting on exceptions, including the results of asynchronous exception assertions.
 /// </summary>
+/// <remarks>
+/// Assertions that apply to every thrown exception are members of <see cref="ExceptionAssertions{TException}"/> and
+/// <see cref="ExceptionAssertionsTask{TException}"/> themselves. This class hosts those that apply to a subset of the
+/// exception types only, such as the ones requiring an <see cref="ArgumentException"/>, because a member cannot
+/// narrow the type parameter of the class that declares it.
+/// </remarks>
 public static class ExceptionAssertionsExtensions
 {
-#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
-
     /// <summary>
-    /// Asserts that the thrown exception has a message that matches <paramref name="expectedWildcardPattern" />.
+    /// Continues asserting on the exception provided by <paramref name="task"/>.
     /// </summary>
-    /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
-    /// <param name="expectedWildcardPattern">
-    /// The wildcard pattern with which the exception message is matched, where * and ? have special meanings.
-    /// </param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
-    /// </param>
-    public static async Task<ExceptionAssertions<TException>> WithMessage<TException>(
-        this Task<ExceptionAssertions<TException>> task,
-        string expectedWildcardPattern,
-        [StringSyntax("CompositeFormat")] string because = "",
-        params object[] becauseArgs)
+    /// <typeparam name="TException">The type of the thrown exception.</typeparam>
+    /// <param name="task">The task providing the <see cref="ExceptionAssertions{TException}"/> to continue on.</param>
+    /// <remarks>
+    /// Needed to continue on a <see cref="Task{TResult}"/> that one of the <c>ThrowAsync</c> assertions did not
+    /// produce, such as the outcome of your own helper method. Unlike the constructor of
+    /// <see cref="ExceptionAssertionsTask{TException}"/>, this infers <typeparamref name="TException"/>, so it does
+    /// not have to be spelled out.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="task"/> is <see langword="null"/>.</exception>
+    public static ExceptionAssertionsTask<TException> AsExceptionAssertionsTask<TException>(
+        this Task<ExceptionAssertions<TException>> task)
         where TException : Exception
     {
-        return (await task).WithMessage(expectedWildcardPattern, because, becauseArgs);
-    }
-
-    /// <summary>
-    /// Asserts that the exception matches a particular condition.
-    /// </summary>
-    /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
-    /// <param name="exceptionExpression">
-    /// The condition that the exception must match.
-    /// </param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
-    /// </param>
-    public static async Task<ExceptionAssertions<TException>> Where<TException>(
-        this Task<ExceptionAssertions<TException>> task,
-        Expression<Func<TException, bool>> exceptionExpression,
-        [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-        where TException : Exception
-    {
-        return (await task).Where(exceptionExpression, because, becauseArgs);
-    }
-
-    /// <summary>
-    /// Asserts that the thrown exception contains an inner exception of type <typeparamref name="TInnerException" />.
-    /// </summary>
-    /// <typeparam name="TException">The expected type of the exception.</typeparam>
-    /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
-    /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    public static async Task<ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(
-        this Task<ExceptionAssertions<TException>> task,
-        [StringSyntax("CompositeFormat")] string because = "",
-        params object[] becauseArgs)
-        where TException : Exception
-        where TInnerException : Exception
-    {
-        return (await task).WithInnerException<TInnerException>(because, becauseArgs);
-    }
-
-    /// <summary>
-    /// Asserts that the thrown exception contains an inner exception of type <param name="innerException" />.
-    /// </summary>
-    /// <typeparam name="TException">The expected type of the exception.</typeparam>
-    /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    public static async Task<ExceptionAssertions<Exception>> WithInnerException<TException>(
-        this Task<ExceptionAssertions<TException>> task,
-        Type innerException,
-        [StringSyntax("CompositeFormat")] string because = "",
-        params object[] becauseArgs)
-        where TException : Exception
-    {
-        return (await task).WithInnerException(innerException, because, becauseArgs);
-    }
-
-    /// <summary>
-    /// Asserts that the thrown exception contains an inner exception of the exact type <typeparamref name="TInnerException" /> (and not a derived exception type).
-    /// </summary>
-    /// <typeparam name="TException">The expected type of the exception.</typeparam>
-    /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
-    /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    public static async Task<ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(
-        this Task<ExceptionAssertions<TException>> task,
-        [StringSyntax("CompositeFormat")] string because = "",
-        params object[] becauseArgs)
-        where TException : Exception
-        where TInnerException : Exception
-    {
-        return (await task).WithInnerExceptionExactly<TInnerException>(because, becauseArgs);
-    }
-
-    /// <summary>
-    /// Asserts that the thrown exception contains an inner exception of the exact type <param name="innerException" /> (and not a derived exception type).
-    /// </summary>
-    /// <typeparam name="TException">The expected type of the exception.</typeparam>
-    /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    public static async Task<ExceptionAssertions<Exception>> WithInnerExceptionExactly<TException>(
-        this Task<ExceptionAssertions<TException>> task,
-        Type innerException,
-        [StringSyntax("CompositeFormat")] string because = "",
-        params object[] becauseArgs)
-        where TException : Exception
-    {
-        return (await task).WithInnerExceptionExactly(innerException, because, becauseArgs);
+        return new ExceptionAssertionsTask<TException>(task);
     }
 
     /// <summary>
@@ -188,28 +73,7 @@ public static class ExceptionAssertionsExtensions
     /// <summary>
     /// Asserts that the thrown exception has a parameter which name matches <paramref name="paramName" />.
     /// </summary>
-    /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
-    /// <param name="paramName">The expected name of the parameter</param>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
-    /// </param>
-    public static async Task<ExceptionAssertions<TException>> WithParameterName<TException>(
-        this Task<ExceptionAssertions<TException>> task,
-        string paramName,
-        [StringSyntax("CompositeFormat")] string because = "",
-        params object[] becauseArgs)
-        where TException : ArgumentException
-    {
-        return (await task).WithParameterName(paramName, because, becauseArgs);
-    }
-
-    /// <summary>
-    /// Asserts that the thrown exception has a parameter which name matches <paramref name="paramName" />.
-    /// </summary>
+    /// <typeparam name="TException">The type of the exception.</typeparam>
     /// <param name="assertions">The <see cref="ExceptionAssertionsTask{TException}"/> containing the thrown exception.</param>
     /// <param name="paramName">The expected name of the parameter</param>
     /// <param name="because">
@@ -219,6 +83,7 @@ public static class ExceptionAssertionsExtensions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="assertions"/> is <see langword="null"/>.</exception>
     public static ExceptionAssertionsTask<TException> WithParameterName<TException>(
         this ExceptionAssertionsTask<TException> assertions,
         string paramName,
@@ -241,6 +106,4 @@ public static class ExceptionAssertionsExtensions
     {
         return (await task).WithParameterName(paramName, because, becauseArgs);
     }
-
-#pragma warning restore AV1755
 }

--- a/Src/AwesomeAssertions/ExceptionAssertionsExtensions.cs
+++ b/Src/AwesomeAssertions/ExceptionAssertionsExtensions.cs
@@ -207,5 +207,40 @@ public static class ExceptionAssertionsExtensions
         return (await task).WithParameterName(paramName, because, becauseArgs);
     }
 
+    /// <summary>
+    /// Asserts that the thrown exception has a parameter which name matches <paramref name="paramName" />.
+    /// </summary>
+    /// <param name="assertions">The <see cref="ExceptionAssertionsTask{TException}"/> containing the thrown exception.</param>
+    /// <param name="paramName">The expected name of the parameter</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+    /// </param>
+    public static ExceptionAssertionsTask<TException> WithParameterName<TException>(
+        this ExceptionAssertionsTask<TException> assertions,
+        string paramName,
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+        where TException : ArgumentException
+    {
+        Guard.ThrowIfArgumentIsNull(assertions);
+
+        return new ExceptionAssertionsTask<TException>(
+            WithParameterNameAsync(assertions.AsTask(), paramName, because, becauseArgs));
+    }
+
+    private static async Task<ExceptionAssertions<TException>> WithParameterNameAsync<TException>(
+        Task<ExceptionAssertions<TException>> task,
+        string paramName,
+        string because,
+        object[] becauseArgs)
+        where TException : ArgumentException
+    {
+        return (await task).WithParameterName(paramName, because, becauseArgs);
+    }
+
 #pragma warning restore AV1755
 }

--- a/Src/AwesomeAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/AwesomeAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -91,8 +91,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     /// <returns>
     /// Returns an object that allows asserting additional members of the thrown exception.
     /// </returns>
-    public async Task<ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(
+    public ExceptionAssertionsTask<TException> ThrowExactlyAsync<TException>(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        where TException : Exception
+    {
+        return new ExceptionAssertionsTask<TException>(ThrowExactlyCoreAsync<TException>(because, becauseArgs));
+    }
+
+    private async Task<ExceptionAssertions<TException>> ThrowExactlyCoreAsync<TException>(
+        string because, object[] becauseArgs)
         where TException : Exception
     {
         Type expectedType = typeof(TException);
@@ -133,8 +140,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public async Task<ExceptionAssertions<TException>> ThrowAsync<TException>(
+    public ExceptionAssertionsTask<TException> ThrowAsync<TException>(
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        where TException : Exception
+    {
+        return new ExceptionAssertionsTask<TException>(ThrowCoreAsync<TException>(because, becauseArgs));
+    }
+
+    private async Task<ExceptionAssertions<TException>> ThrowCoreAsync<TException>(
+        string because, object[] becauseArgs)
         where TException : Exception
     {
         assertionChain
@@ -164,8 +178,15 @@ public class AsyncFunctionAssertions<TTask, TAssertions> : DelegateAssertionsBas
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because" />.
     /// </param>
-    public async Task<ExceptionAssertions<TException>> ThrowWithinAsync<TException>(TimeSpan timeSpan,
+    public ExceptionAssertionsTask<TException> ThrowWithinAsync<TException>(TimeSpan timeSpan,
         [StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        where TException : Exception
+    {
+        return new ExceptionAssertionsTask<TException>(ThrowWithinCoreAsync<TException>(timeSpan, because, becauseArgs));
+    }
+
+    private async Task<ExceptionAssertions<TException>> ThrowWithinCoreAsync<TException>(TimeSpan timeSpan,
+        string because, object[] becauseArgs)
         where TException : Exception
     {
         assertionChain

--- a/Src/AwesomeAssertions/Specialized/ExceptionAssertionsTask.cs
+++ b/Src/AwesomeAssertions/Specialized/ExceptionAssertionsTask.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
@@ -203,63 +202,6 @@ public sealed class ExceptionAssertionsTask<TException>
         params object[] becauseArgs)
     {
         return ContinueWith(assertions => assertions.WithInnerExceptionExactly(innerException, because, becauseArgs));
-    }
-
-    /// <summary>
-    /// Asserts that the thrown exception contains an inner exception of type <typeparamref name="TInnerException" />.
-    /// </summary>
-    /// <typeparam name="TOuterException">
-    /// The type of the thrown exception. This type parameter is redundant and is ignored.
-    /// </typeparam>
-    /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    /// <remarks>
-    /// This overload only exists to keep code compiling that had to name the thrown exception type explicitly.
-    /// Use <see cref="WithInnerException{TInnerException}"/> instead.
-    /// </remarks>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>(
-        [StringSyntax("CompositeFormat")] string because = "",
-        params object[] becauseArgs)
-        where TOuterException : Exception
-        where TInnerException : Exception
-    {
-        return WithInnerException<TInnerException>(because, becauseArgs);
-    }
-
-    /// <summary>
-    /// Asserts that the thrown exception contains an inner exception of the exact type
-    /// <typeparamref name="TInnerException" /> (and not a derived exception type).
-    /// </summary>
-    /// <typeparam name="TOuterException">
-    /// The type of the thrown exception. This type parameter is redundant and is ignored.
-    /// </typeparam>
-    /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-    /// </param>
-    /// <remarks>
-    /// This overload only exists to keep code compiling that had to name the thrown exception type explicitly.
-    /// Use <see cref="WithInnerExceptionExactly{TInnerException}"/> instead.
-    /// </remarks>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>(
-        [StringSyntax("CompositeFormat")] string because = "",
-        params object[] becauseArgs)
-        where TOuterException : Exception
-        where TInnerException : Exception
-    {
-        return WithInnerExceptionExactly<TInnerException>(because, becauseArgs);
     }
 
     private ExceptionAssertionsTask<TResult> ContinueWith<TResult>(

--- a/Src/AwesomeAssertions/Specialized/ExceptionAssertionsTask.cs
+++ b/Src/AwesomeAssertions/Specialized/ExceptionAssertionsTask.cs
@@ -1,0 +1,279 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using AwesomeAssertions.Common;
+
+namespace AwesomeAssertions.Specialized;
+
+/// <summary>
+/// Represents the awaitable outcome of an asynchronous exception assertion, such as
+/// <see cref="AsyncFunctionAssertions{TTask,TAssertions}.ThrowAsync{TException}"/>.
+/// </summary>
+/// <typeparam name="TException">The type of the thrown exception.</typeparam>
+/// <remarks>
+/// Awaiting an instance of this type yields the <see cref="ExceptionAssertions{TException}"/> of the thrown exception,
+/// so it can be used wherever a <see cref="Task{TResult}"/> was expected before.
+/// <para>
+/// Since <typeparamref name="TException"/> is part of this type instead of being inferred from an argument,
+/// assertions about the inner exception take a single type parameter, just like their synchronous counterparts.
+/// </para>
+/// </remarks>
+[DebuggerNonUserCode]
+public sealed class ExceptionAssertionsTask<TException>
+    where TException : Exception
+{
+    private readonly Task<ExceptionAssertions<TException>> task;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExceptionAssertionsTask{TException}"/> class.
+    /// </summary>
+    /// <param name="task">The task providing the <see cref="ExceptionAssertions{TException}"/> to continue on.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="task"/> is <see langword="null"/>.</exception>
+    public ExceptionAssertionsTask(Task<ExceptionAssertions<TException>> task)
+    {
+        Guard.ThrowIfArgumentIsNull(task);
+
+        this.task = task;
+    }
+
+    /// <summary>
+    /// Converts the assertion into the <see cref="Task{TResult}"/> it wraps.
+    /// </summary>
+    /// <remarks>
+    /// This conversion is not merely convenient, it carries source compatibility: it keeps code compiling that uses the
+    /// outcome where a <see cref="Task"/> is expected, such as assigning the assertion chain to a <c>Func&lt;Task&gt;</c>
+    /// or passing it to <see cref="Task.WhenAll(Task[])"/>. Removing it is a breaking change.
+    /// </remarks>
+    public static implicit operator Task<ExceptionAssertions<TException>>(ExceptionAssertionsTask<TException> assertions)
+    {
+        Guard.ThrowIfArgumentIsNull(assertions);
+
+        return assertions.task;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="Task{TResult}"/> this assertion wraps, as the named alternative to the implicit conversion.
+    /// </summary>
+    /// <remarks>
+    /// Needed to hand the outcome to code that requires an actual <see cref="Task{TResult}"/>. In particular, own
+    /// extension methods on <c>Task&lt;ExceptionAssertions&lt;TException&gt;&gt;</c> are not found on this type, because
+    /// extension method lookup never applies the implicit conversion declared above. Inserting <c>AsTask()</c> makes
+    /// them available again.
+    /// </remarks>
+    public Task<ExceptionAssertions<TException>> AsTask() => task;
+
+    /// <summary>
+    /// Gets an awaiter used to await the <see cref="ExceptionAssertions{TException}"/> of the thrown exception.
+    /// </summary>
+    /// <remarks>
+    /// This is what makes the assertion awaitable, as in <c>await action.Should().ThrowAsync&lt;TException&gt;()</c>.
+    /// It satisfies the awaitable pattern the compiler looks for by convention; no interface is involved.
+    /// </remarks>
+    public TaskAwaiter<ExceptionAssertions<TException>> GetAwaiter() => task.GetAwaiter();
+
+    /// <summary>
+    /// Configures how the awaited continuation is scheduled.
+    /// </summary>
+    /// <param name="continueOnCapturedContext">
+    /// <see langword="true"/> to attempt to marshal the continuation back to the captured original context;
+    /// otherwise <see langword="false"/>.
+    /// </param>
+    public ConfiguredTaskAwaitable<ExceptionAssertions<TException>> ConfigureAwait(bool continueOnCapturedContext) =>
+        task.ConfigureAwait(continueOnCapturedContext);
+
+    /// <summary>
+    /// Asserts that the thrown exception has a message that matches <paramref name="expectedWildcardPattern" />.
+    /// </summary>
+    /// <param name="expectedWildcardPattern">
+    /// The wildcard pattern with which the exception message is matched, where * and ? have special meanings.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+    /// </param>
+    public ExceptionAssertionsTask<TException> WithMessage(
+        string expectedWildcardPattern,
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+    {
+        return ContinueWith(assertions => assertions.WithMessage(expectedWildcardPattern, because, becauseArgs));
+    }
+
+    /// <summary>
+    /// Asserts that the exception matches a particular condition.
+    /// </summary>
+    /// <param name="exceptionExpression">
+    /// The condition that the exception must match.
+    /// </param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+    /// </param>
+    public ExceptionAssertionsTask<TException> Where(
+        Expression<Func<TException, bool>> exceptionExpression,
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+    {
+        return ContinueWith(assertions => assertions.Where(exceptionExpression, because, becauseArgs));
+    }
+
+    /// <summary>
+    /// Asserts that the thrown exception contains an inner exception of type <typeparamref name="TInnerException" />.
+    /// </summary>
+    /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public ExceptionAssertionsTask<TInnerException> WithInnerException<TInnerException>(
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+        where TInnerException : Exception
+    {
+        return ContinueWith(assertions => assertions.WithInnerException<TInnerException>(because, becauseArgs));
+    }
+
+    /// <summary>
+    /// Asserts that the thrown exception contains an inner exception of type <paramref name="innerException" />.
+    /// </summary>
+    /// <param name="innerException">The expected type of the inner exception.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public ExceptionAssertionsTask<Exception> WithInnerException(
+        Type innerException,
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+    {
+        return ContinueWith(assertions => assertions.WithInnerException(innerException, because, becauseArgs));
+    }
+
+    /// <summary>
+    /// Asserts that the thrown exception contains an inner exception of the exact type
+    /// <typeparamref name="TInnerException" /> (and not a derived exception type).
+    /// </summary>
+    /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TInnerException>(
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+        where TInnerException : Exception
+    {
+        return ContinueWith(assertions => assertions.WithInnerExceptionExactly<TInnerException>(because, becauseArgs));
+    }
+
+    /// <summary>
+    /// Asserts that the thrown exception contains an inner exception of the exact type
+    /// <paramref name="innerException" /> (and not a derived exception type).
+    /// </summary>
+    /// <param name="innerException">The expected type of the inner exception.</param>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    public ExceptionAssertionsTask<Exception> WithInnerExceptionExactly(
+        Type innerException,
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+    {
+        return ContinueWith(assertions => assertions.WithInnerExceptionExactly(innerException, because, becauseArgs));
+    }
+
+    /// <summary>
+    /// Asserts that the thrown exception contains an inner exception of type <typeparamref name="TInnerException" />.
+    /// </summary>
+    /// <typeparam name="TOuterException">
+    /// The type of the thrown exception. This type parameter is redundant and is ignored.
+    /// </typeparam>
+    /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <remarks>
+    /// This overload only exists to keep code compiling that had to name the thrown exception type explicitly.
+    /// Use <see cref="WithInnerException{TInnerException}"/> instead.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>(
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+        where TOuterException : Exception
+        where TInnerException : Exception
+    {
+        return WithInnerException<TInnerException>(because, becauseArgs);
+    }
+
+    /// <summary>
+    /// Asserts that the thrown exception contains an inner exception of the exact type
+    /// <typeparamref name="TInnerException" /> (and not a derived exception type).
+    /// </summary>
+    /// <typeparam name="TOuterException">
+    /// The type of the thrown exception. This type parameter is redundant and is ignored.
+    /// </typeparam>
+    /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+    /// </param>
+    /// <remarks>
+    /// This overload only exists to keep code compiling that had to name the thrown exception type explicitly.
+    /// Use <see cref="WithInnerExceptionExactly{TInnerException}"/> instead.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>(
+        [StringSyntax("CompositeFormat")] string because = "",
+        params object[] becauseArgs)
+        where TOuterException : Exception
+        where TInnerException : Exception
+    {
+        return WithInnerExceptionExactly<TInnerException>(because, becauseArgs);
+    }
+
+    private ExceptionAssertionsTask<TResult> ContinueWith<TResult>(
+        Func<ExceptionAssertions<TException>, ExceptionAssertions<TResult>> assertion)
+        where TResult : Exception
+    {
+        return new ExceptionAssertionsTask<TResult>(AssertAsync(task, assertion));
+    }
+
+    private static async Task<ExceptionAssertions<TResult>> AssertAsync<TResult>(
+        Task<ExceptionAssertions<TException>> task,
+        Func<ExceptionAssertions<TException>, ExceptionAssertions<TResult>> assertion)
+        where TResult : Exception
+    {
+        return assertion(await task);
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
@@ -391,6 +391,8 @@ namespace AwesomeAssertions
             where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
         public static AwesomeAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
@@ -2729,11 +2731,11 @@ namespace AwesomeAssertions.Specialized
         public System.Threading.Tasks.Task<AwesomeAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<AwesomeAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
     public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : AwesomeAssertions.Primitives.ReferenceTypeAssertions<TDelegate, AwesomeAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
@@ -2761,6 +2763,29 @@ namespace AwesomeAssertions.Specialized
             where TException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+    }
+    public sealed class ExceptionAssertionsTask<TException>
+        where TException : System.Exception
+    {
+        public ExceptionAssertionsTask(System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task) { }
+        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> AsTask() { }
+        public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ConfigureAwait(bool continueOnCapturedContext) { }
+        public System.Runtime.CompilerServices.TaskAwaiter<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> GetAwaiter() { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerException(System.Type innerException, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TInnerException>(string because = "", params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
+            where TOuterException : System.Exception
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerExceptionExactly(System.Type innerException, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = "", params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
+            where TOuterException : System.Exception
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> op_Implicit(AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions) { }
     }
     public class ExceptionAssertions<TException> : AwesomeAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, AwesomeAssertions.Specialized.ExceptionAssertions<TException>>
         where TException : System.Exception

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
@@ -377,25 +377,11 @@ namespace AwesomeAssertions
     }
     public static class ExceptionAssertionsExtensions
     {
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> Where<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerException<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
-            where TException : System.Exception
-            where TInnerException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerExceptionExactly<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
-            where TException : System.Exception
-            where TInnerException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+        public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> AsExceptionAssertionsTask<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task)
             where TException : System.Exception { }
         public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions, string paramName, string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
         public static AwesomeAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
-            where TException : System.ArgumentException { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
     }
     public static class FluentActions
@@ -2775,14 +2761,8 @@ namespace AwesomeAssertions.Specialized
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerException(System.Type innerException, string because = "", params object[] becauseArgs) { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TInnerException>(string because = "", params object[] becauseArgs)
             where TInnerException : System.Exception { }
-        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
-            where TOuterException : System.Exception
-            where TInnerException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerExceptionExactly(System.Type innerException, string because = "", params object[] becauseArgs) { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = "", params object[] becauseArgs)
-            where TInnerException : System.Exception { }
-        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
-            where TOuterException : System.Exception
             where TInnerException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> op_Implicit(AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions) { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -400,25 +400,11 @@ namespace AwesomeAssertions
     }
     public static class ExceptionAssertionsExtensions
     {
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> Where<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerException<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-            where TException : System.Exception
-            where TInnerException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerExceptionExactly<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-            where TException : System.Exception
-            where TInnerException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> AsExceptionAssertionsTask<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task)
             where TException : System.Exception { }
         public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions, string paramName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
         public static AwesomeAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-            where TException : System.ArgumentException { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
     }
     public static class FluentActions
@@ -2991,14 +2977,8 @@ namespace AwesomeAssertions.Specialized
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerException(System.Type innerException, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TInnerException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TInnerException : System.Exception { }
-        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-            where TOuterException : System.Exception
-            where TInnerException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerExceptionExactly(System.Type innerException, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TInnerException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-            where TInnerException : System.Exception { }
-        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
-            where TOuterException : System.Exception
             where TInnerException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithMessage(string expectedWildcardPattern, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> op_Implicit(AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions) { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -414,6 +414,8 @@ namespace AwesomeAssertions
             where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions, string paramName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
         public static AwesomeAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
@@ -2945,11 +2947,11 @@ namespace AwesomeAssertions.Specialized
         public System.Threading.Tasks.Task<AwesomeAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<AwesomeAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowAsync<TException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowExactlyAsync<TException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
     public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : AwesomeAssertions.Primitives.ReferenceTypeAssertions<TDelegate, AwesomeAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
@@ -2977,6 +2979,29 @@ namespace AwesomeAssertions.Specialized
             where TException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+    }
+    public sealed class ExceptionAssertionsTask<TException>
+        where TException : System.Exception
+    {
+        public ExceptionAssertionsTask(System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task) { }
+        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> AsTask() { }
+        public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ConfigureAwait(bool continueOnCapturedContext) { }
+        public System.Runtime.CompilerServices.TaskAwaiter<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> GetAwaiter() { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerException(System.Type innerException, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TInnerException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+            where TOuterException : System.Exception
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerExceptionExactly(System.Type innerException, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TInnerException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>([System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
+            where TOuterException : System.Exception
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithMessage(string expectedWildcardPattern, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> op_Implicit(AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions) { }
     }
     public class ExceptionAssertions<TException> : AwesomeAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, AwesomeAssertions.Specialized.ExceptionAssertions<TException>>
         where TException : System.Exception

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -367,25 +367,11 @@ namespace AwesomeAssertions
     }
     public static class ExceptionAssertionsExtensions
     {
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> Where<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerException<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
-            where TException : System.Exception
-            where TInnerException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerExceptionExactly<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
-            where TException : System.Exception
-            where TInnerException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+        public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> AsExceptionAssertionsTask<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task)
             where TException : System.Exception { }
         public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions, string paramName, string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
         public static AwesomeAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
-            where TException : System.ArgumentException { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
     }
     public static class FluentActions
@@ -2717,14 +2703,8 @@ namespace AwesomeAssertions.Specialized
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerException(System.Type innerException, string because = "", params object[] becauseArgs) { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TInnerException>(string because = "", params object[] becauseArgs)
             where TInnerException : System.Exception { }
-        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
-            where TOuterException : System.Exception
-            where TInnerException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerExceptionExactly(System.Type innerException, string because = "", params object[] becauseArgs) { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = "", params object[] becauseArgs)
-            where TInnerException : System.Exception { }
-        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
-            where TOuterException : System.Exception
             where TInnerException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> op_Implicit(AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions) { }

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -381,6 +381,8 @@ namespace AwesomeAssertions
             where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
         public static AwesomeAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
@@ -2671,11 +2673,11 @@ namespace AwesomeAssertions.Specialized
         public System.Threading.Tasks.Task<AwesomeAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<AwesomeAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
     public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : AwesomeAssertions.Primitives.ReferenceTypeAssertions<TDelegate, AwesomeAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
@@ -2703,6 +2705,29 @@ namespace AwesomeAssertions.Specialized
             where TException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+    }
+    public sealed class ExceptionAssertionsTask<TException>
+        where TException : System.Exception
+    {
+        public ExceptionAssertionsTask(System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task) { }
+        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> AsTask() { }
+        public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ConfigureAwait(bool continueOnCapturedContext) { }
+        public System.Runtime.CompilerServices.TaskAwaiter<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> GetAwaiter() { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerException(System.Type innerException, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TInnerException>(string because = "", params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
+            where TOuterException : System.Exception
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerExceptionExactly(System.Type innerException, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = "", params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
+            where TOuterException : System.Exception
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> op_Implicit(AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions) { }
     }
     public class ExceptionAssertions<TException> : AwesomeAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, AwesomeAssertions.Specialized.ExceptionAssertions<TException>>
         where TException : System.Exception

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -391,6 +391,8 @@ namespace AwesomeAssertions
             where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
         public static AwesomeAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
@@ -2729,11 +2731,11 @@ namespace AwesomeAssertions.Specialized
         public System.Threading.Tasks.Task<AwesomeAssertions.AndConstraint<TAssertions>> NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<AwesomeAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> ThrowWithinAsync<TException>(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
     public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : AwesomeAssertions.Primitives.ReferenceTypeAssertions<TDelegate, AwesomeAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
@@ -2761,6 +2763,29 @@ namespace AwesomeAssertions.Specialized
             where TException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+    }
+    public sealed class ExceptionAssertionsTask<TException>
+        where TException : System.Exception
+    {
+        public ExceptionAssertionsTask(System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task) { }
+        public System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> AsTask() { }
+        public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> ConfigureAwait(bool continueOnCapturedContext) { }
+        public System.Runtime.CompilerServices.TaskAwaiter<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> GetAwaiter() { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerException(System.Type innerException, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TInnerException>(string because = "", params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
+            where TOuterException : System.Exception
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerExceptionExactly(System.Type innerException, string because = "", params object[] becauseArgs) { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = "", params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
+            where TOuterException : System.Exception
+            where TInnerException : System.Exception { }
+        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> op_Implicit(AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions) { }
     }
     public class ExceptionAssertions<TException> : AwesomeAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, AwesomeAssertions.Specialized.ExceptionAssertions<TException>>
         where TException : System.Exception

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -377,25 +377,11 @@ namespace AwesomeAssertions
     }
     public static class ExceptionAssertionsExtensions
     {
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> Where<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerException<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
-            where TException : System.Exception
-            where TInnerException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<System.Exception>> WithInnerExceptionExactly<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, System.Type innerException, string because = "", params object[] becauseArgs)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
-            where TException : System.Exception
-            where TInnerException : System.Exception { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+        public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> AsExceptionAssertionsTask<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task)
             where TException : System.Exception { }
         public static AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions, string paramName, string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
         public static AwesomeAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this AwesomeAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
-            where TException : System.ArgumentException { }
-        public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
             where TException : System.ArgumentException { }
     }
     public static class FluentActions
@@ -2775,14 +2761,8 @@ namespace AwesomeAssertions.Specialized
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerException(System.Type innerException, string because = "", params object[] becauseArgs) { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TInnerException>(string because = "", params object[] becauseArgs)
             where TInnerException : System.Exception { }
-        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerException<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
-            where TOuterException : System.Exception
-            where TInnerException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<System.Exception> WithInnerExceptionExactly(System.Type innerException, string because = "", params object[] becauseArgs) { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = "", params object[] becauseArgs)
-            where TInnerException : System.Exception { }
-        public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TInnerException> WithInnerExceptionExactly<TOuterException, TInnerException>(string because = "", params object[] becauseArgs)
-            where TOuterException : System.Exception
             where TInnerException : System.Exception { }
         public AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
         public static System.Threading.Tasks.Task<AwesomeAssertions.Specialized.ExceptionAssertions<TException>> op_Implicit(AwesomeAssertions.Specialized.ExceptionAssertionsTask<TException> assertions) { }

--- a/Tests/AwesomeAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 using AwesomeAssertions.Execution;
 using AwesomeAssertions.Extensions;
+using AwesomeAssertions.Specialized;
 #if NETFRAMEWORK
 using AwesomeAssertions.Specs.Common;
 #endif
@@ -1356,6 +1357,225 @@ public class AsyncFunctionExceptionAssertionSpecs
     }
 
     #endregion
+
+    public class WithInnerException
+    {
+        [Fact]
+        public async Task Can_be_used_with_a_single_type_parameter()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+            await subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerException<InvalidOperationException>();
+        }
+
+        [Fact]
+        public async Task Can_be_used_with_a_single_type_parameter_after_an_exact_throw()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+            await subject.Should().ThrowExactlyAsync<AggregateException>()
+                .WithInnerException<InvalidOperationException>();
+        }
+
+        [Fact]
+        public async Task Can_be_used_with_a_single_type_parameter_after_a_throw_within()
+        {
+            Func<Task> subject = () => Throw.Async(new InvalidOperationException("outer", new ArgumentException("inner")));
+
+            await subject.Should().ThrowWithinAsync<InvalidOperationException>(1.Seconds())
+                .WithInnerException<ArgumentException>();
+        }
+
+        [Fact]
+        public async Task Accepts_a_derived_inner_exception()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentNullException()));
+
+            await subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerException<ArgumentException>();
+        }
+
+        [Fact]
+        public async Task Fails_for_a_different_inner_exception()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+            Func<Task> act = () => subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerException<InvalidOperationException>();
+
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*InvalidOperation*Argument*");
+        }
+
+        [Fact]
+        public async Task Fails_for_a_different_inner_exception_with_a_reason()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+            Func<Task> act = () => subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerException<InvalidOperationException>("we want to test the {0} message", "failure");
+
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*InvalidOperation*because we want to test the failure message*Argument*");
+        }
+
+        [Fact]
+        public async Task Keeps_the_type_of_the_inner_exception_for_further_assertions()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentNullException("someParameter")));
+
+            await subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerException<ArgumentNullException>()
+                .WithParameterName("someParameter");
+        }
+
+        [Fact]
+        public async Task Exposes_the_inner_exception_as_the_awaited_result()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentNullException("someParameter")));
+
+            ExceptionAssertions<ArgumentNullException> assertions =
+                await subject.Should().ThrowAsync<AggregateException>()
+                    .WithInnerException<ArgumentNullException>();
+
+            assertions.Which.ParamName.Should().Be("someParameter");
+        }
+
+        [Fact]
+        public async Task Can_be_chained_for_nested_inner_exceptions()
+        {
+            Func<Task> subject = () => Throw.Async(
+                new AggregateException(new InvalidOperationException("outer", new ArgumentException("inner"))));
+
+            await subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerException<InvalidOperationException>()
+                .WithInnerException<ArgumentException>()
+                .WithMessage("inner");
+        }
+
+        [Fact]
+        public async Task Still_supports_naming_the_thrown_exception_type_explicitly()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+            await subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerException<AggregateException, InvalidOperationException>();
+        }
+    }
+
+    public class WithInnerExceptionExactly
+    {
+        [Fact]
+        public async Task Can_be_used_with_a_single_type_parameter()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+            await subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<ArgumentException>();
+        }
+
+        [Fact]
+        public async Task Rejects_a_derived_inner_exception()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentNullException()));
+
+            Func<Task> act = () => subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<ArgumentException>();
+
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*ArgumentException*ArgumentNullException*");
+        }
+
+        [Fact]
+        public async Task Fails_for_a_different_inner_exception_with_a_reason()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentNullException()));
+
+            Func<Task> act = () => subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<ArgumentException>("we want to test the {0} message", "failure");
+
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*ArgumentException*because we want to test the failure message*ArgumentNullException*");
+        }
+
+        [Fact]
+        public async Task Keeps_the_type_of_the_inner_exception_for_further_assertions()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentNullException("someParameter")));
+
+            await subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<ArgumentNullException>()
+                .WithParameterName("someParameter");
+        }
+
+        [Fact]
+        public async Task Still_supports_naming_the_thrown_exception_type_explicitly()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+            await subject.Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<AggregateException, ArgumentException>();
+        }
+    }
+
+    public class AwaitableBehavior
+    {
+        [Fact]
+        public async Task Can_be_assigned_to_the_task_it_wraps()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+            Task<ExceptionAssertions<AggregateException>> assertions = subject.Should().ThrowAsync<AggregateException>();
+
+            (await assertions).Which.InnerException.Should().BeOfType<InvalidOperationException>();
+        }
+
+        [Fact]
+        public async Task Can_be_converted_into_the_task_it_wraps()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+            Task<ExceptionAssertions<InvalidOperationException>> assertions = subject.Should()
+                .ThrowAsync<AggregateException>()
+                .WithInnerException<InvalidOperationException>()
+                .AsTask();
+
+            (await assertions).Which.Should().BeOfType<InvalidOperationException>();
+        }
+
+        [Fact]
+        public async Task Supports_configuring_the_continuation()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new InvalidOperationException()));
+
+            ExceptionAssertions<InvalidOperationException> assertions = await subject.Should()
+                .ThrowAsync<AggregateException>()
+                .WithInnerException<InvalidOperationException>()
+                .ConfigureAwait(false);
+
+            assertions.Which.Should().BeOfType<InvalidOperationException>();
+        }
+
+        [Fact]
+        public async Task Can_be_used_where_a_task_is_expected()
+        {
+            Func<Task> subject = () => Throw.Async(new InvalidOperationException());
+
+            await Task.WhenAll(
+                subject.Should().ThrowAsync<InvalidOperationException>(),
+                subject.Should().ThrowAsync<Exception>());
+        }
+
+        [Fact]
+        public void Guards_against_a_missing_task()
+        {
+            Action act = () => _ = new ExceptionAssertionsTask<Exception>(null);
+
+            act.Should().Throw<ArgumentNullException>()
+                .WithParameterName("task");
+        }
+    }
 }
 
 internal class AsyncClass

--- a/Tests/AwesomeAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -874,7 +874,7 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => task
             .Should().ThrowAsync<AggregateException>()
-            .WithInnerException<AggregateException, InvalidOperationException>();
+            .WithInnerException<InvalidOperationException>();
 
         // Assert
         await action.Should().NotThrowAsync();
@@ -904,7 +904,7 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => task
             .Should().ThrowAsync<AggregateException>()
-            .WithInnerExceptionExactly<AggregateException, ArgumentException>();
+            .WithInnerExceptionExactly<ArgumentException>();
 
         // Assert
         await action.Should().NotThrowAsync();
@@ -962,7 +962,7 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => task
             .Should().ThrowAsync<AggregateException>()
-            .WithInnerException<AggregateException, InvalidOperationException>();
+            .WithInnerException<InvalidOperationException>();
 
         // Assert
         await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
@@ -992,7 +992,7 @@ public class AsyncFunctionExceptionAssertionSpecs
         // Act
         Func<Task> action = () => task
             .Should().ThrowAsync<AggregateException>()
-            .WithInnerExceptionExactly<AggregateException, ArgumentException>();
+            .WithInnerExceptionExactly<ArgumentException>();
 
         // Assert
         await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
@@ -1453,15 +1453,6 @@ public class AsyncFunctionExceptionAssertionSpecs
                 .WithInnerException<ArgumentException>()
                 .WithMessage("inner");
         }
-
-        [Fact]
-        public async Task Still_supports_naming_the_thrown_exception_type_explicitly()
-        {
-            Func<Task> subject = () => Throw.Async(new AggregateException(new InvalidOperationException()));
-
-            await subject.Should().ThrowAsync<AggregateException>()
-                .WithInnerException<AggregateException, InvalidOperationException>();
-        }
     }
 
     public class WithInnerExceptionExactly
@@ -1507,15 +1498,6 @@ public class AsyncFunctionExceptionAssertionSpecs
             await subject.Should().ThrowAsync<AggregateException>()
                 .WithInnerExceptionExactly<ArgumentNullException>()
                 .WithParameterName("someParameter");
-        }
-
-        [Fact]
-        public async Task Still_supports_naming_the_thrown_exception_type_explicitly()
-        {
-            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentException()));
-
-            await subject.Should().ThrowAsync<AggregateException>()
-                .WithInnerExceptionExactly<AggregateException, ArgumentException>();
         }
     }
 
@@ -1574,6 +1556,37 @@ public class AsyncFunctionExceptionAssertionSpecs
 
             act.Should().Throw<ArgumentNullException>()
                 .WithParameterName("task");
+        }
+    }
+
+    public class AsExceptionAssertionsTask
+    {
+        [Fact]
+        public async Task Continues_on_a_task_that_a_throw_assertion_did_not_produce()
+        {
+            Task<ExceptionAssertions<AggregateException>> assertions = ThrowingHelper();
+
+            await assertions.AsExceptionAssertionsTask()
+                .WithInnerException<ArgumentNullException>()
+                .WithParameterName("someParameter");
+        }
+
+        [Fact]
+        public void Guards_against_a_missing_task()
+        {
+            Task<ExceptionAssertions<Exception>> assertions = null;
+
+            Action act = () => _ = assertions.AsExceptionAssertionsTask();
+
+            act.Should().Throw<ArgumentNullException>()
+                .WithParameterName("task");
+        }
+
+        private static async Task<ExceptionAssertions<AggregateException>> ThrowingHelper()
+        {
+            Func<Task> subject = () => Throw.Async(new AggregateException(new ArgumentNullException("someParameter")));
+
+            return await subject.Should().ThrowAsync<AggregateException>();
         }
     }
 }

--- a/docs/_pages/exceptions.md
+++ b/docs/_pages/exceptions.md
@@ -121,6 +121,16 @@ await act.Should().ThrowAsync<ArgumentException>();
 
 Both give you the same results, so it's just a matter of personal preference.
 
+The asynchronous assertions can be chained in the same way as the synchronous ones:
+
+```csharp
+var act = () => asyncObject.ThrowAsync(new InvalidOperationException("outer", new ArgumentException("inner")));
+
+await act.Should().ThrowAsync<InvalidOperationException>()
+    .WithInnerException<ArgumentException>()
+    .WithMessage("inner");
+```
+
 As for synchronous methods, you can also check that an asynchronously executed method executes successfully after a given wait time using `NotThrowAfter`:
 
 ```csharp

--- a/docs/_pages/exceptions.md
+++ b/docs/_pages/exceptions.md
@@ -131,6 +131,15 @@ await act.Should().ThrowAsync<InvalidOperationException>()
     .WithMessage("inner");
 ```
 
+This works because the asynchronous assertions return an `ExceptionAssertionsTask<TException>` rather than a plain task. If you have a `Task<ExceptionAssertions<TException>>` from somewhere else, for instance from a helper method of your own, `AsExceptionAssertionsTask` gets you back into the chain:
+
+```csharp
+Task<ExceptionAssertions<InvalidOperationException>> assertions = MyOwnHelper();
+
+await assertions.AsExceptionAssertionsTask()
+    .WithInnerException<ArgumentException>();
+```
+
 As for synchronous methods, you can also check that an asynchronously executed method executes successfully after a given wait time using `NotThrowAfter`:
 
 ```csharp

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -8,15 +8,20 @@ sidebar:
 ---
 ## Unreleased
 
+### Improvements
+* `ThrowAsync`, `ThrowExactlyAsync` and `ThrowWithinAsync` now return `ExceptionAssertionsTask<TException>`, so that `WithInnerException<TInnerException>` and `WithInnerExceptionExactly<TInnerException>` can be used with a single type parameter, just like their synchronous counterparts - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
+* The comparison of `WithParameterName` is now case-insensitive - [#610](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/610)
+
+### Deprecations
+* Deprecate `ExceptionAssertionsTask.WithInnerException<TException, TInnerException>` and `ExceptionAssertionsTask.WithInnerExceptionExactly<TException, TInnerException>` in favor of their single type parameter versions - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
+
 ### Breaking Changes (for users)
 * Removed support for the target framework .NET 6 - [#603](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/603)
 * Upgraded the minimum target for .NET Framework to 4.7.2 - [#603](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/603)
 * The reference to `System.Threading.Tasks.Extensions` to has been upgraded to version 4.6.3 - [#603](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/603)
 * Enable [PureAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.pureattribute) in the public API - [#605](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/605)
   * It is declared as a breaking change because it may raise warnings like [CA1806](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1806).
-
-### Improvements
-* The comparison of `WithParameterName` is now case-insensitive - [#610](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/610)
+* The result of `ThrowAsync`, `ThrowExactlyAsync` and `ThrowWithinAsync` has changed to `ExceptionAssertionsTask<TException>` instead of `Task<ExceptionAssertions<TException>>`. - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
 
 ## 9.6.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,10 +10,8 @@ sidebar:
 
 ### Improvements
 * `ThrowAsync`, `ThrowExactlyAsync` and `ThrowWithinAsync` now return `ExceptionAssertionsTask<TException>`, so that `WithInnerException<TInnerException>` and `WithInnerExceptionExactly<TInnerException>` can be used with a single type parameter, just like their synchronous counterparts - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
+* Add `AsExceptionAssertionsTask` to continue asserting on a `Task<ExceptionAssertions<TException>>` that none of the `ThrowAsync` assertions produced, such as the result of your own helper method - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
 * The comparison of `WithParameterName` is now case-insensitive - [#610](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/610)
-
-### Deprecations
-* Deprecate `ExceptionAssertionsTask.WithInnerException<TException, TInnerException>` and `ExceptionAssertionsTask.WithInnerExceptionExactly<TException, TInnerException>` in favor of their single type parameter versions - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
 
 ### Breaking Changes (for users)
 * Removed support for the target framework .NET 6 - [#603](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/603)
@@ -22,6 +20,11 @@ sidebar:
 * Enable [PureAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.pureattribute) in the public API - [#605](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/605)
   * It is declared as a breaking change because it may raise warnings like [CA1806](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1806).
 * The result of `ThrowAsync`, `ThrowExactlyAsync` and `ThrowWithinAsync` has changed to `ExceptionAssertionsTask<TException>` instead of `Task<ExceptionAssertions<TException>>`. - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
+  * This allows the use of `WithInnerException` and `WithInnerExceptionExactly` with a single type parameter, just like their synchronous counterparts.
+* Removed the extension methods on `Task<ExceptionAssertions<TException>>` (`WithMessage`, `Where`, `WithInnerException`, `WithInnerExceptionExactly` and `WithParameterName`), since none of the assertions returns that type anymore. - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
+  * Use the members of `ExceptionAssertionsTask<TException>` instead, or `AsExceptionAssertionsTask` when you start from a task of your own.
+* Removed `ExceptionAssertionsTask.WithInnerException<TException, TInnerException>` and `ExceptionAssertionsTask.WithInnerExceptionExactly<TException, TInnerException>` in favor of their single type parameter versions - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
+  * Just remove the first type parameter.
 
 ## 9.6.0
 


### PR DESCRIPTION
Implements #340 .

With the help of "Claude AI" I finally found a solution for the described problem.
But, it is a breaking change. So, we must target the fix to v10.
Anyway, the required changes are not that much, as you can see in the list of changed tests.

## IMPORTANT 

* [x] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [x] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
