### PR TITLE
Add new tests to create coverage identified by the switch to MS Coverage

### DIFF
--- a/Src/AwesomeAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -48,6 +48,7 @@ internal class EnumerableEquivalencyValidator
             }
             else
             {
+                // HELP WANTED: Unable to create a test for this block.
                 using var _ = context.Tracer.WriteBlock(member =>
                     Invariant(
                         $"Comparing subject {subject} and expectation {expectation} at {member.Expectation} using simple value equality"));

--- a/Src/AwesomeAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
+++ b/Src/AwesomeAssertions/Equivalency/Steps/EnumerableEquivalencyValidator.cs
@@ -48,7 +48,6 @@ internal class EnumerableEquivalencyValidator
             }
             else
             {
-                // HELP WANTED: Unable to create a test for this block.
                 using var _ = context.Tracer.WriteBlock(member =>
                     Invariant(
                         $"Comparing subject {subject} and expectation {expectation} at {member.Expectation} using simple value equality"));

--- a/Tests/AwesomeAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/AssertionRuleSpecs.cs
@@ -64,6 +64,19 @@ public class AssertionRuleSpecs
     }
 
     [Fact]
+    public void When_two_collection_properties_dont_match_tracing_provides_details()
+    {
+        var subject = new { Values = new[] { 1, 2, 3 } };
+        var other = new { Values = new[] { 1, 4, 3 } };
+
+        Action act = () => subject.Should().BeEquivalentTo(other, o => o.WithTracing());
+
+        act.Should().Throw<XunitException>().WithMessage(
+            "*subject.Values[0]*It's a match"
+            + "*subject.Values[1]*Contained 1 failures*");
+    }
+
+    [Fact]
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
     public void When_two_string_properties_do_not_match_it_should_throw_and_state_the_difference()
     {

--- a/Tests/AwesomeAssertions.Equivalency.Specs/BasicSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/BasicSpecs.cs
@@ -52,6 +52,19 @@ public class BasicSpecs
         act.Should().Throw<XunitException>().WithMessage("Expected*subject[0].Items*null*, but found*\"a\"*");
     }
 
+    [Fact]
+    public void When_comparing_nested_collection_with_a_null_value_tracing_provides_details()
+    {
+        MyClass[] subject = [new() { Items = ["a"] }];
+        MyClass[] expectation = [new()];
+
+        Action act = () => subject.Should().BeEquivalentTo(expectation, o => o.WithTracing());
+
+        act.Should().Throw<XunitException>().WithMessage(
+            "*Finding the best match of *BasicSpecs+MyClass within all items in System.Object[] at subject[0]"
+            + "*Comparing subject at subject[0] with the expectation at subject[0]*");
+    }
+
     public class MyClass
     {
         public IEnumerable<string> Items { get; set; }

--- a/Tests/AwesomeAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
+using AwesomeAssertions.Equivalency.Tracing;
 using AwesomeAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
@@ -1293,6 +1294,29 @@ public class CollectionSpecs
         IList<MyObject> expectationList = new List<MyObject> { expectation };
 
         actualList.Should().BeEquivalentTo(expectationList, opt => opt.WithoutRecursing());
+    }
+
+    [Fact]
+    public void When_a_nested_non_generic_collection_contains_the_same_elements_it_should_be_equivalent()
+    {
+        var actual = new { Values = new ArrayList { 1, 2, 3 } };
+        var expectation = new { Values = new ArrayList { 3, 1, 2 } };
+
+        actual.Should().BeEquivalentTo(expectation, opt => opt.WithoutRecursing());
+    }
+
+    [Fact]
+    public void When_a_nested_non_generic_collection_contains_the_same_elements_it_should_be_equivalent_works_with_tracing()
+    {
+        var actual = new { Values = new ArrayList { 1, 2, 3 } };
+        var expectation = new { Values = new ArrayList { 3, 1, 2 } };
+        var traceWriter = new StringBuilderTraceWriter();
+
+        actual.Should().BeEquivalentTo(expectation, opt =>
+            opt.WithoutRecursing().WithTracing(traceWriter));
+
+        traceWriter.ToString().Should().Contain(
+            "Comparing subject System.Object[] and expectation System.Object[] at property Values using simple value equality");
     }
 
     [Fact]

