### PR TITLE
Code cleanup on CollectionAssertionSpecs

### DIFF
--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeAssignableTo.cs
@@ -6,9 +6,6 @@ using Xunit.Sdk;
 
 namespace AwesomeAssertions.Specs.Collections;
 
-/// <content>
-/// The AllBeAssignableTo specs.
-/// </content>
 public partial class CollectionAssertionSpecs
 {
     public class AllBeAssignableTo
@@ -16,41 +13,32 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_the_types_in_a_collection_is_matched_against_a_null_type_it_should_throw()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act
             Action act = () => collection.Should().AllBeAssignableTo(null);
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("expectedType");
+            act.Should().Throw<ArgumentNullException>().WithParameterName("expectedType");
         }
 
         [Fact]
         public void All_items_in_an_empty_collection_are_assignable_to_a_generic_type()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act / Assert
             collection.Should().AllBeAssignableTo<int>();
         }
 
         [Fact]
         public void When_collection_is_null_then_all_be_assignable_to_should_fail()
         {
-            // Arrange
             IEnumerable<object> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 collection.Should().AllBeAssignableTo(typeof(object), "we want to test the {0} message", "failure");
             };
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type to be object because*failure message, but found collection is <null>.");
         }
@@ -58,64 +46,50 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void All_items_in_an_empty_collection_are_assignable_to_a_type()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act / Assert
             collection.Should().AllBeAssignableTo(typeof(int));
         }
 
         [Fact]
         public void When_all_of_the_types_in_a_collection_match_expected_type_it_should_succeed()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act / Assert
             collection.Should().AllBeAssignableTo(typeof(int));
         }
 
         [Fact]
         public void When_all_of_the_types_in_a_collection_match_expected_generic_type_it_should_succeed()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act / Assert
             collection.Should().AllBeAssignableTo<int>();
         }
 
         [Fact]
         public void When_matching_a_collection_against_a_type_it_should_return_the_casted_items()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act / Assert
-            collection.Should().AllBeAssignableTo<int>()
-                .Which.Should().Equal(1, 2, 3);
+            collection.Should().AllBeAssignableTo<int>().Which.Should().Equal(1, 2, 3);
         }
 
         [Fact]
         public void When_all_of_the_types_in_a_collection_match_the_type_or_subtype_it_should_succeed()
         {
-            // Arrange
             var collection = new object[] { new Exception(), new ArgumentException("foo") };
 
-            // Act / Assert
             collection.Should().AllBeAssignableTo<Exception>();
         }
 
         [Fact]
         public void When_one_of_the_types_does_not_match_it_should_throw_with_a_clear_explanation()
         {
-            // Arrange
             var collection = new object[] { 1, "2", 3 };
 
-            // Act
             Action act = () => collection.Should().AllBeAssignableTo(typeof(int), "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be int because*failure message, but found {int, string, int}.");
         }
@@ -123,13 +97,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_one_of_the_types_does_not_match_the_generic_type_it_should_throw_with_a_clear_explanation()
         {
-            // Arrange
             var collection = new object[] { 1, "2", 3 };
 
-            // Act
             Action act = () => collection.Should().AllBeAssignableTo<int>("we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be int because*failure message, but found {int, string, int}.");
         }
@@ -137,13 +108,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_one_of_the_elements_is_null_it_should_throw_with_a_clear_explanation()
         {
-            // Arrange
             var collection = new object[] { 1, null, 3 };
 
-            // Act
             Action act = () => collection.Should().AllBeAssignableTo<int>("we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be int because*failure message, but found a null element.");
         }
@@ -151,23 +119,18 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_collection_is_of_matching_types_it_should_succeed()
         {
-            // Arrange
             Type[] collection = [typeof(Exception), typeof(ArgumentException)];
 
-            // Act / Assert
             collection.Should().AllBeAssignableTo<Exception>();
         }
 
         [Fact]
         public void When_collection_of_types_contains_one_type_that_does_not_match_it_should_throw_with_a_clear_explanation()
         {
-            // Arrange
             Type[] collection = [typeof(int), typeof(string), typeof(int)];
 
-            // Act
             Action act = () => collection.Should().AllBeAssignableTo<int>("we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be int because*failure message, but found {int, string, int}.");
         }
@@ -175,37 +138,30 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_collection_of_types_and_objects_are_all_of_matching_types_it_should_succeed()
         {
-            // Arrange
             var collection = new object[] { typeof(int), 2, typeof(int) };
 
-            // Act / Assert
             collection.Should().AllBeAssignableTo<int>();
         }
 
         [Fact]
         public void When_collection_of_different_types_and_objects_are_all_assignable_to_type_it_should_succeed()
         {
-            // Arrange
             var collection = new object[] { typeof(Exception), new ArgumentException("foo") };
 
-            // Act / Assert
             collection.Should().AllBeAssignableTo<Exception>();
         }
 
         [Fact]
         public void When_collection_is_null_then_all_be_assignable_toOfT_should_fail()
         {
-            // Arrange
             IEnumerable<object> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 collection.Should().AllBeAssignableTo<object>("we want to test the {0} message", "failure");
             };
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type to be object because*failure message, but found collection is <null>.");
         }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeEquivalentTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeEquivalentTo.cs
@@ -9,44 +9,36 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void Can_ignore_casing_while_comparing_collections_of_strings()
         {
-            // Arrange
             var actual = new[] { "test", "tEst", "Test", "TEst", "teST" };
-            var expectation = "test";
+            const string expectation = "test";
 
-            // Act / Assert
             actual.Should().AllBeEquivalentTo(expectation, o => o.IgnoringCase());
         }
 
         [Fact]
         public void Can_ignore_leading_whitespace_while_comparing_collections_of_strings()
         {
-            // Arrange
             var actual = new[] { " test", "test", "\ttest", "\ntest", "  \t \n test" };
-            var expectation = "test";
+            const string expectation = "test";
 
-            // Act / Assert
             actual.Should().AllBeEquivalentTo(expectation, o => o.IgnoringLeadingWhitespace());
         }
 
         [Fact]
         public void Can_ignore_trailing_whitespace_while_comparing_collections_of_strings()
         {
-            // Arrange
             var actual = new[] { "test ", "test", "test\t", "test\n", "test  \t \n " };
-            var expectation = "test";
+            const string expectation = "test";
 
-            // Act / Assert
             actual.Should().AllBeEquivalentTo(expectation, o => o.IgnoringTrailingWhitespace());
         }
 
         [Fact]
         public void Can_ignore_newline_style_while_comparing_collections_of_strings()
         {
-            // Arrange
             var actual = new[] { "A\nB\nC", "A\r\nB\r\nC", "A\r\nB\nC", "A\nB\r\nC" };
-            var expectation = "A\nB\nC";
+            const string expectation = "A\nB\nC";
 
-            // Act / Assert
             actual.Should().AllBeEquivalentTo(expectation, o => o.IgnoringNewlineStyle());
         }
     }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllBeOfType.cs
@@ -6,9 +6,6 @@ using Xunit.Sdk;
 
 namespace AwesomeAssertions.Specs.Collections;
 
-/// <content>
-/// The AllBeOfType specs.
-/// </content>
 public partial class CollectionAssertionSpecs
 {
     public class AllBeOfType
@@ -16,51 +13,40 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_the_types_in_a_collection_is_matched_against_a_null_type_exactly_it_should_throw()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act
             Action act = () => collection.Should().AllBeOfType(null);
 
-            // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .WithParameterName("expectedType");
+            act.Should().Throw<ArgumentNullException>().WithParameterName("expectedType");
         }
 
         [Fact]
         public void All_items_in_an_empty_collection_are_of_a_generic_type()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act / Assert
             collection.Should().AllBeOfType<int>();
         }
 
         [Fact]
         public void All_items_in_an_empty_collection_are_of_a_type()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act / Assert
             collection.Should().AllBeOfType(typeof(int));
         }
 
         [Fact]
         public void When_collection_is_null_then_all_be_of_type_should_fail()
         {
-            // Arrange
             IEnumerable<object> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 collection.Should().AllBeOfType(typeof(object), "we want to test the {0} message", "failure");
             };
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type to be object because*failure message, but found collection is <null>.");
         }
