### PR TITLE
Calculate NuGet version only when packaging is enabled

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -102,7 +102,7 @@ class Build : FalloutBuild
 
     Target Compile => _ => _
         .DependsOn(Restore)
-        .DependsOn(CalculateNugetVersion)
+        .After(CalculateNugetVersion)
         .OnlyWhenDynamic(() => RunAllTargets || HasSourceChanges)
         .Executes(() =>
         {
@@ -305,6 +305,7 @@ class Build : FalloutBuild
         .DependsOn(TestingPlatformFrameworks);
 
     Target Pack => _ => _
+        .DependsOn(CalculateNugetVersion)
         .DependsOn(ApiChecks)
         .DependsOn(TestFrameworks)
         .DependsOn(UnitTests)


### PR DESCRIPTION
While local execution of all tests (using Fallout) the sources are touched unnecessarily by changing the NuGet version.
With the proposed change the target `CalculateNugetVersion` is executed before `Compile` (as before), but only when `Pack` is targeted. This makes the `Compile` target very fast when running tests multiple times.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
