### PR TITLE
v10: Make WithParameterName case-insensitive

### DIFF
--- a/Src/AwesomeAssertions/ExceptionAssertionsExtensions.cs
+++ b/Src/AwesomeAssertions/ExceptionAssertionsExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using AwesomeAssertions.Common;
 using AwesomeAssertions.Execution;
 using AwesomeAssertions.Specialized;
 
@@ -152,8 +153,9 @@ public static class ExceptionAssertionsExtensions
     }
 
     /// <summary>
-    /// Asserts that the thrown exception has a parameter which name matches <paramref name="paramName" />.
+    /// Asserts that the thrown exception has a parameter which name matches <paramref name="paramName" /> case insensitive.
     /// </summary>
+    /// <typeparam name="TException">The type of the exception.</typeparam>
     /// <param name="parent">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
     /// <param name="paramName">The expected name of the parameter</param>
     /// <param name="because">
@@ -163,6 +165,7 @@ public static class ExceptionAssertionsExtensions
     /// <param name="becauseArgs">
     /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
     /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="paramName"/> is <langword>null</langword> or empty.</exception>
     public static ExceptionAssertions<TException> WithParameterName<TException>(
         this ExceptionAssertions<TException> parent,
         string paramName,
@@ -170,9 +173,12 @@ public static class ExceptionAssertionsExtensions
         params object[] becauseArgs)
         where TException : ArgumentException
     {
+        Guard.ThrowIfArgumentIsNullOrEmpty(paramName);
+
         AssertionChain
             .GetOrCreate()
-            .ForCondition(parent.Which.ParamName == paramName)
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(paramName.Equals(parent.Which.ParamName, StringComparison.OrdinalIgnoreCase))
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected exception with parameter name {0}{reason}, but found {1}.", paramName, parent.Which.ParamName);
 

--- a/Tests/AwesomeAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Exceptions/MiscellaneousExceptionSpecs.cs
@@ -152,27 +152,48 @@ public class MiscellaneousExceptionSpecs
     [Fact]
     public void When_a_method_throws_with_a_matching_parameter_name_it_should_succeed()
     {
-        // Arrange
         Action throwException = () => throw new ArgumentNullException("someParameter");
 
-        // Act / Assert
-        throwException.Should().Throw<ArgumentException>()
-            .WithParameterName("someParameter");
+        throwException.Should().Throw<ArgumentException>().WithParameterName("someParameter");
+    }
+
+    [Fact]
+    public void When_a_method_throws_with_a_case_insensitive_matching_parameter_name_it_should_succeed()
+    {
+        Action throwException = () => throw new ArgumentNullException("someParameter");
+
+        throwException.Should().Throw<ArgumentException>().WithParameterName("SomeParameter");
     }
 
     [Fact]
     public void When_a_method_throws_with_a_non_matching_parameter_name_it_should_fail_with_a_descriptive_message()
     {
-        // Arrange
         Action throwException = () => throw new ArgumentNullException("someOtherParameter");
 
-        // Act
-        Action act = () =>
-            throwException.Should().Throw<ArgumentException>()
-                .WithParameterName("someParameter", "we want to test the {0} message", "failure");
+        Action act = () => throwException.Should().Throw<ArgumentException>()
+            .WithParameterName("someParameter", "we want to test the {0} message", "failure");
 
-        // Assert
         act.Should().Throw<XunitException>()
             .WithMessage("*with parameter name \"someParameter\"*because*failure message*\"someOtherParameter\"*");
+    }
+
+    [Fact]
+    public void When_asserting_empty_parameter_name_an_exception_is_thrown()
+    {
+        Action throwException = () => throw new ArgumentNullException();
+
+        Action act = () => throwException.Should().Throw<ArgumentException>().WithParameterName("");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void When_asserting_null_as_parameter_name_an_exception_is_thrown()
+    {
+        Action throwException = () => throw new ArgumentNullException();
+
+        Action act = () => throwException.Should().Throw<ArgumentException>().WithParameterName(null);
+
+        act.Should().Throw<ArgumentException>();
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,6 +15,9 @@ sidebar:
 * Enable [PureAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.pureattribute) in the public API - [#605](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/605)
   * It is declared as a breaking change because it may raise warnings like [CA1806](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1806).
 
+### Improvements
+* The comparison of `WithParameterName` is now case-insensitive - [#610](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/610)
+
 ## 9.6.0
 
 ### What's new


### PR DESCRIPTION
Fixes #291 .

I also added guard for `paramName`. According to the assertion documentation `null` or `string.Empty` doesn't make sense.

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/main/Tests/AwesomeAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [x] If the PR adds a feature or fixes a bug, please update [the release notes](../tree/main/docs/_pages/releases.md) with a functional description that explains what the change means to consumers of this library, which are published on the [website](https://awesomeassertions.org/releases).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
* [x] If the PR affects [the documentation](../tree/main/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://awesomeassertions.org/introduction).
    * [ ] Please also run `./build.sh --target spellcheck` or `.\build.ps1 --target spellcheck` before pushing and check the good outcome

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
