### PR TITLE
Fix ApiChecks build target

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -138,7 +138,6 @@ class Build : FalloutBuild
                     .SetConfiguration(Configuration == Configuration.Debug ? "Debug" : "Release")
                     .SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
                     .EnableNoBuild()
-                    .EnableListTests()
                     .SetResultsDirectory(TestResultsDirectory)
                     .CombineWith(x => x.SetProjectFile(project)),
                 completeOnFailure: true);


### PR DESCRIPTION
* EnableListTests only lists the tests and doesn't run them

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
