### PR TITLE
Fix package updates of MTP

### DIFF
--- a/Tests/TestFrameworks/MicrosoftTestingPlatform/NUnit4.Mtp.Specs/NUnit4.Mtp.Specs.csproj
+++ b/Tests/TestFrameworks/MicrosoftTestingPlatform/NUnit4.Mtp.Specs/NUnit4.Mtp.Specs.csproj
@@ -10,8 +10,12 @@
     <ProjectReference Include="..\..\..\..\Src\AwesomeAssertions\AwesomeAssertions.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <!--
+      Microsoft.Testing.Extensions.CodeCoverage and Microsoft.Testing.Extensions.TrxReport
+      must be referenced explicitely to enable coverage analysis.
+    -->
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>

--- a/Tests/TestFrameworks/MicrosoftTestingPlatform/TUnit.Specs/TUnit.Specs.csproj
+++ b/Tests/TestFrameworks/MicrosoftTestingPlatform/TUnit.Specs/TUnit.Specs.csproj
@@ -11,9 +11,7 @@
     <ProjectReference Include="..\..\..\..\Src\AwesomeAssertions\AwesomeAssertions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="TUnit" Version="1.63.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
+    <PackageReference Include="TUnit" Version="1.65.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
While TUnit has explicit references to Microsoft.Testing.Extensions.TrxReport and Microsoft.Testing.Extensions.CodeCoverage (which caused renovate update issues in the past), the NUnit3TestAdapter does not have. With this combination, no renovate grouping should be required.

* Update Microsoft.Testing.Extensions.CodeCoverage to 18.10.0
* and TUnit to 1.65.0

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