--- a/Tests/AwesomeAssertions.Equivalency.Specs/CollectionSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/CollectionSpecs.cs
@@ -265,6 +265,32 @@ public class CollectionSpecs
     }
 
     [Fact]
+    public void When_collection_differs_tracing_provides_details()
+    {
+        // Subjects contain different values because we want to distinguish them in the assertion message
+        var subject = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var expectation = Enumerable.Repeat(10, subject.Length).ToArray();
+
+        Action action = () => subject.Should().BeEquivalentTo(expectation, o => o.WithTracing());
+
+        action.Should().Throw<XunitException>()
+            .WithMessage("*Structurally comparing System.Object[] and expectation System.Int32[] at subject*");
+    }
+
+    [Fact]
+    public void When_long_collection_differs_tracing_provides_details()
+    {
+        // Subjects contain different values because we want to distinguish them in the assertion message
+        var subject = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var expectation = Enumerable.Repeat(20, subject.Length).ToArray();
+
+        Action action = () => subject.Should().BeEquivalentTo(expectation, o => o.WithTracing());
+
+        action.Should().Throw<XunitException>()
+            .WithMessage("*Fail failing loose order comparison of collection after 10 items failed at subject*");
+    }
+
+    [Fact]
     public void When_a_nullable_collection_does_not_match_it_should_throw()
     {
         var subject = new { Values = (ImmutableArray<int>?)ImmutableArray.Create(1, 2, 3) };
@@ -949,10 +975,11 @@ public class CollectionSpecs
     {
         var subject = Enumerable.Repeat(2, 11);
 
-        Action action = () => subject.Should().AllBeEquivalentTo(1);
+        Action action = () => subject.Should().AllBeEquivalentTo(1, o => o.WithTracing());
 
-        action.Should().Throw<XunitException>().Which
-            .Message.Should().Contain("subject[9] to be 1, but found 2")
+        action.Should().Throw<XunitException>().Which.Message.Should()
+            .Contain("subject[9] to be 1, but found 2")
+            .And.Contain("Aborting strict order comparison of collections after 10 items failed at subject")
             .And.NotContain("item[10]");
     }
 

--- a/Tests/AwesomeAssertions.Equivalency.Specs/DictionarySpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/DictionarySpecs.cs
@@ -522,6 +522,45 @@ public class DictionarySpecs
     }
 
     [Fact]
+    public void When_comparing_dictionaries_tracing_provide_details()
+    {
+        var expected = new NonGenericDictionary
+        {
+            ["Key2"] = "Value2",
+            ["Key1"] = "Value1"
+        };
+        var subject = new NonGenericDictionary
+        {
+            ["Key1"] = "Value1",
+            ["Key3"] = "Value2"
+        };
+
+        Action act = () => subject.Should().BeEquivalentTo(expected, options => options.WithTracing());
+
+        act.Should().Throw<XunitException>().WithMessage("*Recursing into dictionary item Key1 at subject*subject[Key1]*");
+    }
+
+    [Fact]
+    public void When_comparing_dictionaries_without_recursion_tracing_provide_details()
+    {
+        var expected = new NonGenericDictionary
+        {
+            ["Key2"] = "Value2",
+            ["Key1"] = "Value1"
+        };
+        var subject = new NonGenericDictionary
+        {
+            ["Key1"] = "Value1",
+            ["Key3"] = "Value2"
+        };
+
+        Action act = () => subject.Should().BeEquivalentTo(expected, options => options.WithoutRecursing().WithTracing());
+
+        act.Should().Throw<XunitException>().WithMessage(
+            "*Comparing dictionary item Key1 at subject between subject and expectation*");
+    }
+
+    [Fact]
     public void When_asserting_equivalence_of_dictionaries_it_should_respect_the_declared_type()
     {
         var actual = new Dictionary<int, CustomerType> { [0] = new("123") };

--- a/Tests/AwesomeAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/ExtensibilitySpecs.cs
@@ -121,12 +121,24 @@ public static class ExtensibilitySpecs
             string[] subject = ["First", "Second"];
             string[] expected = ["Second", "First"];
 
-            Action act = () => subject.Should().BeEquivalentTo(
-                expected,
-                options => options.Using(new StrictOrderingRule()));
+            Action act = () => subject.Should().BeEquivalentTo(expected, options => options.Using(new StrictOrderingRule()));
+
+            act.Should().Throw<XunitException>().WithMessage($"*{nameof(StrictOrderingRule)}*");
+        }
+
+        [Fact]
+        public void When_an_ordering_rule_is_added_it_should_appear_in_the_tracing_message()
+        {
+            string[] subject = ["First", "Second"];
+            string[] expected = ["Second", "First"];
+
+            Action act = () =>
+                subject.Should().BeEquivalentTo(expected, options => options.Using(new StrictOrderingRule()).WithTracing());
 
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{nameof(StrictOrderingRule)}*");
+                .WithMessage(
+                    "*Strictly comparing expectation Second at subject to item with index 0 in System.Object[]"
+                    + "*Strictly comparing expectation First at subject to item with index 1 in System.Object[]*");
         }
 
         private class StrictOrderingRule : IOrderingRule

