### PR TITLE
Make CallerIdentifier internal

### DIFF
--- a/Src/AwesomeAssertions/CallerIdentifier.cs
+++ b/Src/AwesomeAssertions/CallerIdentifier.cs
@@ -14,8 +14,7 @@ namespace AwesomeAssertions;
 /// <summary>
 /// Tries to extract the name of the variable or invocation on which the assertion is executed.
 /// </summary>
-// REFACTOR: Should be internal and treated as an implementation detail of the AssertionScope
-public static class CallerIdentifier
+internal static class CallerIdentifier
 {
     /// <summary>
     /// Gets or sets the action used to log diagnostic messages produced while determining the caller identity.

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net472.verified.txt
@@ -331,11 +331,6 @@ namespace AwesomeAssertions
         public static AwesomeAssertions.OccurrenceConstraint Times(int expected) { }
         public static AwesomeAssertions.OccurrenceConstraint Twice() { }
     }
-    public static class CallerIdentifier
-    {
-        public static System.Action<string> Logger { get; set; }
-        public static string DetermineCallerIdentity() { }
-    }
     [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/net8.0.verified.txt
@@ -354,11 +354,6 @@ namespace AwesomeAssertions
         public static AwesomeAssertions.OccurrenceConstraint Times(int expected) { }
         public static AwesomeAssertions.OccurrenceConstraint Twice() { }
     }
-    public static class CallerIdentifier
-    {
-        public static System.Action<string> Logger { get; set; }
-        public static string DetermineCallerIdentity() { }
-    }
     [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.0.verified.txt
@@ -327,11 +327,6 @@ namespace AwesomeAssertions
         public static AwesomeAssertions.OccurrenceConstraint Times(int expected) { }
         public static AwesomeAssertions.OccurrenceConstraint Twice() { }
     }
-    public static class CallerIdentifier
-    {
-        public static System.Action<string> Logger { get; set; }
-        public static string DetermineCallerIdentity() { }
-    }
     [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {

--- a/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/AwesomeAssertions/netstandard2.1.verified.txt
@@ -331,11 +331,6 @@ namespace AwesomeAssertions
         public static AwesomeAssertions.OccurrenceConstraint Times(int expected) { }
         public static AwesomeAssertions.OccurrenceConstraint Twice() { }
     }
-    public static class CallerIdentifier
-    {
-        public static System.Action<string> Logger { get; set; }
-        public static string DetermineCallerIdentity() { }
-    }
     [System.AttributeUsage(System.AttributeTargets.Method)]
     public class CustomAssertionAttribute : System.Attribute
     {

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -25,7 +25,7 @@ sidebar:
   * Use the members of `ExceptionAssertionsTask<TException>` instead, or `AsExceptionAssertionsTask` when you start from a task of your own.
 * Removed `ExceptionAssertionsTask.WithInnerException<TException, TInnerException>` and `ExceptionAssertionsTask.WithInnerExceptionExactly<TException, TInnerException>` in favor of their single type parameter versions - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
   * Just remove the first type parameter.
-* Made `CallerIdentifer` `internal` - [TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
+* Removed `CallerIdentifer` from public API (now `internal`) - [#635](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/635)
 
 ## 9.6.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -25,6 +25,7 @@ sidebar:
   * Use the members of `ExceptionAssertionsTask<TException>` instead, or `AsExceptionAssertionsTask` when you start from a task of your own.
 * Removed `ExceptionAssertionsTask.WithInnerException<TException, TInnerException>` and `ExceptionAssertionsTask.WithInnerExceptionExactly<TException, TInnerException>` in favor of their single type parameter versions - [#592](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/592)
   * Just remove the first type parameter.
+* Made `CallerIdentifer` `internal` - [TBD](https://github.com/AwesomeAssertions/AwesomeAssertions/pull/TBD)
 
 ## 9.6.0
 


### PR DESCRIPTION
* The class had a long-standing comment saying, that this should be treated as an implementation detail of the AssertionScope/AssertionChain

Fix #631 
<!-- Please provide a description of your changes above the IMPORTANT checklist -->
## Legal checklist

* [x] This work is entirely original, it is not derived from any existing code incompatible with the Apache 2.0 License, like FluentAssertions.
