### PR TITLE
Prepare docs for 9.6.0 release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -24,9 +24,9 @@ changelog:
     - title: Documentation
       labels:
         - "documentation"
+    - title: Dependencies (move to the last)
+      labels:
+        - "dependencies"
     - title: Others
       labels: 
         - "*"
-    - title: Dependencies
-      labels:
-        - "dependencies"

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -8,6 +8,8 @@ sidebar:
 ---
 ## Unreleased
 
+## 9.6.0
+
 ### What's new
 * Add `AssertionScope.AddReportable` to add custom reportable information to the current scope - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
 * Add more `AssertionChain.WithReportable` overloads - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,7 +13,7 @@ sidebar:
 ### What's new
 * Add `AssertionScope.AddReportable` to add custom reportable information to the current scope - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
 * Add more `AssertionChain.WithReportable` overloads - [#551](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/551)
-* Add documentation to all public API - [#TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
+* Add documentation to all public API - [#556](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/556)
 * Add `ExcludingObsoleteMembers` to `SelfReferenceEquivalencyOptions` allowing obsolete members to be ignored in structural comparison - [#558](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/558)
   * Please note that the interface `IEquivalencyOptions` has been marked as "technically public" and not part of the public API.
 


### PR DESCRIPTION
## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
