### PR TITLE
Remove obsolete warning suppressions

### DIFF
--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -2,8 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <RootNamespace></RootNamespace>
-    <NoWarn>CS0649;CS0169</NoWarn>
+    <RootNamespace />
+    <!-- "Field is never used" - by design in Fallout -->
+    <NoWarn>$(NoWarn);CS0169</NoWarn>
+    <!-- "Field is never assigned" - by design in Fallout -->
+    <NoWarn>$(NoWarn);CS0649</NoWarn>
     <FalloutRootDirectory>..\</FalloutRootDirectory>
     <FalloutScriptDirectory>..\</FalloutScriptDirectory>
   </PropertyGroup>

--- a/Tests/AwesomeAssertions.Equivalency.Specs/AwesomeAssertions.Equivalency.Specs.csproj
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/AwesomeAssertions.Equivalency.Specs.csproj
@@ -5,7 +5,6 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\AwesomeAssertions.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn),IDE0052,1573,1591,1712</NoWarn>
     <DebugType>full</DebugType>
   </PropertyGroup>
 

--- a/Tests/AwesomeAssertions.Extensibility.Specs/AwesomeAssertions.Extensibility.Specs.csproj
+++ b/Tests/AwesomeAssertions.Extensibility.Specs/AwesomeAssertions.Extensibility.Specs.csproj
@@ -2,10 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net6.0;net8.0;net10.0</TargetFrameworks>
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\Src\AwesomeAssertions.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn),IDE0052,1573,1591,1712</NoWarn>
     <DebugType>full</DebugType>
   </PropertyGroup>
 

--- a/Tests/AwesomeAssertions.Specs/AwesomeAssertions.Specs.csproj
+++ b/Tests/AwesomeAssertions.Specs/AwesomeAssertions.Specs.csproj
@@ -5,7 +5,6 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\AwesomeAssertions.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn),IDE0052,1573,1591,1712,CS8002</NoWarn>
     <DebugType>full</DebugType>
   </PropertyGroup>
 

--- a/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
+++ b/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>MSpec.Specs</RootNamespace>
     <AssemblyName>MSpec.Specs</AssemblyName>
-    <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\AwesomeAssertions\AwesomeAssertions.csproj" />


### PR DESCRIPTION
## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