@@ -68,30 +54,24 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_all_of_the_types_in_a_collection_match_expected_type_exactly_it_should_succeed()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act / Assert
             collection.Should().AllBeOfType(typeof(int));
         }
 
         [Fact]
         public void When_all_of_the_types_in_a_collection_match_expected_generic_type_exactly_it_should_succeed()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act / Assert
             collection.Should().AllBeOfType<int>();
         }
 
         [Fact]
         public void When_matching_a_collection_against_an_exact_type_it_should_return_the_casted_items()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act / Assert
             collection.Should().AllBeOfType<int>()
                 .Which.Should().Equal(1, 2, 3);
         }
@@ -99,13 +79,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_one_of_the_types_does_not_match_exactly_it_should_throw_with_a_clear_explanation()
         {
-            // Arrange
             var collection = new object[] { new Exception(), new ArgumentException("foo") };
 
-            // Act
             Action act = () => collection.Should().AllBeOfType(typeof(Exception), "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be System.Exception because*failure message, but found {System.Exception, System.ArgumentException}.");
         }
@@ -113,13 +90,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_one_of_the_types_does_not_match_exactly_the_generic_type_it_should_throw_with_a_clear_explanation()
         {
-            // Arrange
             var collection = new object[] { new Exception(), new ArgumentException("foo") };
 
-            // Act
             Action act = () => collection.Should().AllBeOfType<Exception>("we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be System.Exception because*failure message, but found {System.Exception, System.ArgumentException}.");
         }
@@ -127,13 +101,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_one_of_the_elements_is_null_for_an_exact_match_it_should_throw_with_a_clear_explanation()
         {
-            // Arrange
             var collection = new object[] { 1, null, 3 };
 
-            // Act
             Action act = () => collection.Should().AllBeOfType<int>("we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be int because*failure message, but found a null element.");
         }
@@ -141,33 +112,26 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_collection_of_types_match_expected_type_exactly_it_should_succeed()
         {
-            // Arrange
             Type[] collection = [typeof(int), typeof(int), typeof(int)];
 
-            // Act / Assert
             collection.Should().AllBeOfType<int>();
         }
 
         [Fact]
         public void When_collection_of_types_and_objects_match_type_exactly_it_should_succeed()
         {
-            // Arrange
             var collection = new object[] { typeof(ArgumentException), new ArgumentException("foo") };
 
-            // Act / Assert
             collection.Should().AllBeOfType<ArgumentException>();
         }
 
         [Fact]
         public void When_collection_of_types_and_objects_do_not_match_type_exactly_it_should_throw()
         {
-            // Arrange
             var collection = new object[] { typeof(Exception), new ArgumentException("foo") };
 
-            // Act
             Action act = () => collection.Should().AllBeOfType<ArgumentException>();
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be System.ArgumentException, but found {System.Exception, System.ArgumentException}.");
         }
@@ -175,17 +139,14 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_collection_is_null_then_all_be_of_typeOfT_should_fail()
         {
-            // Arrange
             IEnumerable<object> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 collection.Should().AllBeOfType<object>("we want to test the {0} message", "failure");
             };
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type to be object because*failure message, but found collection is <null>.");
         }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.AllSatisfy.cs
@@ -6,9 +6,6 @@ using Xunit.Sdk;
 
 namespace AwesomeAssertions.Specs.Collections;
 
-/// <content>
-/// The AllSatisfy specs.
-/// </content>
 public partial class CollectionAssertionSpecs
 {
     public class AllSatisfy
@@ -16,69 +13,54 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void A_null_inspector_should_throw()
         {
-            // Arrange
             IEnumerable<int> collection = [1, 2];
 
-            // Act
             Action act = () => collection.Should().AllSatisfy(null);
 
-            // Assert
-            act.Should()
-                .Throw<ArgumentException>()
-                .WithMessage("Cannot verify against a <null> inspector*");
+            act.Should().Throw<ArgumentException>().WithMessage("Cannot verify against a <null> inspector*");
         }
 
         [Fact]
         public void A_null_collection_should_throw()
         {
-            // Arrange
             IEnumerable<int> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 collection.Should().AllSatisfy(x => x.Should().Be(1), "we want to test the {0} message", "failure");
             };
 
-            // Assert
-            act.Should()
-                .Throw<XunitException>()
-                .WithMessage(
-                    "Expected collection to contain only items satisfying the inspector because*failure message, but collection is <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection to contain only items satisfying the inspector"
+                + " because*failure message, but collection is <null>.");
         }
 
         [Fact]
         public void An_empty_collection_should_succeed()
         {
-            // Arrange
             IEnumerable<int> collection = [];
 
-            // Act / Assert
             collection.Should().AllSatisfy(x => x.Should().Be(1));
         }
 
         [Fact]
         public void All_items_satisfying_inspector_should_succeed()
         {
-            // Arrange
-            Customer[] collection = [new Customer { Age = 21, Name = "John" }, new Customer { Age = 21, Name = "Jane" }];
+            Customer[] collection = [new() { Age = 21, Name = "John" }, new() { Age = 21, Name = "Jane" }];
 
-            // Act / Assert
             collection.Should().AllSatisfy(x => x.Age.Should().Be(21));
         }
 
         [Fact]
         public void Any_items_not_satisfying_inspector_should_throw()
         {
-            // Arrange
             CustomerWithItems[] customers =
             [
-                new CustomerWithItems { Age = 21, Items = [1, 2] },
-                new CustomerWithItems { Age = 22, Items = [3] }
+                new() { Age = 21, Items = [1, 2] },
+                new() { Age = 22, Items = [3] }
             ];
 
-            // Act
             Action act = () => customers.Should()
                 .AllSatisfy(
                     customer =>
@@ -88,9 +70,9 @@ public partial class CollectionAssertionSpecs
                         customer.Items.Should()
                             .AllSatisfy(item => item.Should().Be(3));
                     },
-                    "we want to test the {0} message", "failure");
+                    "we want to test the {0} message",
+                    "failure");
 
