### PR TITLE
Remove obsolete reference to System.Reflection.Metadata

### DIFF
--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -18,7 +18,5 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Bogus" Version="35.6.5" />
-    <!-- Resolve MSB3277 -->
-    <PackageReference Include="System.Reflection.Metadata" Version="10.0.10" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The reference may be needed in the past (regarding MSB3277).
Now, it is not need according to local testing.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
