### PR TITLE
Fix XML documentation

### DIFF
--- a/docs/_pages/xml.md
+++ b/docs/_pages/xml.md
@@ -13,39 +13,36 @@ Awesome Assertions has support for assertions on several of the LINQ-to-XML clas
 xDocument.Should().HaveRoot("configuration");
 xDocument.Should().HaveElement("settings");
 xDocument.Should().HaveElement("settings", Exactly.Once());
-xDocument.Should().HaveElement("settings", AtLeast.Twice());
 
 xElement.Should().HaveValue("36");
-xElement.Should().HaveAttribute("age", "36");
+xElement.Should().HaveAttribute("age");
+xElement.Should().HaveAttributeWithValue("age", "36");
 xElement.Should().HaveElement("address");
-xElement.Should().HaveElementWithNamespace("address", "http://www.example.com/2012/test");
 
-xElement.Should().HaveInnerText("some textanother textmore text");
-
-xElement.Should().HaveElement("settings", Exactly.Once());
 xElement.Should().HaveElement("settings", AtLeast.Twice());
 ```
 
-Those two last assertions also support `XName` parameters:
+Additional assertions also provide support for `XName` parameters:
 
 ```csharp
-xElement.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"), "36");
+xElement.Should().HaveAttributeWithValue(XName.Get("age", "http://www.example.com/2012/test"), "36");
 xElement.Should().HaveElement(XName.Get("address", "http://www.example.com/2012/test"));
 
 xAttribute.Should().HaveValue("Amsterdam");
 ```
 
-You can also perform a deep comparison between two elements like this.
+You can also perform a deep comparison between two elements like this:
 
 ```csharp
 xDocument.Should().BeEquivalentTo(XDocument.Parse("<configuration><item>value</item></configuration>"));
 xElement.Should().BeEquivalentTo(XElement.Parse("<item>value</item>"));
 ```
 
-Chaining additional assertions on top of a particular (root) element is possible through this syntax.
+Chaining additional assertions on top of a particular (root) element is possible through this syntax:
 
 ```csharp
 xDocument.Should().HaveElement("child")
   .Which.Should().BeOfType<XElement>()
-    .And.HaveAttribute("attr", "1");
+    .And.HaveAttribute("attr")
+      .Which.Should().HaveValue("1");
 ```


### PR DESCRIPTION
* Adapt XMl documentation to reflect the renaming of HaveAttribute to HaveAttributeWithValue, which was done for v8.0
* Add chainability of HaveAttribute to example
* Remove nonexisting methods from LINQ-To-XML example.

## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
