### PR TITLE
v10: Enable PureAttribute in public API

### DIFF
--- a/Src/AwesomeAssertions/AssertionExtensions.cs
+++ b/Src/AwesomeAssertions/AssertionExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -17,11 +18,10 @@ using AwesomeAssertions.Specialized;
 using AwesomeAssertions.Streams;
 using AwesomeAssertions.Types;
 using AwesomeAssertions.Xml;
-using JetBrains.Annotations;
-using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 #if !NETSTANDARD2_0
 using AwesomeAssertions.Events;
 #endif
+using MustUseReturnValueAttribute = JetBrains.Annotations.MustUseReturnValueAttribute;
 
 namespace AwesomeAssertions;
 
@@ -968,7 +968,7 @@ public static class AssertionExtensions
     [return: NotNull]
     public static IMonitor<T> Monitor<T>(this T eventSource, Action<EventMonitorOptions> configureOptions)
     {
-        Guard.ThrowIfArgumentIsNull(configureOptions, nameof(configureOptions));
+        Guard.ThrowIfArgumentIsNull(configureOptions);
 
         var options = new EventMonitorOptions();
         configureOptions(options);

--- a/Src/AwesomeAssertions/AwesomeAssertions.csproj
+++ b/Src/AwesomeAssertions/AwesomeAssertions.csproj
@@ -16,6 +16,13 @@
     <Product>AwesomeAssertions</Product>
   </PropertyGroup>
 
+  <PropertyGroup Label="Contract">
+    <!-- Emit System.Diagnostics.Contracts attributes (e.g. [Pure]); they are [Conditional("CONTRACTS_FULL")]
+     and are otherwise stripped at compile time. No Contract.Requires/Ensures/... calls exist in the code,
+     so this only affects attribute emission, not runtime behaviour. -->
+    <DefineConstants>$(DefineConstants);CONTRACTS_FULL</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Label="Package info">
     <Authors>AwesomeAssertions, Dennis Doomen, Jonas Nyrup and contributors</Authors>
     <PackageDescription>

--- a/Src/AwesomeAssertions/FluentActions.cs
+++ b/Src/AwesomeAssertions/FluentActions.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 
 namespace AwesomeAssertions;
 

--- a/Src/AwesomeAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/DateTimeAssertions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using AwesomeAssertions.Common;
 using AwesomeAssertions.Execution;
@@ -755,6 +756,7 @@ public class DateTimeAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTime"/>  should exceed compared to another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.MoreThan,
@@ -769,6 +771,7 @@ public class DateTimeAssertions<TAssertions>
     /// The amount of time that the current <see cref="DateTime"/>  should be equal or exceed compared to
     /// another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.AtLeast,
@@ -782,6 +785,7 @@ public class DateTimeAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTime"/>  should differ exactly compared to another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.Exactly,
@@ -795,6 +799,7 @@ public class DateTimeAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTime"/>  should be within another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.Within,
@@ -808,6 +813,7 @@ public class DateTimeAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The maximum amount of time that the current <see cref="DateTime"/>  should differ compared to another <see cref="DateTime"/>.
     /// </param>
+    [Pure]
     public DateTimeRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
     {
         return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject, TimeSpanCondition.LessThan,

--- a/Src/AwesomeAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/AwesomeAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using AwesomeAssertions.Common;
 using AwesomeAssertions.Execution;
@@ -945,6 +946,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTimeOffset"/> should exceed compared to another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
@@ -959,6 +961,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// The amount of time that the current <see cref="DateTimeOffset"/> should be equal or exceed compared to
     /// another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
@@ -972,6 +975,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTimeOffset"/> should differ exactly compared to another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
@@ -985,6 +989,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The amount of time that the current <see cref="DateTimeOffset"/> should be within another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,
@@ -998,6 +1003,7 @@ public class DateTimeOffsetAssertions<TAssertions>
     /// <param name="timeSpan">
     /// The maximum amount of time that the current <see cref="DateTimeOffset"/> should differ compared to another <see cref="DateTimeOffset"/>.
     /// </param>
+    [Pure]
     public DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
     {
         return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, CurrentAssertionChain, Subject,

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
@@ -36,17 +36,24 @@ namespace AwesomeAssertions
     }
     public static class AssertionExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         public static TTo As<TTo>(this object subject) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -57,13 +64,16 @@ namespace AwesomeAssertions
         public static AwesomeAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, AwesomeAssertions.Common.StartTimer createTimer = null) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action, AwesomeAssertions.Common.StartTimer createTimer = null) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource, System.Action<AwesomeAssertions.Events.EventMonitorOptions> configureOptions) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.ExecutionTimeAssertions Should(this AwesomeAssertions.Specialized.ExecutionTime executionTime) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -72,115 +82,166 @@ namespace AwesomeAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoSelectorAssertions Should(this AwesomeAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.MethodInfoSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoSelectorAssertions Should(this AwesomeAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.PropertyInfoSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.TypeSelectorAssertions Should(this AwesomeAssertions.Types.TypeSelector typeSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.TypeSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.ActionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Action action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.StringCollectionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<string> @this) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableDateTimeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTime? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableDateTimeOffsetAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTimeOffset? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.ParameterInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ParameterInfo parameterInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableSimpleTimeSpanAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.TimeSpan? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.TypeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Type subject) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XAttributeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XAttribute actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XDocumentAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XDocument actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XElement actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableBooleanAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this bool? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<byte> Should([System.Diagnostics.CodeAnalysis.NotNull] this byte? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<decimal> Should([System.Diagnostics.CodeAnalysis.NotNull] this decimal? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<double> Should([System.Diagnostics.CodeAnalysis.NotNull] this double? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<float> Should([System.Diagnostics.CodeAnalysis.NotNull] this float? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<int> Should([System.Diagnostics.CodeAnalysis.NotNull] this int? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<long> Should([System.Diagnostics.CodeAnalysis.NotNull] this long? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.ObjectAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this object actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<sbyte> Should([System.Diagnostics.CodeAnalysis.NotNull] this sbyte? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<short> Should([System.Diagnostics.CodeAnalysis.NotNull] this short? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.StringAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this string actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<uint> Should([System.Diagnostics.CodeAnalysis.NotNull] this uint? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<ulong> Should([System.Diagnostics.CodeAnalysis.NotNull] this ulong? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<ushort> Should([System.Diagnostics.CodeAnalysis.NotNull] this ushort? actualValue) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -211,14 +272,19 @@ namespace AwesomeAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this AwesomeAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : AwesomeAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -235,10 +301,13 @@ namespace AwesomeAssertions
             "ly following \'And\'", true)]
         public static void Should<TSubject, TAssertions>(this AwesomeAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> _)
             where TAssertions : AwesomeAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this TCollection actualValue)
             where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
@@ -284,9 +353,11 @@ namespace AwesomeAssertions
     }
     public static class EnumAssertionsExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
             where TEnum :  struct, System.Enum { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>([System.Diagnostics.CodeAnalysis.NotNull] this TEnum? @enum)
             where TEnum :  struct, System.Enum { }
@@ -327,11 +398,17 @@ namespace AwesomeAssertions
     }
     public static class FluentActions
     {
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Invoking(System.Action action) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<T> Invoking<T>(System.Func<T> func) { }
     }
     public static class LessThan
@@ -1993,15 +2070,19 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -2017,6 +2098,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -2078,17 +2160,21 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -2104,6 +2190,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -36,17 +36,24 @@ namespace AwesomeAssertions
     }
     public static class AssertionExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         public static TTo As<TTo>(this object subject) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -57,13 +64,16 @@ namespace AwesomeAssertions
         public static AwesomeAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, AwesomeAssertions.Common.StartTimer createTimer = null) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action, AwesomeAssertions.Common.StartTimer createTimer = null) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource, System.Action<AwesomeAssertions.Events.EventMonitorOptions> configureOptions) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.ExecutionTimeAssertions Should(this AwesomeAssertions.Specialized.ExecutionTime executionTime) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -72,125 +82,181 @@ namespace AwesomeAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoSelectorAssertions Should(this AwesomeAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.MethodInfoSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoSelectorAssertions Should(this AwesomeAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.PropertyInfoSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.TypeSelectorAssertions Should(this AwesomeAssertions.Types.TypeSelector typeSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.TypeSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.ActionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Action action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.StringCollectionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<string> @this) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.DateOnlyAssertions Should(this System.DateOnly actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableDateOnlyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateOnly? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableDateTimeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTime? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableDateTimeOffsetAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTimeOffset? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.ParameterInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ParameterInfo parameterInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.TaskCompletionSourceAssertions Should(this System.Threading.Tasks.TaskCompletionSource tcs) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.TimeOnlyAssertions Should(this System.TimeOnly actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableTimeOnlyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.TimeOnly? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableSimpleTimeSpanAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.TimeSpan? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.TypeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Type subject) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XAttributeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XAttribute actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XDocumentAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XDocument actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XElement actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableBooleanAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this bool? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<byte> Should([System.Diagnostics.CodeAnalysis.NotNull] this byte? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<decimal> Should([System.Diagnostics.CodeAnalysis.NotNull] this decimal? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<double> Should([System.Diagnostics.CodeAnalysis.NotNull] this double? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<float> Should([System.Diagnostics.CodeAnalysis.NotNull] this float? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<int> Should([System.Diagnostics.CodeAnalysis.NotNull] this int? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<long> Should([System.Diagnostics.CodeAnalysis.NotNull] this long? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.ObjectAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this object actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<sbyte> Should([System.Diagnostics.CodeAnalysis.NotNull] this sbyte? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<short> Should([System.Diagnostics.CodeAnalysis.NotNull] this short? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.StringAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this string actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<uint> Should([System.Diagnostics.CodeAnalysis.NotNull] this uint? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<ulong> Should([System.Diagnostics.CodeAnalysis.NotNull] this ulong? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<ushort> Should([System.Diagnostics.CodeAnalysis.NotNull] this ushort? actualValue) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -229,14 +295,19 @@ namespace AwesomeAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this AwesomeAssertions.Primitives.TimeOnlyAssertions<TAssertions> _)
             where TAssertions : AwesomeAssertions.Primitives.TimeOnlyAssertions<TAssertions> { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -253,10 +324,13 @@ namespace AwesomeAssertions
             "ly following \'And\'", true)]
         public static void Should<TSubject, TAssertions>(this AwesomeAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> _)
             where TAssertions : AwesomeAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this TCollection actualValue)
             where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
@@ -302,9 +376,11 @@ namespace AwesomeAssertions
     }
     public static class EnumAssertionsExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
             where TEnum :  struct, System.Enum { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>([System.Diagnostics.CodeAnalysis.NotNull] this TEnum? @enum)
             where TEnum :  struct, System.Enum { }
@@ -345,11 +421,17 @@ namespace AwesomeAssertions
     }
     public static class FluentActions
     {
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Invoking(System.Action action) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<T> Invoking<T>(System.Func<T> func) { }
     }
     public static class LessThan
@@ -2094,15 +2176,19 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
@@ -2118,6 +2204,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -2179,17 +2266,21 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
@@ -2205,6 +2296,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, [System.Diagnostics.CodeAnalysis.StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -36,17 +36,24 @@ namespace AwesomeAssertions
     }
     public static class AssertionExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         public static TTo As<TTo>(this object subject) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -57,9 +64,12 @@ namespace AwesomeAssertions
         public static AwesomeAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, AwesomeAssertions.Common.StartTimer createTimer = null) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action, AwesomeAssertions.Common.StartTimer createTimer = null) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.ExecutionTimeAssertions Should(this AwesomeAssertions.Specialized.ExecutionTime executionTime) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -68,115 +78,166 @@ namespace AwesomeAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoSelectorAssertions Should(this AwesomeAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.MethodInfoSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoSelectorAssertions Should(this AwesomeAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.PropertyInfoSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.TypeSelectorAssertions Should(this AwesomeAssertions.Types.TypeSelector typeSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.TypeSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.ActionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Action action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.StringCollectionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<string> @this) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableDateTimeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTime? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableDateTimeOffsetAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTimeOffset? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.ParameterInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ParameterInfo parameterInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableSimpleTimeSpanAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.TimeSpan? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.TypeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Type subject) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XAttributeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XAttribute actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XDocumentAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XDocument actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XElement actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableBooleanAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this bool? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<byte> Should([System.Diagnostics.CodeAnalysis.NotNull] this byte? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<decimal> Should([System.Diagnostics.CodeAnalysis.NotNull] this decimal? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<double> Should([System.Diagnostics.CodeAnalysis.NotNull] this double? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<float> Should([System.Diagnostics.CodeAnalysis.NotNull] this float? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<int> Should([System.Diagnostics.CodeAnalysis.NotNull] this int? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<long> Should([System.Diagnostics.CodeAnalysis.NotNull] this long? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.ObjectAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this object actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<sbyte> Should([System.Diagnostics.CodeAnalysis.NotNull] this sbyte? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<short> Should([System.Diagnostics.CodeAnalysis.NotNull] this short? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.StringAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this string actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<uint> Should([System.Diagnostics.CodeAnalysis.NotNull] this uint? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<ulong> Should([System.Diagnostics.CodeAnalysis.NotNull] this ulong? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<ushort> Should([System.Diagnostics.CodeAnalysis.NotNull] this ushort? actualValue) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -207,14 +268,19 @@ namespace AwesomeAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this AwesomeAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : AwesomeAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -231,10 +297,13 @@ namespace AwesomeAssertions
             "ly following \'And\'", true)]
         public static void Should<TSubject, TAssertions>(this AwesomeAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> _)
             where TAssertions : AwesomeAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this TCollection actualValue)
             where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
@@ -280,9 +349,11 @@ namespace AwesomeAssertions
     }
     public static class EnumAssertionsExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
             where TEnum :  struct, System.Enum { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>([System.Diagnostics.CodeAnalysis.NotNull] this TEnum? @enum)
             where TEnum :  struct, System.Enum { }
@@ -317,11 +388,17 @@ namespace AwesomeAssertions
     }
     public static class FluentActions
     {
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Invoking(System.Action action) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<T> Invoking<T>(System.Func<T> func) { }
     }
     public static class LessThan
@@ -1935,15 +2012,19 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1959,6 +2040,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -2020,17 +2102,21 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -2046,6 +2132,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -36,17 +36,24 @@ namespace AwesomeAssertions
     }
     public static class AssertionExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         public static TTo As<TTo>(this object subject) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -57,13 +64,16 @@ namespace AwesomeAssertions
         public static AwesomeAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, AwesomeAssertions.Common.StartTimer createTimer = null) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action, AwesomeAssertions.Common.StartTimer createTimer = null) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource, System.Action<AwesomeAssertions.Events.EventMonitorOptions> configureOptions) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.ExecutionTimeAssertions Should(this AwesomeAssertions.Specialized.ExecutionTime executionTime) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -72,115 +82,166 @@ namespace AwesomeAssertions
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Specialized.TaskCompletionSourceAssertionsBase _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoSelectorAssertions Should(this AwesomeAssertions.Types.MethodInfoSelector methodSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.MethodInfoSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoSelectorAssertions Should(this AwesomeAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.PropertyInfoSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.TypeSelectorAssertions Should(this AwesomeAssertions.Types.TypeSelector typeSelector) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
             "ly following \'And\'", true)]
         public static void Should(this AwesomeAssertions.Types.TypeSelectorAssertions _) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.ActionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Action action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.StringCollectionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<string> @this) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableDateTimeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTime? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableDateTimeOffsetAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.DateTimeOffset? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.NonGenericAsyncFunctionAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableGuidAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Guid? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Streams.BufferedStreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.BufferedStream actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Streams.StreamAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.IO.Stream actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.AssemblyAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.Assembly assembly) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.ConstructorInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ConstructorInfo constructorInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.MethodInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.MethodInfo methodInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.ParameterInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.ParameterInfo parameterInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.PropertyInfoAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Reflection.PropertyInfo propertyInfo) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableSimpleTimeSpanAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.TimeSpan? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Types.TypeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Type subject) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XAttributeAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XAttribute actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XDocumentAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XDocument actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Xml.XElementAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this System.Xml.Linq.XElement actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableBooleanAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this bool? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<byte> Should([System.Diagnostics.CodeAnalysis.NotNull] this byte? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<decimal> Should([System.Diagnostics.CodeAnalysis.NotNull] this decimal? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<double> Should([System.Diagnostics.CodeAnalysis.NotNull] this double? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<float> Should([System.Diagnostics.CodeAnalysis.NotNull] this float? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<int> Should([System.Diagnostics.CodeAnalysis.NotNull] this int? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<long> Should([System.Diagnostics.CodeAnalysis.NotNull] this long? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.ObjectAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this object actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<sbyte> Should([System.Diagnostics.CodeAnalysis.NotNull] this sbyte? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<short> Should([System.Diagnostics.CodeAnalysis.NotNull] this short? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.StringAssertions Should([System.Diagnostics.CodeAnalysis.NotNull] this string actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<uint> Should([System.Diagnostics.CodeAnalysis.NotNull] this uint? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<ulong> Should([System.Diagnostics.CodeAnalysis.NotNull] this ulong? actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.NullableNumericAssertions<ushort> Should([System.Diagnostics.CodeAnalysis.NotNull] this ushort? actualValue) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -211,14 +272,19 @@ namespace AwesomeAssertions
             "ly following \'And\'", true)]
         public static void Should<TAssertions>(this AwesomeAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> _)
             where TAssertions : AwesomeAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions> { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericCollectionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.FunctionAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Func<T> func) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Numeric.ComparableTypeAssertions<T> Should<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.IComparable<T> comparableValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         [System.Obsolete("You are asserting the \'AndConstraint\' itself. Remove the \'Should()\' method direct" +
@@ -235,10 +301,13 @@ namespace AwesomeAssertions
             "ly following \'And\'", true)]
         public static void Should<TSubject, TAssertions>(this AwesomeAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> _)
             where TAssertions : AwesomeAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions> { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>([System.Diagnostics.CodeAnalysis.NotNull] this TCollection actualValue)
             where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
@@ -284,9 +353,11 @@ namespace AwesomeAssertions
     }
     public static class EnumAssertionsExtensions
     {
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
             where TEnum :  struct, System.Enum { }
+        [System.Diagnostics.Contracts.Pure]
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public static AwesomeAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>([System.Diagnostics.CodeAnalysis.NotNull] this TEnum? @enum)
             where TEnum :  struct, System.Enum { }
@@ -327,11 +398,17 @@ namespace AwesomeAssertions
     }
     public static class FluentActions
     {
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Action Invoking(System.Action action) { }
+        [System.Diagnostics.Contracts.Pure]
         public static System.Func<T> Invoking<T>(System.Func<T> func) { }
     }
     public static class LessThan
@@ -1993,15 +2070,19 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -2017,6 +2098,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
@@ -2078,17 +2160,21 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -2104,6 +2190,7 @@ namespace AwesomeAssertions.Primitives
         public AwesomeAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]
         public AwesomeAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        [System.Diagnostics.Contracts.Pure]
         public AwesomeAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
         public override bool Equals(object obj) { }
         [return: System.Diagnostics.CodeAnalysis.NotNull]

--- a/Tests/AwesomeAssertions.Specs/Exceptions/InvokingActionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/InvokingActionSpecs.cs
@@ -3,33 +3,27 @@ using Xunit;
 
 namespace AwesomeAssertions.Specs.Exceptions;
 
+// ReSharper disable ReturnValueOfPureMethodIsNotUsed
+#pragma warning disable CA1806,MA0060 // false-positive, the result is used in the action
 public class InvokingActionSpecs
 {
     [Fact]
     public void Invoking_on_null_is_not_allowed()
     {
-        // Arrange
         Does someClass = null;
 
-        // Act
         Action act = () => someClass.Invoking(d => d.Do());
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("subject");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("subject");
     }
 
     [Fact]
     public void Invoking_with_null_is_not_allowed()
     {
-        // Arrange
         Does someClass = Does.NotThrow();
 
-        // Act
         Action act = () => someClass.Invoking(null);
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("action");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("action");
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Exceptions/InvokingFunctionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/InvokingFunctionSpecs.cs
@@ -3,33 +3,27 @@ using Xunit;
 
 namespace AwesomeAssertions.Specs.Exceptions;
 
+// ReSharper disable ReturnValueOfPureMethodIsNotUsed
+#pragma warning disable CA1806,MA0060 // false-positive, the result is used in the action
 public class InvokingFunctionSpecs
 {
     [Fact]
     public void Invoking_on_null_is_not_allowed()
     {
-        // Arrange
         Does someClass = null;
 
-        // Act
         Action act = () => someClass.Invoking(d => d.Return());
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("subject");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("subject");
     }
 
     [Fact]
     public void Invoking_with_null_is_not_allowed()
     {
-        // Arrange
         Does someClass = Does.NotThrow();
 
-        // Act
-        Action act = () => someClass.Invoking((Func<Does, object>)null);
+        Action act = () => someClass.Invoking<Does, object>(null);
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("action");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("action");
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
@@ -125,15 +125,13 @@ public class MiscellaneousExceptionSpecs
     [Fact]
     public void When_two_exceptions_are_thrown_and_the_assertion_assumes_there_can_only_be_one_it_should_fail()
     {
-        // Arrange
         Does testSubject = Does.Throw(new AggregateException(new Exception(), new Exception()));
         Action throwingMethod = testSubject.Do;
 
-        // Act
-        Action action = () => throwingMethod.Should().Throw<Exception>().And.Message.Should();
+        Action action = () => _ = throwingMethod.Should().Throw<Exception>().And;
 
-        // Assert
-        action.Should().Throw<Exception>();
+        action.Should().Throw<XunitException>().WithMessage(
+            "More than one exception was thrown.*AwesomeAssertions cannot determine which Exception was meant.*");
     }
 
     [Fact]

--- a/Tests/AwesomeAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -40,15 +40,14 @@ public class PropertyInfoSelectorSpecs
     [Fact]
     public void When_property_info_selector_is_null_then_should_should_throw()
     {
-        // Arrange
         PropertyInfoSelector propertyInfoSelector = null;
 
-        // Act
+#pragma warning disable CA1806,MA0060 // false-positive, the result is used in the action
+        // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
         Action act = () => propertyInfoSelector.Should();
+#pragma warning restore CA1806,MA0060
 
-        // Assert
-        act.Should().ThrowExactly<ArgumentNullException>()
-            .WithParameterName("propertyInfoSelector");
+        act.Should().ThrowExactly<ArgumentNullException>().WithParameterName("propertyInfoSelector");
     }
 
     [Fact]
@@ -484,7 +483,8 @@ internal class TestClassForPropertySelectorWithInheritableAttributeDerived : Tes
     public override string PublicVirtualStringPropertyWithAttribute { get; set; }
 }
 
-internal class TestClassForPropertySelectorWithNonInheritableAttributeDerived : TestClassForPropertySelectorWithNonInheritableAttribute
+internal class TestClassForPropertySelectorWithNonInheritableAttributeDerived
+    : TestClassForPropertySelectorWithNonInheritableAttribute
 {
     public override string PublicVirtualStringPropertyWithAttribute { get; set; }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,8 @@ sidebar:
 * Removed support for the target framework .NET 6 - [#603](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/603)
 * Upgraded the minimum target for .NET Framework to 4.7.2 - [#603](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/603)
 * The reference to `System.Threading.Tasks.Extensions` to has been upgraded to version 4.6.3 - [#603](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/603)
+* Enable [PureAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.pureattribute) in the public API - [#605](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/605)
+  * It is declared as a breaking change because it may raise warnings like [CA1806](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1806).
 
 ## 9.6.0
 


### PR DESCRIPTION
Fixes #434
Fixes #570 

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [x] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [ ] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