-            // Assert
             act.Should()
                 .Throw<XunitException>()
                 .WithMessage("""
@@ -110,13 +92,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void Inspector_message_that_is_not_reformatable_should_not_throw()
         {
-            // Arrange
             byte[][] subject = [[1]];
 
-            // Act
             Action act = () => subject.Should().AllSatisfy(e => e.Should().BeEquivalentTo(new byte[] { 2, 3, 4 }));
 
-            // Assert
             act.Should().NotThrow<FormatException>();
         }
     }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeEmpty.cs
@@ -7,9 +7,6 @@ using Xunit.Sdk;
 
 namespace AwesomeAssertions.Specs.Collections;
 
-/// <content>
-/// The [Not]BeEmpty specs.
-/// </content>
 public partial class CollectionAssertionSpecs
 {
     public class BeEmpty
@@ -17,23 +14,18 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_collection_is_empty_as_expected_it_should_not_throw()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act / Assert
             collection.Should().BeEmpty();
         }
 
         [Fact]
         public void When_collection_is_not_empty_unexpectedly_it_should_throw()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act
             Action act = () => collection.Should().BeEmpty("we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("*to be empty because*failure message, but found at least one item*1*");
         }
@@ -41,49 +33,38 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_collection_with_items_is_not_empty_it_should_succeed()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act / Assert
             collection.Should().NotBeEmpty();
         }
 
         [Fact]
         public void When_asserting_collection_with_items_is_not_empty_it_should_enumerate_the_collection_only_once()
         {
-            // Arrange
             var trackingEnumerable = new TrackingTestEnumerable(1, 2, 3);
 
-            // Act
             trackingEnumerable.Should().NotBeEmpty();
 
-            // Assert
             trackingEnumerable.Enumerator.LoopCount.Should().Be(1);
         }
 
         [Fact]
         public void When_asserting_collection_without_items_is_not_empty_it_should_fail()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act
             Action act = () => collection.Should().NotBeEmpty();
 
-            // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_asserting_collection_without_items_is_not_empty_it_should_fail_with_descriptive_message_()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act
             Action act = () => collection.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection not to be empty because*failure message.");
         }
@@ -91,17 +72,14 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_collection_to_be_empty_but_collection_is_null_it_should_throw()
         {
-            // Arrange
             IEnumerable<object> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 collection.Should().BeEmpty("we want to test the {0} message", "failure");
             };
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection to be empty because*failure message, but found <null>.");
         }
@@ -109,45 +87,35 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_collection_to_be_empty_it_should_enumerate_only_once()
         {
-            // Arrange
             var collection = new CountingGenericEnumerable<int>([]);
 
-            // Act
             collection.Should().BeEmpty();
 
-            // Assert
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
 
         [Fact]
         public void When_asserting_non_empty_collection_is_empty_it_should_enumerate_only_once()
         {
-            // Arrange
             var collection = new CountingGenericEnumerable<int>([1, 2, 3]);
 
-            // Act
             Action act = () => collection.Should().BeEmpty();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*to be empty, but found at least one item {1}.");
+            act.Should().Throw<XunitException>().WithMessage("*to be empty, but found at least one item {1}.");
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
 
         [Fact]
         public void When_asserting_collection_to_not_be_empty_but_collection_is_null_it_should_throw()
         {
-            // Arrange
             IEnumerable<object> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 collection.Should().NotBeEmpty("we want to test the {0} message", "failure");
             };
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection not to be empty because*failure message, but found <null>.");
         }
@@ -155,13 +123,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_an_infinite_collection_to_be_empty_it_should_throw_correctly()
         {
-            // Arrange
             var collection = new InfiniteEnumerable();
 
-            // Act
             Action act = () => collection.Should().BeEmpty();
 
-            // Assert
             act.Should().Throw<XunitException>();
         }
     }
@@ -171,13 +136,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_collection_to_be_not_empty_but_collection_is_null_it_should_throw()
         {
-            // Arrange
             int[] collection = null;
 
-            // Act
             Action act = () => collection.Should().NotBeEmpty("we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection not to be empty because*failure message, but found <null>.");
         }
@@ -185,13 +147,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_collection_to_be_not_empty_it_should_enumerate_only_once()
         {
-            // Arrange
             var collection = new CountingGenericEnumerable<int>([42]);
 
-            // Act
             collection.Should().NotBeEmpty();
 
-            // Assert
             collection.GetEnumeratorCallCount.Should().Be(1);
         }
     }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -7,9 +7,6 @@ using Xunit.Sdk;
 
 namespace AwesomeAssertions.Specs.Collections;
 
-/// <content>
-/// The [Not]BeEquivalentTo specs.
-/// </content>
 public partial class CollectionAssertionSpecs
 {
     public class BeEquivalentTo
@@ -17,46 +14,37 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_two_collections_contain_the_same_elements_it_should_treat_them_as_equivalent()
         {
-            // Arrange
             int[] collection1 = [1, 2, 3];
             int[] collection2 = [3, 1, 2];
 
-            // Act / Assert
             collection1.Should().BeEquivalentTo(collection2);
         }
 
         [Fact]
         public void When_a_collection_contains_same_elements_it_should_treat_it_as_equivalent()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act / Assert
             collection.Should().BeEquivalentTo([3, 1, 2]);
         }
 
         [Fact]
         public void When_character_collections_are_equivalent_it_should_not_throw()
         {
-            // Arrange
             char[] list1 = "abc123ab".ToCharArray();
             char[] list2 = "abc123ab".ToCharArray();
 
-            // Act / Assert
             list1.Should().BeEquivalentTo(list2);
         }
 
         [Fact]
         public void When_collections_are_not_equivalent_it_should_throw()
         {
-            // Arrange
             int[] collection1 = [1, 2, 3];
             int[] collection2 = [1, 2];
 
-            // Act
             Action act = () => collection1.Should().BeEquivalentTo(collection2, "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected*collection*2 item(s) because*failure message, but *1 item(s) more than*");
         }
@@ -64,29 +52,22 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_collections_with_duplicates_are_not_equivalent_it_should_throw()
         {
-            // Arrange
             int[] collection1 = [1, 2, 3, 1];
             int[] collection2 = [1, 2, 3, 3];
 
-            // Act
             Action act = () => collection1.Should().BeEquivalentTo(collection2);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1[3]*to be 3, but found 1*");
+            act.Should().Throw<XunitException>().WithMessage("Expected collection1[3]*to be 3, but found 1*");
         }
 
         [Fact]
         public void When_testing_for_equivalence_against_empty_collection_it_should_throw()
         {
-            // Arrange
             int[] subject = [1, 2, 3];
             int[] otherCollection = [];
 
-            // Act
             Action act = () => subject.Should().BeEquivalentTo(otherCollection);
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected subject to be a collection with 0 item(s), but*contains 3 item(s)*");
         }
@@ -94,27 +75,21 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_two_collections_are_both_empty_it_should_treat_them_as_equivalent()
         {
-            // Arrange
             int[] subject = [];
             int[] otherCollection = [];
 
-            // Act / Assert
             subject.Should().BeEquivalentTo(otherCollection);
         }
 
         [Fact]
         public void When_testing_for_equivalence_against_null_collection_it_should_throw()
         {
-            // Arrange
             int[] collection1 = [1, 2, 3];
             int[] collection2 = null;
 
-            // Act
             Action act = () => collection1.Should().BeEquivalentTo(collection2, "we want to test the {0} message", "failure");
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected*<null> because*failure message*but found {1, 2, 3}*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*<null> because*failure message*but found {1, 2, 3}*");
         }
 
         [Fact]
@@ -123,78 +98,63 @@ public partial class CollectionAssertionSpecs
             int[] collection = null;
             int[] collection1 = [1, 2, 3];
 
-            // Act
-            Action act =
-                () => collection.Should()
-                    .BeEquivalentTo(collection1, "we want to test the {0} message", "failure");
+            Action act = () =>
+                collection.Should().BeEquivalentTo(collection1, "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected collection not to be <null> because*failure message*");
         }
 
         [Fact]
         public void Default_immutable_arrays_should_be_equivalent()
         {
-            // Arrange
             ImmutableArray<string> collection = default;
             ImmutableArray<string> collection1 = default;
 
-            // Act / Assert
             collection.Should().BeEquivalentTo(collection1);
         }
 
         [Fact]
         public void Default_immutable_lists_should_be_equivalent()
         {
-            // Arrange
-            ImmutableList<string> collection = default;
-            ImmutableList<string> collection1 = default;
+            ImmutableList<string> collection = null;
+            ImmutableList<string> collection1 = null;
 
-            // Act / Assert
             collection.Should().BeEquivalentTo(collection1);
         }
 
         [Fact]
         public void Can_ignore_casing_while_comparing_collections_of_strings()
         {
-            // Arrange
             var actual = new[] { "first", "test", "last" };
             var expectation = new[] { "first", "TEST", "last" };
 
-            // Act / Assert
             actual.Should().BeEquivalentTo(expectation, o => o.IgnoringCase());
         }
 
         [Fact]
         public void Can_ignore_leading_whitespace_while_comparing_collections_of_strings()
         {
-            // Arrange
             var actual = new[] { "first", "  test", "last" };
             var expectation = new[] { "first", "test", "last" };
 
-            // Act / Assert
             actual.Should().BeEquivalentTo(expectation, o => o.IgnoringLeadingWhitespace());
         }
 
         [Fact]
         public void Can_ignore_trailing_whitespace_while_comparing_collections_of_strings()
         {
-            // Arrange
             var actual = new[] { "first", "test  ", "last" };
             var expectation = new[] { "first", "test", "last" };
 
-            // Act / Assert
             actual.Should().BeEquivalentTo(expectation, o => o.IgnoringTrailingWhitespace());
         }
 
         [Fact]
         public void Can_ignore_newline_style_while_comparing_collections_of_strings()
         {
-            // Arrange
             var actual = new[] { "first", "A\nB\r\nC", "last" };
             var expectation = new[] { "first", "A\r\nB\nC", "last" };
 
-            // Act / Assert
             actual.Should().BeEquivalentTo(expectation, o => o.IgnoringNewlineStyle());
         }
     }
@@ -204,95 +164,75 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_collection_is_not_equivalent_to_another_smaller_collection_it_should_succeed()
         {
-            // Arrange
             int[] collection1 = [1, 2, 3];
             int[] collection2 = [3, 1];
 
-            // Act / Assert
             collection1.Should().NotBeEquivalentTo(collection2);
         }
 
         [Fact]
         public void When_large_collection_is_equivalent_to_another_equally_size_collection_it_should_throw()
         {
-            // Arrange
             var collection1 = Enumerable.Repeat(1, 10000);
             var collection2 = Enumerable.Repeat(1, 10000);
 
-            // Act
             Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
 
-            // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
         public void When_collection_is_not_equivalent_to_another_equally_sized_collection_it_should_succeed()
         {
-            // Arrange
             int[] collection1 = [1, 2, 3];
             int[] collection2 = [3, 1, 4];
 
-            // Act / Assert
             collection1.Should().NotBeEquivalentTo(collection2);
         }
 
         [Fact]
         public void When_collections_are_unexpectedly_equivalent_it_should_throw()
         {
-            // Arrange
             int[] collection1 = [1, 2, 3];
             int[] collection2 = [3, 1, 2];
 
-            // Act
             Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection1 {1, 2, 3} not*equivalent*{3, 1, 2}.");
+            act.Should().Throw<XunitException>().WithMessage("Expected collection1 {1, 2, 3} not*equivalent*{3, 1, 2}.");
         }
 
         [Fact]
         public void When_asserting_collections_not_to_be_equivalent_but_subject_collection_is_null_it_should_throw()
         {
-            // Arrange
             int[] actual = null;
             int[] expectation = [1, 2, 3];
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 actual.Should().NotBeEquivalentTo(expectation, "we want to test the {0} message", "failure");
             };
 
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "*be equivalent because*failure message, but found <null>*");
+            act.Should().Throw<XunitException>().WithMessage("*be equivalent because*failure message, but found <null>*");
         }
 
         [Fact]
         public void When_non_empty_collection_is_not_expected_to_be_equivalent_to_an_empty_collection_it_should_succeed()
         {
-            // Arrange
             int[] collection1 = [1, 2, 3];
             int[] collection2 = [];
 
-            // Act / Assert
             collection1.Should().NotBeEquivalentTo(collection2);
         }
 
         [Fact]
         public void When_testing_collections_not_to_be_equivalent_against_null_collection_it_should_throw()
         {
-            // Arrange
             int[] collection1 = [1, 2, 3];
             int[] collection2 = null;
 
-            // Act
             Action act = () => collection1.Should().NotBeEquivalentTo(collection2);
 
-            // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot verify inequivalence against a <null> collection.*")
                 .WithParameterName("unexpected");
@@ -301,50 +241,41 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_testing_collections_not_to_be_equivalent_against_same_collection_it_should_throw()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
             var collection1 = collection;
 
-            // Act
             Action act = () => collection.Should().NotBeEquivalentTo(collection1, "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*not to be equivalent*because* failure message, but they both reference the same object.");
+                "*not to be equivalent*because*failure message, but they both reference the same object.");
         }
 
         [Fact]
         public void When_a_collections_is_equivalent_to_an_approximate_copy_it_should_throw()
         {
-            // Arrange
             double[] collection = [1.0, 2.0, 3.0];
             double[] collection1 = [1.5, 2.5, 3.5];
 
-            // Act
             Action act = () => collection.Should().NotBeEquivalentTo(collection1, opt => opt
                     .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.5))
                     .WhenTypeIs<double>(),
                 "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("*not to be equivalent*because*failure message*");
         }
 
         [Fact]
         public void When_asserting_collections_not_to_be_equivalent_with_options_but_subject_collection_is_null_it_should_throw()
         {
-            // Arrange
             int[] actual = null;
             int[] expectation = [1, 2, 3];
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 actual.Should().NotBeEquivalentTo(expectation, opt => opt, "we want to test the {0} message", "failure");
             };
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected actual not to be equivalent because*failure message*, but found <null>.*");
         }
@@ -352,22 +283,18 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void Default_immutable_array_should_not_be_equivalent_to_initialized_immutable_array()
         {
-            // Arrange
             ImmutableArray<string> subject = default;
             ImmutableArray<string> expectation = ImmutableArray.Create("a", "b", "c");
 
-            // Act / Assert
             subject.Should().NotBeEquivalentTo(expectation);
         }
 
         [Fact]
         public void Immutable_array_should_not_be_equivalent_to_default_immutable_array()
         {
-            // Arrange
             ImmutableArray<string> collection = ImmutableArray.Create("a", "b", "c");
             ImmutableArray<string> collection1 = default;
 
-            // Act / Assert
             collection.Should().NotBeEquivalentTo(collection1);
         }
     }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.BeInAscendingOrder.cs
@@ -7,9 +7,6 @@ using Xunit.Sdk;
 
 namespace AwesomeAssertions.Specs.Collections;
 
-/// <content>
-/// The [Not]BeInAscendingOrder specs.
-/// </content>
 public partial class CollectionAssertionSpecs
 {
     public class BeInAscendingOrder
@@ -17,28 +14,22 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_a_null_collection_to_be_in_ascending_order_it_should_throw()
         {
-            // Arrange
             List<int> result = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 result.Should().BeInAscendingOrder();
             };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*but found <null>*");
+            act.Should().Throw<XunitException>().WithMessage("*but found <null>*");
         }
 
         [Fact]
         public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_it_should_succeed()
         {
-            // Arrange
             int[] collection = [1, 2, 2, 3];
 
-            // Act / Assert
             collection.Should().BeInAscendingOrder();
         }
 
@@ -46,158 +37,115 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_succeed()
         {
-            // Arrange
             int[] collection = [1, 2, 2, 3];
 
-            // Act / Assert
             collection.Should().BeInAscendingOrder(Comparer<int>.Default);
         }
 
         [Fact]
         public void When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_it_should_throw()
         {
-            // Arrange
             int[] collection = [1, 6, 12, 15, 12, 17, 26];
 
-            // Act
             Action action = () => collection.Should().BeInAscendingOrder("we want to test the {0} message", "failure");
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be in ascending order because*failure message," +
-                    " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected collection to be in ascending order because*failure message,"
+                + " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
         }
 
         [Fact]
         public void
             When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_given_comparer_it_should_throw()
         {
-            // Arrange
             int[] collection = [1, 6, 12, 15, 12, 17, 26];
 
-            // Act
-            Action action = () => collection.Should().BeInAscendingOrder(Comparer<int>.Default, "we want to test the {0} message", "failure");
+            Action action = () =>
+                collection.Should().BeInAscendingOrder(Comparer<int>.Default, "we want to test the {0} message", "failure");
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to be in ascending order because*failure message," +
-                    " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected collection to be in ascending order because*failure message,"
+                + " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
         }
 
         [Fact]
         public void Items_can_be_ordered_by_the_identity_function()
         {
-            // Arrange
             int[] collection = [1, 2];
 
-            // Act / Assert
             collection.Should().BeInAscendingOrder(x => x);
         }
 
         [Fact]
         public void When_asserting_empty_collection_with_no_parameters_ordered_in_ascending_it_should_succeed()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act / Assert
             collection.Should().BeInAscendingOrder();
         }
 
         [Fact]
         public void When_asserting_empty_collection_by_property_expression_ordered_in_ascending_it_should_succeed()
         {
-            // Arrange
             IEnumerable<SomeClass> collection = [];
 
-            // Act / Assert
             collection.Should().BeInAscendingOrder(o => o.Number);
         }
 
         [Fact]
         public void When_asserting_single_element_collection_with_no_parameters_ordered_in_ascending_it_should_succeed()
         {
-            // Arrange
             int[] collection = [42];
 
-            // Act / Assert
             collection.Should().BeInAscendingOrder();
         }
 
         [Fact]
         public void When_asserting_single_element_collection_by_property_expression_ordered_in_ascending_it_should_succeed()
         {
-            // Arrange
-            var collection = new SomeClass[]
-            {
-                new() { Text = "a", Number = 1 }
-            };
+            var collection = new SomeClass[] { new() { Text = "a", Number = 1 } };
 
-            // Act / Assert
             collection.Should().BeInAscendingOrder(o => o.Number);
         }
 
         [Fact]
         public void Can_use_a_cast_expression_in_the_ordering_expression()
         {
-            // Arrange
-            var collection = new SomeClass[]
-            {
-                new() { Text = "a", Number = 1 }
-            };
+            var collection = new SomeClass[] { new() { Text = "a", Number = 1 } };
 
-            // Act & Assert
             collection.Should().BeInAscendingOrder(o => (float)o.Number);
         }
 
         [Fact]
         public void Can_use_an_index_into_a_list_in_the_ordering_expression()
         {
-            // Arrange
-            List<SomeClass>[] collection =
-            [
-                [new() { Text = "a", Number = 1 }]
-            ];
+            List<SomeClass>[] collection = [[new() { Text = "a", Number = 1 }]];
 
-            // Act & Assert
             collection.Should().BeInAscendingOrder(o => o[0].Number);
         }
 
         [Fact]
         public void Can_use_an_index_into_an_array_in_the_ordering_expression()
         {
-            // Arrange
-            SomeClass[][] collection =
-            [
-                [new SomeClass { Text = "a", Number = 1 }]
-            ];
+            SomeClass[][] collection = [[new SomeClass { Text = "a", Number = 1 }]];
 
-            // Act & Assert
             collection.Should().BeInAscendingOrder(o => o[0].Number);
         }
 
         [Fact]
         public void Unsupported_ordering_expressions_are_invalid()
         {
-            // Arrange
-            var collection = new SomeClass[]
-            {
-                new() { Text = "a", Number = 1 }
-            };
+            var collection = new SomeClass[] { new() { Text = "a", Number = 1 } };
 
-            // Act
             Action act = () => collection.Should().BeInAscendingOrder(o => o.Number > 1);
 
-            // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("*Expression <*> cannot be used to select a member.*");
+            act.Should().Throw<ArgumentException>().WithMessage("*Expression <*> cannot be used to select a member.*");
         }
 
         [Fact]
         public void
             When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_specified_property_it_should_throw()
         {
-            // Arrange
             var collection = new[]
             {
                 new { Text = "b", Numeric = 1 },
@@ -205,10 +153,8 @@ public partial class CollectionAssertionSpecs
                 new { Text = "a", Numeric = 3 }
             };
 
-            // Act
             Action act = () => collection.Should().BeInAscendingOrder(o => o.Text, "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection*b*c*a*ordered*Text* because*failure message*a*b*c*");
         }
@@ -217,7 +163,6 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_in_an_unordered_collection_are_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
-            // Arrange
             var collection = new[]
             {
                 new { Text = "b", Numeric = 1 },
@@ -225,11 +170,9 @@ public partial class CollectionAssertionSpecs
                 new { Text = "a", Numeric = 3 }
             };
 
-            // Act
-            Action act = () =>
-                collection.Should().BeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "we want to test the {0} message", "failure");
+            Action act = () => collection.Should().BeInAscendingOrder(
+                o => o.Text, StringComparer.OrdinalIgnoreCase, "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection*b*c*a*ordered*Text* because*failure message*a*b*c*");
         }
@@ -238,7 +181,6 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_specified_property_it_should_succeed()
         {
-            // Arrange
             var collection = new[]
             {
                 new { Text = "b", Numeric = 1 },
@@ -246,7 +188,6 @@ public partial class CollectionAssertionSpecs
                 new { Text = "a", Numeric = 3 }
             };
 
-            // Act / Assert
             collection.Should().BeInAscendingOrder(o => o.Numeric);
         }
 
@@ -254,7 +195,6 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
         {
-            // Arrange
             var collection = new[]
             {
                 new { Text = "b", Numeric = 1 },
@@ -262,139 +202,103 @@ public partial class CollectionAssertionSpecs
                 new { Text = "a", Numeric = 3 }
             };
 
-            // Act / Assert
             collection.Should().BeInAscendingOrder(o => o.Numeric, Comparer<int>.Default);
         }
 
         [Fact]
         public void When_strings_are_in_ascending_order_it_should_succeed()
         {
-            // Arrange
             string[] strings = ["alpha", "beta", "theta"];
 
-            // Act / Assert
             strings.Should().BeInAscendingOrder();
         }
 
         [Fact]
         public void When_strings_are_not_in_ascending_order_it_should_throw()
         {
-            // Arrange
             string[] strings = ["theta", "alpha", "beta"];
 
-            // Act
             Action act = () => strings.Should().BeInAscendingOrder("we want to test the {0} message", "failure");
 
-            // Assert
-            act.Should()
-                .Throw<XunitException>()
-                .WithMessage("Expected*ascending*because*failure message*index 0*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*ascending*because*failure message*index 0*");
         }
 
         [Fact]
         public void When_strings_are_in_ascending_order_according_to_a_custom_comparer_it_should_succeed()
         {
-            // Arrange
             string[] strings = ["alpha", "beta", "theta"];
 
-            // Act / Assert
             strings.Should().BeInAscendingOrder(new ByLastCharacterComparer());
         }
 
         [Fact]
         public void When_strings_are_not_in_ascending_order_according_to_a_custom_comparer_it_should_throw()
         {
-            // Arrange
             string[] strings = ["dennis", "roy", "thomas"];
 
-            // Act
-            Action act = () => strings.Should().BeInAscendingOrder(new ByLastCharacterComparer(), "we want to test the {0} message", "failure");
+            Action act = () =>
+                strings.Should().BeInAscendingOrder(new ByLastCharacterComparer(), "we want to test the {0} message", "failure");
 
-            // Assert
-            act.Should()
-                .Throw<XunitException>()
-                .WithMessage("Expected*ascending*because*failure message*index 1*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*ascending*because*failure message*index 1*");
         }
 
         [Fact]
         public void When_strings_are_in_ascending_order_according_to_a_custom_lambda_it_should_succeed()
         {
-            // Arrange
             string[] strings = ["alpha", "beta", "theta"];
 
-            // Act / Assert
             strings.Should().BeInAscendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]));
         }
 
         [Fact]
         public void When_strings_are_not_in_ascending_order_according_to_a_custom_lambda_it_should_throw()
         {
-            // Arrange
             string[] strings = ["dennis", "roy", "thomas"];
 
-            // Act
-            Action act = () =>
-                strings.Should().BeInAscendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "we want to test the {0} message", "failure");
+            Action act = () => strings.Should().BeInAscendingOrder(
+                (sut, exp) => sut[^1].CompareTo(exp[^1]), "we want to test the {0} message", "failure");
 
-            // Assert
-            act.Should()
-                .Throw<XunitException>()
-                .WithMessage("Expected*ascending*because*failure message*index 1*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*ascending*because*failure message*index 1*");
         }
 
         [Fact]
         public void When_asserting_the_items_in_a_null_collection_are_ordered_using_the_specified_property_it_should_throw()
         {
-            // Arrange
             const IEnumerable<SomeClass> collection = null;
 
-            // Act
             Action act = () => collection.Should().BeInAscendingOrder(o => o.Text);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Text*found*null*");
+            act.Should().Throw<XunitException>().WithMessage("*Text*found*null*");
         }
 
         [Fact]
         public void When_asserting_the_items_in_a_null_collection_are_ordered_using_the_given_comparer_it_should_throw()
         {
-            // Arrange
             const IEnumerable<SomeClass> collection = null;
 
-            // Act
             Action act = () => collection.Should().BeInAscendingOrder(Comparer<SomeClass>.Default);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*found*null*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*found*null*");
         }
 
         [Fact]
         public void
             When_asserting_the_items_in_a_null_collection_are_ordered_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
-            // Arrange
             const IEnumerable<SomeClass> collection = null;
 
-            // Act
             Action act = () => collection.Should().BeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*Text*found*null*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*Text*found*null*");
         }
 
         [Fact]
         public void When_asserting_the_items_in_a_collection_are_ordered_and_the_specified_property_is_null_it_should_throw()
         {
-            // Arrange
             IEnumerable<SomeClass> collection = [];
 
-            // Act
             Action act = () => collection.Should().BeInAscendingOrder((Expression<Func<SomeClass, string>>)null);
 
-            // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot assert collection ordering without specifying a property*")
                 .WithParameterName("propertyExpression");
@@ -403,13 +307,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_the_items_in_a_collection_are_ordered_and_the_given_comparer_is_null_it_should_throw()
         {
-            // Arrange
             IEnumerable<SomeClass> collection = [];
 
-            // Act
             Action act = () => collection.Should().BeInAscendingOrder(comparer: null);
 
-            // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot assert collection ordering without specifying a comparer*")
                 .WithParameterName("comparer");
@@ -418,15 +319,11 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_the_items_in_ay_collection_are_ordered_using_an_invalid_property_expression_it_should_throw()
         {
-            // Arrange
             IEnumerable<SomeClass> collection = [];
 
-            // Act
             Action act = () => collection.Should().BeInAscendingOrder(o => o.GetHashCode());
 
-            // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("Expression*o.GetHashCode()*cannot be used to select a member*");
+            act.Should().Throw<ArgumentException>().WithMessage("Expression*o.GetHashCode()*cannot be used to select a member*");
         }
     }
 
@@ -435,24 +332,18 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_a_null_collection_to_not_be_in_ascending_order_it_should_throw()
         {
-            // Arrange
             List<int> result = null;
 
-            // Act
             Action act = () => result.Should().NotBeInAscendingOrder();
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*but found <null>*");
+            act.Should().Throw<XunitException>().WithMessage("*but found <null>*");
         }
 
         [Fact]
         public void When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_it_should_succeed()
         {
-            // Arrange
             int[] collection = [1, 5, 3];
 
-            // Act / Assert
             collection.Should().NotBeInAscendingOrder();
         }
 
@@ -460,55 +351,44 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_in_an_unordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_succeed()
         {
-            // Arrange
             int[] collection = [1, 5, 3];
 
-            // Act / Assert
             collection.Should().NotBeInAscendingOrder(Comparer<int>.Default);
         }
 
         [Fact]
         public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_it_should_throw()
         {
-            // Arrange
             int[] collection = [1, 2, 2, 3];
 
-            // Act
             Action action = () => collection.Should().NotBeInAscendingOrder("we want to test the {0} message", "failure");
 
             // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in ascending order because*failure message," +
-                    " but found {1, 2, 2, 3}.");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Did not expect collection to be in ascending order because*failure message, but found {1, 2, 2, 3}.");
         }
 
         [Fact]
         public void
             When_asserting_the_items_in_an_ascendingly_ordered_collection_are_not_in_ascending_order_using_the_given_comparer_it_should_throw()
         {
-            // Arrange
             int[] collection = [1, 2, 2, 3];
 
-            // Act
             Action action = () =>
                 collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "we want to test the {0} message", "failure");
 
             // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to be in ascending order because*failure message," +
-                    " but found {1, 2, 2, 3}.");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Did not expect collection to be in ascending order because*failure message, but found {1, 2, 2, 3}.");
         }
 
         [Fact]
         public void When_asserting_empty_collection_by_property_expression_to_not_be_ordered_in_ascending_it_should_throw()
         {
-            // Arrange
             IEnumerable<SomeClass> collection = [];
 
-            // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(o => o.Number);
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection {empty} to not be ordered \"by Number\" and not result in {empty}.");
         }
@@ -516,13 +396,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_empty_collection_with_no_parameters_not_be_ordered_in_ascending_it_should_throw()
         {
-            // Arrange
             int[] collection = [];
 
-            // Act
             Action act = () => collection.Should().NotBeInAscendingOrder("we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Did not expect collection to be in ascending order because*failure message, but found {empty}.");
         }
@@ -530,13 +407,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_single_element_collection_with_no_parameters_not_be_ordered_in_ascending_it_should_throw()
         {
-            // Arrange
             int[] collection = [42];
 
-            // Act
             Action act = () => collection.Should().NotBeInAscendingOrder();
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Did not expect collection to be in ascending order, but found {42}.");
         }
@@ -545,16 +419,10 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_single_element_collection_by_property_expression_to_not_be_ordered_in_ascending_it_should_throw()
         {
-            // Arrange
-            var collection = new SomeClass[]
-            {
-                new() { Text = "a", Number = 1 }
-            };
+            var collection = new SomeClass[] { new() { Text = "a", Number = 1 } };
 
-            // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(o => o.Number);
 
-            // Assert
             act.Should().Throw<XunitException>();
         }
 
@@ -562,13 +430,11 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_in_a_ascending_ordered_collection_are_not_ordered_ascending_using_the_given_comparer_it_should_throw()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act
-            Action act = () => collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "we want to test the {0} message", "failure");
+            Action act = () =>
+                collection.Should().NotBeInAscendingOrder(Comparer<int>.Default, "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Did not expect collection to be in ascending order because*failure message*1*2*3*");
         }
@@ -577,10 +443,8 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_given_comparer_it_should_succeed()
         {
-            // Arrange
             int[] collection = [3, 2, 1];
 
-            // Act / Assert
             collection.Should().NotBeInAscendingOrder(Comparer<int>.Default);
         }
 
@@ -588,7 +452,6 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_in_a_ascending_ordered_collection_are_not_ordered_ascending_using_the_specified_property_it_should_throw()
         {
-            // Arrange
             var collection = new[]
             {
                 new { Text = "a", Numeric = 3 },
@@ -596,10 +459,9 @@ public partial class CollectionAssertionSpecs
                 new { Text = "c", Numeric = 2 }
             };
 
-            // Act
-            Action act = () => collection.Should().NotBeInAscendingOrder(o => o.Text, "we want to test the {0} message", "failure");
+            Action act = () =>
+                collection.Should().NotBeInAscendingOrder(o => o.Text, "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection*a*b*c*not be ordered \"by Text\" because*failure message*a*b*c*");
         }
@@ -608,7 +470,6 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_in_an_ordered_collection_are_not_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
-            // Arrange
             var collection = new[]
             {
                 new { Text = "A", Numeric = 1 },
@@ -616,12 +477,9 @@ public partial class CollectionAssertionSpecs
                 new { Text = "C", Numeric = 3 }
             };
 
-            // Act
-            Action act = () =>
-                collection.Should()
-                    .NotBeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase, "we want to test the {0} message", "failure");
+            Action act = () => collection.Should().NotBeInAscendingOrder(
+                o => o.Text, StringComparer.OrdinalIgnoreCase, "we want to test the {0} message", "failure");
 
-            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected collection*A*b*C*not be ordered* \"by Text\" because*failure message*A*b*C*");
         }
@@ -630,7 +488,6 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_specified_property_it_should_succeed()
         {
-            // Arrange
             var collection = new[]
             {
                 new { Text = "b", Numeric = 3 },
@@ -638,7 +495,6 @@ public partial class CollectionAssertionSpecs
                 new { Text = "a", Numeric = 1 }
             };
 
-            // Act / Assert
             collection.Should().NotBeInAscendingOrder(o => o.Numeric);
         }
 
@@ -646,7 +502,6 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_not_in_an_ascendingly_ordered_collection_are_not_ordered_ascending_using_the_specified_property_and_the_given_comparer_it_should_succeed()
         {
-            // Arrange
             var collection = new[]
             {
                 new { Text = "b", Numeric = 3 },
@@ -654,147 +509,111 @@ public partial class CollectionAssertionSpecs
                 new { Text = "a", Numeric = 1 }
             };
 
-            // Act / Assert
             collection.Should().NotBeInAscendingOrder(o => o.Numeric, Comparer<int>.Default);
         }
 
         [Fact]
         public void When_strings_are_not_in_ascending_order_it_should_succeed()
         {
-            // Arrange
             string[] strings = ["beta", "alpha", "theta"];
 
-            // Act / Assert
             strings.Should().NotBeInAscendingOrder();
         }
 
         [Fact]
         public void When_strings_are_in_ascending_order_unexpectedly_it_should_throw()
         {
-            // Arrange
             string[] strings = ["alpha", "beta", "theta"];
 
-            // Act
             Action act = () => strings.Should().NotBeInAscendingOrder("we want to test the {0} message", "failure");
 
-            // Assert
-            act.Should()
-                .Throw<XunitException>()
-                .WithMessage("Did not expect*ascending*because*failure message, but found*");
+            act.Should().Throw<XunitException>().WithMessage("Did not expect*ascending*because*failure message, but found*");
         }
 
         [Fact]
         public void When_strings_are_not_in_ascending_order_according_to_a_custom_comparer_it_should_succeed()
         {
-            // Arrange
             string[] strings = ["dennis", "roy", "barbara"];
 
-            // Act / Assert
             strings.Should().NotBeInAscendingOrder(new ByLastCharacterComparer());
         }
 
         [Fact]
         public void When_strings_are_unexpectedly_in_ascending_order_according_to_a_custom_comparer_it_should_throw()
         {
-            // Arrange
             string[] strings = ["dennis", "thomas", "roy"];
 
-            // Act
-            Action act = () => strings.Should().NotBeInAscendingOrder(new ByLastCharacterComparer(), "we want to test the {0} message", "failure");
+            Action act = () => strings.Should().NotBeInAscendingOrder(
+                new ByLastCharacterComparer(), "we want to test the {0} message", "failure");
 
-            // Assert
-            act.Should()
-                .Throw<XunitException>()
-                .WithMessage("Did not expect*ascending*because*failure message, but found*");
+            act.Should().Throw<XunitException>().WithMessage("Did not expect*ascending*because*failure message, but found*");
         }
 
         [Fact]
         public void When_strings_are_not_in_ascending_order_according_to_a_custom_lambda_it_should_succeed()
         {
-            // Arrange
             string[] strings = ["roy", "dennis", "thomas"];
 
-            // Act / Assert
             strings.Should().NotBeInAscendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]));
         }
 
         [Fact]
         public void When_strings_are_unexpectedly_in_ascending_order_according_to_a_custom_lambda_it_should_throw()
         {
-            // Arrange
             string[] strings = ["barbara", "dennis", "roy"];
 
-            // Act
-            Action act = () =>
-                strings.Should().NotBeInAscendingOrder((sut, exp) => sut[^1].CompareTo(exp[^1]), "we want to test the {0} message", "failure");
+            Action act = () => strings.Should().NotBeInAscendingOrder(
+                (sut, exp) => sut[^1].CompareTo(exp[^1]), "we want to test the {0} message", "failure");
 
-            // Assert
-            act.Should()
-                .Throw<XunitException>()
-                .WithMessage("Did not expect*ascending*because*failure message, but found*");
+            act.Should().Throw<XunitException>().WithMessage("Did not expect*ascending*because*failure message, but found*");
         }
 
         [Fact]
         public void When_asserting_the_items_in_a_null_collection_are_not_ordered_using_the_specified_property_it_should_throw()
         {
-            // Arrange
             const IEnumerable<SomeClass> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 collection.Should().NotBeInAscendingOrder(o => o.Text);
             };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Text*found*null*");
+            act.Should().Throw<XunitException>().WithMessage("*Text*found*null*");
         }
 
         [Fact]
         public void When_asserting_the_items_in_a_null_collection_are_not_ordered_using_the_given_comparer_it_should_throw()
         {
-            // Arrange
             const IEnumerable<SomeClass> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using var _ = new AssertionScope();
                 collection.Should().NotBeInAscendingOrder(Comparer<SomeClass>.Default);
             };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*found*null*");
+            act.Should().Throw<XunitException>().WithMessage("*found*null*");
         }
 
         [Fact]
         public void
             When_asserting_the_items_in_a_null_collection_are_not_ordered_using_the_specified_property_and_the_given_comparer_it_should_throw()
         {
-            // Arrange
             const IEnumerable<SomeClass> collection = null;
 
-            // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(o => o.Text, StringComparer.OrdinalIgnoreCase);
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Text*found*null*");
+            act.Should().Throw<XunitException>().WithMessage("*Text*found*null*");
         }
 
         [Fact]
         public void When_asserting_the_items_in_a_collection_are_not_ordered_and_the_specified_property_is_null_it_should_throw()
         {
-            // Arrange
             IEnumerable<SomeClass> collection = [];
 
-            // Act
             Action act = () => collection.Should().NotBeInAscendingOrder((Expression<Func<SomeClass, string>>)null);
 
-            // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot assert collection ordering without specifying a property*propertyExpression*");
         }
@@ -802,13 +621,10 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_the_items_in_a_collection_are_not_ordered_and_the_given_comparer_is_null_it_should_throw()
         {
-            // Arrange
             IEnumerable<SomeClass> collection = [];
 
-            // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(comparer: null);
 
-            // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithMessage("Cannot assert collection ordering without specifying a comparer*comparer*");
         }
@@ -817,15 +633,11 @@ public partial class CollectionAssertionSpecs
         public void
             When_asserting_the_items_in_ay_collection_are_not_ordered_using_an_invalid_property_expression_it_should_throw()
         {
-            // Arrange
             IEnumerable<SomeClass> collection = [];
 
-            // Act
             Action act = () => collection.Should().NotBeInAscendingOrder(o => o.GetHashCode());
 
-            // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("Expression*o.GetHashCode()*cannot be used to select a member*");
+            act.Should().Throw<ArgumentException>().WithMessage("Expression*o.GetHashCode()*cannot be used to select a member*");
         }
     }
 }

--- a/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -8,9 +8,6 @@ using Xunit.Sdk;
 
 namespace AwesomeAssertions.Specs.Collections;
 
-/// <summary>
-/// Collection assertion specs.
-/// </summary>
 public partial class CollectionAssertionSpecs
 {
     public class Chaining
@@ -18,24 +15,18 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void Chaining_something_should_do_something()
         {
-            // Arrange
             var languages = new[] { "C#" };
 
-            // Act
-            var act = () => languages.Should().ContainSingle()
-                .Which.Should().EndWith("script");
+            var act = () => languages.Should().ContainSingle().Which.Should().EndWith("script");
 
-            // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected languages[0]*");
         }
 
         [Fact]
         public void Should_support_chaining_constraints_with_and()
         {
-            // Arrange
             int[] collection = [1, 2, 3];
 
-            // Act / Assert
             collection.Should()
                 .HaveCount(3)
                 .And
@@ -47,16 +38,8 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_the_collection_is_ordered_according_to_the_subsequent_ascending_assertion_it_should_succeed()
         {
-            // Arrange
-            (int, string)[] collection =
-            [
-                (1, "a"),
-                (2, "b"),
-                (2, "c"),
-                (3, "a")
-            ];
+            (int, string)[] collection = [(1, "a"), (2, "b"), (2, "c"), (3, "a")];
 
-            // Act / Assert
             collection.Should()
                 .BeInAscendingOrder(x => x.Item1)
                 .And
@@ -66,40 +49,22 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_the_collection_is_not_ordered_according_to_the_subsequent_ascending_assertion_it_should_fail()
         {
-            // Arrange
-            (int, string)[] collection =
-            [
-                (1, "a"),
-                (2, "b"),
-                (2, "c"),
-                (3, "a")
-            ];
+            (int, string)[] collection = [(1, "a"), (2, "b"), (2, "c"), (3, "a")];
 
-            // Act
             Action action = () => collection.Should()
                 .BeInAscendingOrder(x => x.Item1)
                 .And
                 .BeInAscendingOrder(x => x.Item2);
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection*to be ordered \"by Item2\"*");
+            action.Should().Throw<XunitException>().WithMessage("Expected collection*to be ordered \"by Item2\"*");
         }
 
         [Fact]
         public void
             When_the_collection_is_ordered_according_to_the_subsequent_ascending_assertion_with_comparer_it_should_succeed()
         {
-            // Arrange
-            (int, string)[] collection =
-            [
-                (1, "a"),
-                (2, "B"),
-                (2, "b"),
-                (3, "a")
-            ];
+            (int, string)[] collection = [(1, "a"), (2, "B"), (2, "b"), (3, "a")];
 
-            // Act / Assert
             collection.Should()
                 .BeInAscendingOrder(x => x.Item1)
                 .And
@@ -109,16 +74,8 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_the_collection_is_ordered_according_to_the_multiple_subsequent_ascending_assertions_it_should_succeed()
         {
-            // Arrange
-            (int, string, double)[] collection =
-            [
-                (1, "a", 1.1),
-                (2, "b", 1.2),
-                (2, "c", 1.3),
-                (3, "a", 1.1)
-            ];
+            (int, string, double)[] collection = [(1, "a", 1.1), (2, "b", 1.2), (2, "c", 1.3), (3, "a", 1.1)];
 
-            // Act / Assert
             collection.Should()
                 .BeInAscendingOrder(x => x.Item1)
                 .And
@@ -130,16 +87,8 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_the_collection_is_ordered_according_to_the_subsequent_descending_assertion_it_should_succeed()
         {
-            // Arrange
-            (int, string)[] collection =
-            [
-                (3, "a"),
-                (2, "c"),
-                (2, "b"),
-                (1, "a")
-            ];
+            (int, string)[] collection = [(3, "a"), (2, "c"), (2, "b"), (1, "a")];
 
-            // Act / Assert
             collection.Should()
                 .BeInDescendingOrder(x => x.Item1)
                 .And
@@ -149,22 +98,13 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_the_collection_is_not_ordered_according_to_the_subsequent_descending_assertion_it_should_fail()
         {
-            // Arrange
-            (int, string)[] collection =
-            [
-                (3, "a"),
-                (2, "c"),
-                (2, "b"),
-                (1, "a")
-            ];
+            (int, string)[] collection = [(3, "a"), (2, "c"), (2, "b"), (1, "a")];
 
-            // Act
             Action action = () => collection.Should()
                 .BeInDescendingOrder(x => x.Item1)
                 .And
                 .BeInDescendingOrder(x => x.Item2);
 
-            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected collection*to be ordered \"by Item2\"*");
         }
@@ -173,16 +113,8 @@ public partial class CollectionAssertionSpecs
         public void
             When_the_collection_is_ordered_according_to_the_subsequent_descending_assertion_with_comparer_it_should_succeed()
         {
-            // Arrange
-            (int, string)[] collection =
-            [
-                (3, "a"),
-                (2, "b"),
-                (2, "B"),
-                (1, "a")
-            ];
+            (int, string)[] collection = [(3, "a"), (2, "b"), (2, "B"), (1, "a")];
 
-            // Act / Assert
             collection.Should()
                 .BeInDescendingOrder(x => x.Item1)
                 .And
@@ -192,16 +124,8 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_the_collection_is_ordered_according_to_the_multiple_subsequent_descending_assertions_it_should_succeed()
         {
-            // Arrange
-            (int, string, double)[] collection =
-            [
-                (3, "a", 1.1),
-                (2, "c", 1.3),
-                (2, "b", 1.2),
-                (1, "a", 1.1)
-            ];
+            (int, string, double)[] collection = [(3, "a", 1.1), (2, "c", 1.3), (2, "b", 1.2), (1, "a", 1.1)];
 
-            // Act / Assert
             collection.Should()
                 .BeInDescendingOrder(x => x.Item1)
                 .And
@@ -213,10 +137,8 @@ public partial class CollectionAssertionSpecs
         [Fact]
         public void When_asserting_ordering_by_property_of_a_null_collection_failed_inside_a_scope_then_a_subsequent_assertion_is_not_evaluated()
         {
-            // Arrange
             const IEnumerable<SomeClass> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using (new AssertionScope())
@@ -226,18 +148,14 @@ public partial class CollectionAssertionSpecs
                 }
             };
 
-            // AssertText but found <null>.
-            act.Should().Throw<XunitException>()
-               .WithMessage("*Text*found*<null>.");
+            act.Should().Throw<XunitException>().WithMessage("*Text*found*<null>.");
         }
 
         [Fact]
         public void When_asserting_ordering_with_given_comparer_of_a_null_collection_failed_inside_a_scope_then_a_subsequent_assertion_is_not_evaluated()
         {
-            // Arrange
             const IEnumerable<SomeClass> collection = null;
 
-            // Act
             Action act = () =>
             {
                 using (new AssertionScope())
@@ -247,18 +165,14 @@ public partial class CollectionAssertionSpecs
                 }
             };
 
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*found*<null>.");
+            act.Should().Throw<XunitException>().WithMessage("Expected*found*<null>.");
         }
 
         [Fact]
         public void When_asserting_ordering_of_an_unordered_collection_failed_inside_a_scope_then_a_subsequent_assertion_is_not_evaluated()
         {
-            // Arrange
             int[] collection = [1, 27, 12];
 
-            // Act
             Action action = () =>
             {
                 using (new AssertionScope())
@@ -268,9 +182,7 @@ public partial class CollectionAssertionSpecs
                 }
             };
 
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("*because*failure message*item at index 1 is in wrong order.");
+            action.Should().Throw<XunitException>().WithMessage("*because*failure message*item at index 1 is in wrong order.");
         }
     }
 
@@ -427,11 +339,4 @@ internal class OneTimeEnumerable<T> : IEnumerable<T>
 
         return items.AsEnumerable().GetEnumerator();
     }
-}
-
-internal class SomeClass
-{
-    public string Text { get; set; }
-
-    public int Number { get; set; }
 }


### PR DESCRIPTION
While consolidating because-of-arguments in the specs (#383) I also started removing majority of AAA comments.
This caused to much changes. This PR comes with the remaining changes I had already started but suspended after feedback.
Before deleting these changes I just propose to accept.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