--- a/Tests/AwesomeAssertions.Equivalency.Specs/MemberConversionSpecs.cs
+++ b/Tests/AwesomeAssertions.Equivalency.Specs/MemberConversionSpecs.cs
@@ -57,9 +57,10 @@ public class MemberConversionSpecs
         var expectation = new { Property = EnumTwo.Two };
         var subject = new { Property = "Two" };
 
-        var act = () => subject.Should().BeEquivalentTo(expectation, options => options.WithAutoConversion());
+        var act = () => subject.Should().BeEquivalentTo(expectation, o => o.WithAutoConversion().WithTracing());
 
-        act.Should().Throw<XunitException>();
+        act.Should().Throw<XunitException>().WithMessage(
+            "*Subject Two at property subject.Property could not be converted to *EnumTwo*");
     }
 
     [Fact]
@@ -92,9 +93,11 @@ public class MemberConversionSpecs
         var expectation = new { Age = "32", Birthdate = new DateTime(1973, 9, 20) };
 
         Action act = () => subject.Should().BeEquivalentTo(expectation,
-            options => options.WithAutoConversionFor(x => x.Path.Contains("Birthdate")));
+            o => o.WithAutoConversionFor(x => x.Path.Contains("Birthdate")).WithTracing());
 
-        act.Should().Throw<XunitException>().WithMessage("*Age*String*int*");
+        act.Should().Throw<XunitException>().WithMessage(
+            "Expected property subject.Age to be string, but found int"
+            + "*Converted subject 1973-09-20 at property subject.Birthdate to System.DateTime*");
     }
 
     [Fact]

--- a/Tests/AwesomeAssertions.Specs/Common/MemberPathSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Common/MemberPathSpecs.cs
@@ -1,0 +1,15 @@
+﻿using AwesomeAssertions.Common;
+using Xunit;
+
+namespace AwesomeAssertions.Specs.Common;
+
+public class MemberPathSpecs
+{
+    [Fact]
+    public void The_hash_code_of_path_segment_comparer_shall_use_the_string_hash_code()
+    {
+        var sut = new MemberPathSegmentEqualityComparer();
+
+        sut.GetHashCode("Test").Should().Be("Test".GetHashCode());
+    }
+}

--- a/Tests/AwesomeAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
+++ b/Tests/AwesomeAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
@@ -1,4 +1,3 @@
-#if NET
 using System;
 using System.IO;
 using AwesomeAssertions.Execution;
@@ -7,8 +6,20 @@ using Xunit.Sdk;
 
 namespace AwesomeAssertions.Specs.Streams;
 
-public class BufferedStreamAssertionSpecs
+public static class BufferedStreamAssertionSpecs
 {
+    public class BeWritable
+    {
+        [Fact]
+        public void When_having_a_writable_stream_be_writable_should_succeed()
+        {
+            using var stream = new BufferedStream(new MemoryStream(), 10);
+
+            stream.Should().BeWritable();
+        }
+    }
+
+#if NET
     public class HaveBufferSize
     {
         [Fact]
@@ -98,5 +109,5 @@ public class BufferedStreamAssertionSpecs
                 "Expected the buffer size of stream not to be 10 because*failure message*, but found a <null> reference.");
         }
     }
-}
 #endif
+}


### PR DESCRIPTION
While updating test runtime in #620 I faced some code not be covered (anymore). This finding of coveralls is wrong, the code was never covered before, but Coverlet and MS Coverage calculates differently.
This PR adds some new tests to solve the majority of missing coverage.

One block I was not able to create a hitting test. Help is welcome, see below.
The remaining misses cannot be solved according to my analysis.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
